### PR TITLE
Update workflows for web-content

### DIFF
--- a/.github/workflows/doc_update_event.yml
+++ b/.github/workflows/doc_update_event.yml
@@ -1,0 +1,28 @@
+name: web-content - Dispatch event after docs files updated
+
+on:
+  push:
+    branches-ignore:
+      - 'master'
+      - '1.*'
+    paths:
+      - 'docs/**'
+
+jobs:
+  dispatch_event:
+    name: Dispatch event
+    runs-on: ubuntu-latest
+    steps:
+      - id: extract_branch
+        name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      - id: dispatch_branch_name
+        name: Dispatch branch name if update any docs
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/milvus-io/web-content/actions/workflows/updateApiByBranchEvent.yml/dispatches" \
+          -d '{"ref":"master", "inputs": { "branchName": "${{ steps.extract_branch.outputs.branch }}", "repoName": "${{ github.event.repository.name }}" } }' \
+          -u ".:${{secrets.DOC_TOKEN}}"

--- a/.github/workflows/release_event.yml
+++ b/.github/workflows/release_event.yml
@@ -1,4 +1,4 @@
-name: dispatch new release event
+name: web-content - Dispatch new release event
 on:
   release:
     types: [published]
@@ -18,6 +18,6 @@ jobs:
           curl \
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          "https://api.github.com/repos/milvus-io/docs/actions/workflows/updateApiReference.yml/dispatches" \
+          "https://api.github.com/repos/milvus-io/web-content/actions/workflows/updateApiReference.yml/dispatches" \
           -d '{"ref":"master", "inputs": { "tagName": "${{ steps.tag_name.outputs.SOURCE_TAG }}", "repoName": "${{ github.event.repository.name }}" } }' \
           -u ".:${{secrets.DOC_TOKEN}}"


### PR DESCRIPTION
- Update latest repo url from `doc` to `web-content`
- Add docs update event. Any modifies under `docs/` should dispatch event action to `web-content` for consistent update.