### PR TITLE
Expose guarantee_timestamp of search api (ref: #666)

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -500,6 +500,7 @@ class Prepare:
                     collection_name=collection_name,
                     partition_names=partition_names,
                     output_fields=fields,
+                    guarantee_timestamp=kwargs.get("guarantee_timestamp", 0),
                 )
                 request.dsl = ujson.dumps(duplicated_entities)
                 request.placeholder_group = plg_str
@@ -524,6 +525,7 @@ class Prepare:
             collection_name=collection_name,
             partition_names=partition_names,
             output_fields=fields,
+            guarantee_timestamp=kwargs.get("guarantee_timestamp", 0),
         )
 
         duplicated_entities = copy.deepcopy(query_entities)
@@ -646,6 +648,7 @@ class Prepare:
                 collection_name=collection_name,
                 partition_names=partition_names,
                 output_fields=output_fields,
+                guarantee_timestamp=kwargs.get("guarantee_timestamp", 0),
             )
             request.placeholder_group = plg_str
 

--- a/pymilvus/client/stub.py
+++ b/pymilvus/client/stub.py
@@ -1044,6 +1044,9 @@ class Milvus:
             * *_callback* (``function``) --
               The callback function which is invoked after server response successfully. It only take
               effect when _async is set to True.
+            * *guarantee_timestamp* (``function``) --
+              This function instructs Milvus to see all operations performed before a provided timestamp. If no
+              such timestamp is provided, then Milvus will search all operations performed to date.
 
         :return: Query result. QueryResult is iterable and is a 2d-array-like class, the first dimension is
                  the number of vectors to query (nq), the second dimension is the number of limit(topk).

--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -616,6 +616,9 @@ class Collection:
             * *_callback* (``function``) --
               The callback function which is invoked after server response successfully.
               It functions only if _async is set to True.
+            * *guarantee_timestamp* (``function``) --
+              This function instructs Milvus to see all operations performed before a provided timestamp. If no
+              such timestamp is provided, then Milvus will search all operations performed to date.
 
         :return: SearchResult:
             SearchResult is iterable and is a 2d-array-like class, the first dimension is

--- a/pymilvus/orm/partition.py
+++ b/pymilvus/orm/partition.py
@@ -354,6 +354,9 @@ class Partition:
             * *_callback* (``function``) --
               The callback function which is invoked after server response successfully. It only
               takes effect when _async is set to True.
+            * *guarantee_timestamp* (``function``) --
+              This function instructs Milvus to see all operations performed before a provided timestamp. If no
+              such timestamp is provided, then Milvus will search all operations performed to date.
 
         :return: SearchResult:
             SearchResult is iterable and is a 2d-array-like class, the first dimension is


### PR DESCRIPTION
**ISSUE SOLVED**
This PR solves issue #666

**Changes Made**

Changed prepare.py at 3 instances as discussed [here](https://github.com/milvus-io/pymilvus/issues/666).
The `SearchRequest` function had the `guarantee_timestamp` attribute stored in `kwargs`. It was added as a function parameter.

**NOTE**
Please consider this PR as a submission towards Hacktoberfest 2021 and add the `hacktoberfest-accepted` label.