### PR TITLE
Move aliases operations into utility

### DIFF
--- a/docs/source/api/utility.rst
+++ b/docs/source/api/utility.rst
@@ -7,48 +7,54 @@ Utility
 Methods
 -------
 
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| API                                                                                                                            | Description                                   |
-+================================================================================================================================+===============================================+
-| `loading_progress(collection_name, [partition_names,using]) <#pymilvus.utility.loading_progress>`_                             | Query the progress of loading.                |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `wait_for_loading_complete(collection_name, [partition_names, timeout, using]) <#pymilvus.utility.wait_for_loading_complete>`_ | Wait until loading is complete.               |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `index_building_progress(collection_name, [using]) <#pymilvus.utility.index_building_progress>`_                               | Query the progress of index building.         |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `wait_for_index_building_complete(collection_name, [timeout, using]) <#pymilvus.utility.wait_for_index_building_complete>`_    | Wait util index building is complete.         |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `has_collection(collection_name, [using]) <#pymilvus.utility.has_collection>`_                                                 | Check if a specified collection exists.       |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `has_partition(collection_name, partition_name, [using]) <#pymilvus.utility.has_partition>`_                                   | Check if a specified partition exists.        |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `list_collections([timeout, using]) <#pymilvus.utility.list_collections>`_                                                     | List all collections.                         |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `drop_collections(collection_name, [timeout, using]) <#pymilvus.utility.drop_collection>`_                                     | Drop a collection by name.                    |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `calc_distance(vectors_left, vectors_right, params, [timeout, using]) <#pymilvus.utility.calc_distance>`_                      | Calculate distance between two vector arrays. |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `get_query_segment_info([timeout, using]) <#pymilvus.utility.get_query_segment_info>`_                                         | Get segments information from query nodes.    |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `load_balance(src_node_id, dst_node_id, sealed_segment_ids, [timeout, using]) <#pymilvus.utility.load_balance>`_               | Do load balancing between query nodes.        |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `mkts_from_hybridts(ts, [milliseconds, delta]) <#pymilvus.utility.mkts_from_hybridts>`_                                        | Generate hybrid timestamp with a known one.   |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `mkts_from_unixtime(timestamp, [milliseconds, delta]) <#pymilvus.utility.mkts_from_unixtime>`_                                 | Generate hybrid timestamp with Unix time.     |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `mkts_from_datetime(d_time, [milliseconds, delta]) <#pymilvus.utility.mkts_from_datetime>`_                                    | Generate hybrid timestamp with datatime.      |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `hybridts_to_unixtime(hybridts) <#pymilvus.utility.hybridts_to_unixtime>`_                                                     | Convert hybrid timestamp to UNIX Epoch time.  |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
-| `hybridts_to_datetime(hybridts, [tz]) <#pymilvus.utility.hybridts_to_datetime>`_                                               | Convert hybrid timestamp to datetime.         |
-+--------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------+
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| API                                                                                                                            | Description                                             |
++================================================================================================================================+=========================================================+
+| `loading_progress(collection_name, [partition_names,using]) <#pymilvus.utility.loading_progress>`_                             | Query the progress of loading.                          |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `wait_for_loading_complete(collection_name, [partition_names, timeout, using]) <#pymilvus.utility.wait_for_loading_complete>`_ | Wait until loading is complete.                         |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `index_building_progress(collection_name, [using]) <#pymilvus.utility.index_building_progress>`_                               | Query the progress of index building.                   |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `wait_for_index_building_complete(collection_name, [timeout, using]) <#pymilvus.utility.wait_for_index_building_complete>`_    | Wait util index building is complete.                   |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `has_collection(collection_name, [using]) <#pymilvus.utility.has_collection>`_                                                 | Check if a specified collection exists.                 |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `has_partition(collection_name, partition_name, [using]) <#pymilvus.utility.has_partition>`_                                   | Check if a specified partition exists.                  |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `list_collections([timeout, using]) <#pymilvus.utility.list_collections>`_                                                     | List all collections.                                   |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `drop_collections(collection_name, [timeout, using]) <#pymilvus.utility.drop_collection>`_                                     | Drop a collection by name.                              |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `calc_distance(vectors_left, vectors_right, params, [timeout, using]) <#pymilvus.utility.calc_distance>`_                      | Calculate distance between two vector arrays.           |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `get_query_segment_info([timeout, using]) <#pymilvus.utility.get_query_segment_info>`_                                         | Get segments information from query nodes.              |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `load_balance(src_node_id, dst_node_id, sealed_segment_ids, [timeout, using]) <#pymilvus.utility.load_balance>`_               | Do load balancing between query nodes.                  |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `mkts_from_hybridts(ts, [milliseconds, delta]) <#pymilvus.utility.mkts_from_hybridts>`_                                        | Generate hybrid timestamp with a known one.             |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `mkts_from_unixtime(timestamp, [milliseconds, delta]) <#pymilvus.utility.mkts_from_unixtime>`_                                 | Generate hybrid timestamp with Unix time.               |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `mkts_from_datetime(d_time, [milliseconds, delta]) <#pymilvus.utility.mkts_from_datetime>`_                                    | Generate hybrid timestamp with datatime.                |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `hybridts_to_unixtime(hybridts) <#pymilvus.utility.hybridts_to_unixtime>`_                                                     | Convert hybrid timestamp to UNIX Epoch time.            |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `hybridts_to_datetime(hybridts, [tz]) <#pymilvus.utility.hybridts_to_datetime>`_                                               | Convert hybrid timestamp to datetime.                   |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `create_alias(collection_name, alias, [timeout, using]) <#pymilvus.utility.create_alias>`_                                     | Specify alias for a collection.                         |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `alter_alias(collection_name, alias, [timeout, using]) <#pymilvus.utility.alter_alias>`_                                       | Change the alias of a collection to another collection. |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
+| `drop_alias(alias, [timeout, using]) <#pymilvus.utility.drop_alias>`_                                                          | Delete the alias.                                       |
++--------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------+
 APIs References
 ---------------
 
