### PR TITLE
Add __str__ methods to orm SearchResult and Hits objects

### DIFF
--- a/pymilvus/orm/search.py
+++ b/pymilvus/orm/search.py
@@ -191,6 +191,9 @@ class Hits:
         """
         return self._hits.__len__()
 
+    def __str__(self):
+        return str(list(map(str, self.__getitem__(slice(0, 10)))))
+
     def on_result(self, res):
         return Hit(res)
 
@@ -261,6 +264,9 @@ class SearchResult:
             The number of query of search result.
         """
         return self._qs.__len__()
+
+    def __str__(self):
+        return str(list(map(str, self.__getitem__(slice(0, 10)))))
 
     def on_result(self, res):
         return Hits(res)


### PR DESCRIPTION
Adds __str__ methods to ORM versions of the SearchResult and Hits objects. They print out the string of the objects they contain; capped at a maximum of 10 if there are more than that.

Signed-off-by: NotRyan <ryan.chan@zilliz.com>