### PR TITLE
Update ORM SearchResult and Hits objects to use consistent types for index gets and slice gets

### DIFF
--- a/pymilvus/orm/search.py
+++ b/pymilvus/orm/search.py
@@ -180,7 +180,7 @@ class Hits:
             for i in range(_start, _end):
                 elements.append(self.on_result(s[i]))
             return elements
-        return s
+        return self.on_result(s)
 
     def __len__(self) -> int:
         """
@@ -251,7 +251,7 @@ class SearchResult:
             for i in range(_start, _end):
                 elements.append(self.on_result(s[i]))
             return elements
-        return s
+        return self.on_result(s)
 
     def __len__(self) -> int:
         """


### PR DESCRIPTION
Currently, getting the contents of an ORM SearchResult or an ORM Hits object will result in a differently typed version of the contents depending on whether the get is done with a slice or an index. See this image for an example:

<img width="1076" alt="Screen Shot 2021-09-29 at 4 34 43 PM" src="https://user-images.githubusercontent.com/5742796/135363360-442ccb35-7420-4c39-8372-da2b62744f22.png">

It does not make sense for one to return objects of different types; logically they should be the same. This PR changes it so that all objects are returned as the corresponding ORM type. See the following image: 

<img width="1008" alt="Screen Shot 2021-09-29 at 4 37 39 PM" src="https://user-images.githubusercontent.com/5742796/135363500-ca393d89-ea0b-4fb8-a6a8-81b9e4d9ac16.png">

If we would rather have the objects return the other type, let me know and I can change it to that. But whatever they are, it should be consistent. 

Signed-off-by: NotRyan <ryan.chan@zilliz.com>