### PR TITLE
Add unittests framework for grpc_handler

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -10,6 +10,7 @@ from grpc._cython import cygrpc
 
 from ..grpc_gen import milvus_pb2_grpc
 from ..grpc_gen import milvus_pb2 as milvus_types
+from ..grpc_gen import common_pb2
 
 from .abstract import CollectionSchema, ChunkedQueryResult, MutationResult
 from .check import (
@@ -200,10 +201,9 @@ class GrpcHandler:
     def has_collection(self, collection_name, timeout=None, **kwargs):
         check_pass_param(collection_name=collection_name)
         request = Prepare.has_collection_request(collection_name)
-
-        rf = self._stub.HasCollection.future(request, wait_for_ready=True, timeout=timeout)
+        rf = self._stub.HasCollection.future(request, timeout=timeout)
         reply = rf.result()
-        if reply.status.error_code == 0:
+        if reply.status.error_code == common_pb2.Success:
             return reply.value
 
         raise MilvusException(reply.status.error_code, reply.status.reason)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,30 @@
 import sys
+import pytest
+import grpc_testing
+
+# https://github.com/grpc/grpc/blob/5918f98ecbf5ace77f30fa97f7fc3e8bdac08e04/src/python/grpcio_tests/tests/testing/_client_test.py
+from grpc.framework.foundation import logging_pool
+
+from pymilvus.grpc_gen import milvus_pb2
 
 from os.path import dirname, abspath
 sys.path.append(dirname(dirname(abspath(__file__))))
+
+descriptor = milvus_pb2.DESCRIPTOR.services_by_name['MilvusService']
+
+
+@pytest.fixture(scope="function")
+def channel(request):
+    channel = grpc_testing.channel([descriptor], grpc_testing.strict_real_time())
+
+    return channel
+
+
+@pytest.fixture(scope="function")
+def client_thread(request):
+    client_execution_thread_pool = logging_pool.pool(1)
+
+    def teardown():
+        client_execution_thread_pool.shutdown(wait=True)
+
+    return client_execution_thread_pool

--- a/tests/test_grpc_handler.py
+++ b/tests/test_grpc_handler.py
@@ -1,0 +1,50 @@
+import pytest
+import grpc
+
+
+from pymilvus import MilvusException
+from pymilvus.client.grpc_handler import GrpcHandler
+from pymilvus.grpc_gen import milvus_pb2
+from pymilvus.grpc_gen import common_pb2
+
+
+descriptor = milvus_pb2.DESCRIPTOR.services_by_name['MilvusService']
+
+
+class TestGrpcHandler:
+    @pytest.mark.parametrize("ifHas", [True, False])
+    def test_has_collection_no_error(self, channel, client_thread, ifHas):
+        handler = GrpcHandler(channel=channel)
+
+        has_collection_future = client_thread.submit(
+            handler.has_collection, "fake")
+
+        (invocation_metadata, request, rpc) = (
+            channel.take_unary_unary(descriptor.methods_by_name['HasCollection']))
+        rpc.send_initial_metadata(())
+
+        expected_result = milvus_pb2.BoolResponse(
+            status=common_pb2.Status(error_code=common_pb2.Success),
+            value=ifHas)
+        rpc.terminate(expected_result, (), grpc.StatusCode.OK, '')
+
+        got_result = has_collection_future.result()
+        assert got_result is ifHas
+
+    def test_has_collection_error(self, channel, client_thread):
+        handler = GrpcHandler(channel=channel)
+
+        has_collection_future = client_thread.submit(
+            handler.has_collection, "fake")
+
+        (invocation_metadata, request, rpc) = (
+            channel.take_unary_unary(descriptor.methods_by_name['HasCollection']))
+        rpc.send_initial_metadata(())
+
+        expected_result = milvus_pb2.BoolResponse(
+            status=common_pb2.Status(error_code=common_pb2.UnexpectedError),
+            value=False)
+        rpc.terminate(expected_result, (), grpc.StatusCode.OK, '')
+
+        with pytest.raises(MilvusException):
+            has_collection_future.result()


### PR DESCRIPTION
Note grpc_testing doesn's support EXPERIMENTAL apis
such as `wait_for_ready`.

See also: #985

Signed-off-by: XuanYang-cn <xuan.yang@zilliz.com>