### PR TITLE
Adds __str__ for baseloop (Search results)

### DIFF
--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -45,7 +45,7 @@ class LoopBase(object):
         raise StopIteration()
 
     def __str__(self):
-        return str(list(map(str, self.__getitem__(slice(None)))))
+        return str(list(map(str, self.__getitem__(slice(0, 10)))))
 
     @abc.abstractmethod
     def get__item(self, item):

--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -44,6 +44,9 @@ class LoopBase(object):
         self.__index = 0
         raise StopIteration()
 
+    def __str__(self):
+        return str(list(map(str, self.__getitem__(slice(None)))))
+
     @abc.abstractmethod
     def get__item(self, item):
         raise NotImplementedError()


### PR DESCRIPTION
In reference to #701.
This adds a __str__ method to baseloop, which is a parent of our hits object. Now hits can be printed directly, which will simply list out a string representation of all the contents. See image below. 
<img width="1052" alt="Screen Shot 2021-09-16 at 6 50 31 PM" src="https://user-images.githubusercontent.com/5742796/133711111-96fba118-76ba-413a-a9bc-ffd3125cfde0.png">

Signed-off-by: NotRyan <ryan.chan@zilliz.com>