-.. automodule:: pymilvus.utility 
+.. automodule:: pymilvus.utility
    :member-order: bysource
    :members: loading_progress, wait_for_loading_complete, index_building_progress,
              wait_for_index_building_complete, has_collection, has_partition, list_collections,
              drop_collection, calc_distance, get_query_segment_info, load_balance,
              mkts_from_hybridts, mkts_from_unixtime, mkts_from_datetime,
-             hybridts_to_unixtime, hybridts_to_datetime,
+             hybridts_to_unixtime, hybridts_to_datetime, create_alias, alter_alias, drop_alias

--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -9,9 +9,8 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-import copy
-import json
 
+import copy
 import pandas
 
 from .connections import get_connection
@@ -913,37 +912,6 @@ class Collection:
         conn = self._get_connection()
         return conn.drop_partition(self._name, partition_name, timeout=timeout, **kwargs)
 
-    # The server side not yet finished to return aliases by the describe_collection api.
-    # Disable this property until the work is done.
-    # @property
-    # def aliases(self) -> list:
-    #     """
-    #     Returns alias list of the collection.
-    #
-    #     :return list of str:
-    #         The collection aliases, returned when the operation succeeds.
-    #
-    #     :example:
-    #         >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType
-    #         >>> connections.connect()
-    #         >>> fields = [
-    #         ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
-    #         ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=128)
-    #         ... ]
-    #         >>> schema = CollectionSchema(fields)
-    #         >>> collection = Collection("test_collection_name", schema)
-    #         >>> collection.create_alias("tom")
-    #         >>> collection.alias
-    #         ['tom']
-    #     """
-    #     conn = self._get_connection()
-    #     has = conn.has_collection(self._name)
-    #     aliases = []
-    #     if has:
-    #         resp = conn.describe_collection(self._name)
-    #         aliases = resp['aliases']
-    #     return aliases
-
     @property
     def indexes(self) -> list:
         """
@@ -1112,118 +1080,12 @@ class Collection:
             index = Index(self, tmp_index['field_name'], tmp_index, construct_only=True)
             index.drop(timeout=timeout, **kwargs)
 
-    def create_alias(self, alias, timeout=None, **kwargs):
-        """
-        Specify alias for a collection.
-        Alias cannot be duplicated, you can't assign same alias to different collections.
-        But you can specify multiple aliases for a collection, for example:
-            before create_alias("collection_1", "bob"):
-                collection_1's aliases = ["tom"]
-            after create_alias("collection_1", "bob"):
-                collection_1's aliases = ["tom", "bob"]
-
-        :param alias: The alias of the collection.
-        :type  alias: str.
-
-        :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
-                        is set to None, client waits until server response or error occur
-        :type  timeout: float
-
-        :raises CollectionNotExistException: If the collection does not exist.
-        :raises BaseException: If the alias failed to create.
-
-        :example:
-            >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType
-            >>> connections.connect()
-            >>> schema = CollectionSchema([
-            ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
-            ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=2)
-            ... ])
-            >>> collection = Collection("test_collection_create_index", schema)
-            >>> collection.create_alias("alias")
-            Status(code=0, message='')
-        """
-        conn = self._get_connection()
-        conn.create_alias(self._name, alias, timeout=timeout, **kwargs)
-
-    def drop_alias(self, alias, timeout=None, **kwargs):
-        """
-        Delete an alias.
-        This api no need to specify collection name because the milvus server knows which collection it belongs.
-        For example:
-            before drop_alias("bob"):
-                collection_1's aliases = ["tom", "bob"]
-            after drop_alias("bob"):
-                collection_1's aliases = ["tom"]
-
-        :param alias: The alias of the collection.
-        :type  alias: str.
-
-        :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
-                        is set to None, client waits until server response or error occur
-        :type  timeout: float
-
-        :raises CollectionNotExistException: If the collection does not exist.
-        :raises BaseException: If the alias doesn't exist.
-
-        :example:
-            >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType
-            >>> connections.connect()
-            >>> schema = CollectionSchema([
-            ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
-            ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=2)
-            ... ])
-            >>> collection = Collection("test_collection_create_index", schema)
-            >>> collection.create_alias("alias")
-            >>> collection.drop_alias("alias")
-            Status(code=0, message='')
-        """
-        conn = self._get_connection()
-        conn.drop_alias(alias, timeout=timeout, **kwargs)
-
-    def alter_alias(self, alias, timeout=None, **kwargs):
-        """
-        Change alias of a collection to another collection. If the alias doesn't exist, the api will return error.
-        Alias cannot be duplicated, you can't assign same alias to different collections.
-        This api can change alias owner collection, for example:
-            before alter_alias("collection_2", "bob"):
-                collection_1's aliases = ["bob"]
-                collection_2's aliases = []
-            after alter_alias("collection_2", "bob"):
-                collection_1's aliases = []
-                collection_2's aliases = ["bob"]
-
-        :param alias: The alias of the collection.
-        :type  alias: str.
-
-        :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
-                        is set to None, client waits until server response or error occur
-        :type  timeout: float
-
-        :raises CollectionNotExistException: If the collection does not exist.
-        :raises BaseException: If the alias failed to alter.
-
-        :example:
-            >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType
-            >>> connections.connect()
-            >>> schema = CollectionSchema([
-            ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
-            ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=2)
-            ... ])
-            >>> collection = Collection("test_collection_create_index", schema)
-            >>> collection.alter_alias("alias")
-            if the alias exists, return Status(code=0, message='')
-            otherwise return Status(code=1, message='alias does not exist')
-        """
-        conn = self._get_connection()
-        conn.alter_alias(self._name, alias, timeout=timeout, **kwargs)
-
     def compact(self, timeout=None, **kwargs):
         """
         Compact merge the small segments in a collection
 
         :param collection_name: The name of the collection.
