### PR TITLE
Remove git dep in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import pathlib
 import setuptools
 from datetime import datetime
-import git
 import re
 
 HERE = pathlib.Path(__file__).parent


### PR DESCRIPTION
The dependency does not seem to be needed during the setup.py. I noticed it while building a conda forge package for pymilvus at https://github.com/conda-forge/staged-recipes/pull/14772