### PR TITLE
Set default calc_distance metric to "L2"

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -22,6 +22,7 @@ from .check import (
     is_legal_host,
     is_legal_port,
 )
+from ..settings import DefaultConfig as config
 from .utils import len_of
 
 from .abs_client import AbsMilvus
@@ -1075,6 +1076,7 @@ class GrpcHandler(AbsMilvus):
 
     @error_handler(None)
     def calc_distance(self,  vectors_left, vectors_right, params, timeout=30, **kwargs):
+        params = params or {"metric": config.CALC_DIST_METRIC}
         req = Prepare.calc_distance_request(vectors_left, vectors_right, params)
         future = self._stub.CalcDistance.future(req, wait_for_ready=True, timeout=timeout)
         response = future.result()

--- a/pymilvus/settings.py
+++ b/pymilvus/settings.py
@@ -10,6 +10,7 @@ class DefaultConfig:
     HTTP_ADDRESS = "127.0.0.1:19121"
     HTTP_URI = "http://{}".format(HTTP_ADDRESS)
 
+    CALC_DIST_METRIC = "L2"
 
 # logging
 COLORS = {


### PR DESCRIPTION
Resolves milvus-io/milvus#6625

According to the comments [here](https://github.com/milvus-io/pymilvus/blob/547ff0f6f8dc266bbc4e31ecedb2ed7bc1402106/pymilvus/client/abs_client.py#L551), the default metric used for calc_distance should be "L2". However, calling this function through pymilvus or pymilvus_orm results in an error, as seen in milvus-io/milvus#6625

This PR sets the default to be "L2", configurable in the settings. 

There are multiple places that this could have been implemented, such as in the milvus-io/milvus repository instead of here. Let me know if there's a better place for the default check to be made. 

Signed-off-by: NotRyan <ryan.chan@zilliz.com>