-        :type  alias: str.
+        :type  collection_name: str.
 
         :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
                         is set to None, client waits until server response or error occur

--- a/pymilvus/orm/utility.py
+++ b/pymilvus/orm/utility.py
@@ -536,9 +536,9 @@ def load_balance(src_node_id, dst_node_ids=None, sealed_segment_ids=None, timeou
 
     :example:
         >>> from pymilvus import connections, utility
-        >>> 
+        >>>
         >>> connections.connect()
-        >>> 
+        >>>
         >>> src_node_id = 0
         >>> dst_node_ids = [1]
         >>> sealed_segment_ids = []
@@ -581,3 +581,133 @@ def get_query_segment_info(collection_name, timeout=None, using="default"):
         >>> res = utility.get_query_segment_info("test_get_segment_info")
     """
     return _get_connection(using).get_query_segment_info(collection_name, timeout=timeout)
+
+
+def create_alias(collection_name: str, alias: str, timeout=None, using="default"):
+    """ Specify alias for a collection.
+    Alias cannot be duplicated, you can't assign the same alias to different collections.
+    But you can specify multiple aliases for a collection, for example:
+        before create_alias("collection_1", "bob"):
+            aliases of collection_1 are ["tom"]
+        after create_alias("collection_1", "bob"):
+            aliases of collection_1 are ["tom", "bob"]
+
+    :param alias: The alias of the collection.
+    :type  alias: str.
+
+    :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
+                    is set to None, client waits until server response or error occur
+    :type  timeout: float
+
+    :raises CollectionNotExistException: If the collection does not exist.
+    :raises BaseException: If the alias failed to create.
+
+    :example:
+        >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
+        >>> connections.connect()
+        >>> schema = CollectionSchema([
+        ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
+        ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=2)
+        ... ])
+        >>> collection = Collection("test_collection_create_alias", schema)
+        >>> utility.create_alias(collection.name, "alias")
+        Status(code=0, message='')
+    """
+    return _get_connection(using).create_alias(collection_name, alias, timeout=timeout)
+
+
+def drop_alias(alias: str, timeout=None, using="default"):
+    """ Delete the alias.
+    No need to provide collection name because an alias can only be assigned to one collection
+    and the server knows which collection it belongs.
+    For example:
+        before drop_alias("bob"):
+            aliases of collection_1 are ["tom", "bob"]
+        after drop_alias("bob"):
+            aliases of collection_1 are = ["tom"]
+
+    :param alias: The alias to drop.
+    :type  alias: str
+
+    :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
+                    is set to None, client waits until server response or error occur
+    :type  timeout: float
+
+    :raises CollectionNotExistException: If the collection does not exist.
+    :raises BaseException: If the alias doesn't exist.
+
+    :example:
+        >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
+        >>> connections.connect()
+        >>> schema = CollectionSchema([
+        ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
+        ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=2)
+        ... ])
+        >>> collection = Collection("test_collection_drop_alias", schema)
+        >>> utility.create_alias(collection.name, "alias")
+        >>> utility.drop_alias("alias")
+        Status(code=0, message='')
+    """
+    return _get_connection(using).drop_alias(alias, timeout=timeout)
+
+
+def alter_alias(collection_name: str, alias: str, timeout=None, using="default"):
+    """ Change the alias of a collection to another collection.
+    Raise error if the alias doesn't exist.
+    Alias cannot be duplicated, you can't assign same alias to different collections.
+    This api can change alias owner collection, for example:
+        before alter_alias("collection_2", "bob"):
+            collection_1's aliases = ["bob"]
+            collection_2's aliases = []
+        after alter_alias("collection_2", "bob"):
+            collection_1's aliases = []
+            collection_2's aliases = ["bob"]
+
+    :param collection_name: The collection name to witch this alias is goting to alter.
+    :type  collection_name: str.
+
+    :param alias: The alias of the collection.
+    :type  alias: str
+
+    :param timeout: An optional duration of time in seconds to allow for the RPC. When timeout
+                    is set to None, client waits until server response or error occur
+    :type  timeout: float
+
+    :raises CollectionNotExistException: If the collection does not exist.
+    :raises BaseException: If the alias failed to alter.
+
+    :example:
+        >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
+        >>> connections.connect()
+        >>> schema = CollectionSchema([
+        ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
+        ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=2)
+        ... ])
+        >>> collection = Collection("test_collection_alter_alias", schema)
+        >>> utility.alter_alias(collection.name, "alias")
+        if the alias exists, return Status(code=0, message='')
+        otherwise return Status(code=1, message='alias does not exist')
+    """
+    return _get_connection(using).alter_alias(collection_name, alias, timeout=timeout)
+
+
+def list_aliases(collection_name: str, timeout=None, using="default"):
+    """ Returns alias list of the collection.
+
+    :return list of str:
+        The collection aliases, returned when the operation succeeds.
+
+    :example:
+        >>> from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType, utility
+        >>> connections.connect()
+        >>> fields = [
+        ...     FieldSchema("film_id", DataType.INT64, is_primary=True),
+        ...     FieldSchema("films", dtype=DataType.FLOAT_VECTOR, dim=128)
+        ... ]
+        >>> schema = CollectionSchema(fields)
+        >>> collection = Collection("test_collection_list_aliases", schema)
+        >>> utility.create_alias(collection.name, "tom")
+        >>> utility.list_aliases(collection.name)
+        ['tom']
+    """
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,6 @@ six==1.16.0
 toml==0.10.2
 ujson==4.0.2
 urllib3==1.26.5
-pandas
-numpy
 sklearn==0.0
 m2r==0.2.1
 mistune==0.8.4
@@ -34,3 +32,4 @@ pytest==5.3.4
 pytest-cov==2.8.1
 pytest-timeout==1.3.4
 pylint==2.4.4
+pandas==1.1.5


### PR DESCRIPTION
Aliases are targeted for multi-collection switching,
it seems wierd to bind aliases operations within `Collection`.

This PR mvs aliases operations into `utility`

Signed-off-by: XuanYang-cn <xuan.yang@zilliz.com>