### PR TITLE
Bump jinja2 pygments and py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ importlib-metadata==1.4.0
 IPy==1.0
 isort==4.3.21
 jeepney==0.4.2
-Jinja2==2.10.3
+Jinja2==2.11.3
 joblib==0.14.1
 keyring==21.1.0
 lazy-object-proxy==1.4.3
@@ -34,9 +34,9 @@ packaging==20.0
 pkginfo==1.5.0.1
 pluggy==0.13.1
 protobuf==3.11.2
-py==1.8.1
+py==1.10.0
 pycparser==2.19
-Pygments==2.5.2
+Pygments==2.7.4
 pylint==2.4.4
 pyparsing==2.4.6
 pytest==5.3.4


### PR DESCRIPTION
Bumps:
- jinja2 from 2.10.3 to 2.11.3.
- pygments from 2.5.2 to 2.7.4.
- py from 1.8.1 to 1.10.0.

Signed-off-by: dependabot[bot] <support@github.com>