### PR TITLE
Fix seach hangs forever while server unavaliable

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -161,7 +161,7 @@ class GrpcHandler:
         check_pass_param(collection_name=collection_name)
         request = Prepare.has_collection_request(collection_name)
 
-        rf = self._stub.HasCollection.future(request, wait_for_ready=True, timeout=timeout)
+        rf = self._stub.HasCollection.future(request, timeout=timeout)
         reply = rf.result()
         if reply.status.error_code == 0:
             return reply.value
@@ -173,7 +173,7 @@ class GrpcHandler:
     def describe_collection(self, collection_name, timeout=None, **kwargs):
         check_pass_param(collection_name=collection_name)
         request = Prepare.describe_collection_request(collection_name)
-        rf = self._stub.DescribeCollection.future(request, wait_for_ready=True, timeout=timeout)
+        rf = self._stub.DescribeCollection.future(request, timeout=timeout)
         response = rf.result()
         status = response.status
 
@@ -339,37 +339,6 @@ class GrpcHandler:
                 return MutationFuture(None, None, err)
             raise err
 
-    def _prepare_search_request(self, collection_name, query_entities, partition_names=None, fields=None, timeout=None,
-                                round_decimal=-1, **kwargs):
-        rf = self._stub.HasCollection.future(Prepare.has_collection_request(collection_name), wait_for_ready=True,
-                                             timeout=timeout)
-        reply = rf.result()
-        if reply.status.error_code != 0 or not reply.value:
-            raise CollectionNotExistException(reply.status.error_code, "collection not exists")
-
-        collection_schema = self.describe_collection(collection_name, timeout)
-        auto_id = collection_schema["auto_id"]
-        request = Prepare.search_request(collection_name, query_entities, partition_names, fields, round_decimal,
-                                         schema=collection_schema)
-
-        return request, auto_id
-
-    def _divide_search_request(self, collection_name, query_entities, partition_names=None, fields=None, timeout=None,
-                               round_decimal=-1, **kwargs):
-        rf = self._stub.HasCollection.future(Prepare.has_collection_request(collection_name), wait_for_ready=True,
-                                             timeout=timeout)
-        reply = rf.result()
-        if reply.status.error_code != 0 or not reply.value:
-            raise CollectionNotExistException(reply.status.error_code, "collection not exists")
-
-        collection_schema = self.describe_collection(collection_name, timeout)
-        auto_id = collection_schema["auto_id"]
-        requests = Prepare.divide_search_request(collection_name, query_entities, partition_names, fields,
-                                                 round_decimal,
-                                                 schema=collection_schema)
-
-        return requests, auto_id
-
     @error_handler
     def _execute_search_requests(self, requests, timeout=None, **kwargs):
         auto_id = kwargs.get("auto_id", True)
@@ -380,7 +349,7 @@ class GrpcHandler:
 
             # step 1: get future object
             for request in requests:
-                ft = self._stub.Search.future(request, wait_for_ready=True, timeout=timeout)
+                ft = self._stub.Search.future(request, timeout=timeout)
                 futures.append(ft)
 
             if kwargs.get("_async", False):
@@ -402,23 +371,6 @@ class GrpcHandler:
             if kwargs.get("_async", False):
                 return SearchFuture(None, None, True, pre_err)
             raise pre_err
-
-    def _batch_search(self, collection_name, query_entities, partition_names=None, fields=None, timeout=None,
-                      round_decimal=-1, **kwargs):
-        requests, auto_id = self._divide_search_request(collection_name, query_entities, partition_names,
-                                                        fields, timeout, round_decimal, **kwargs)
-        kwargs["auto_id"] = auto_id
-        kwargs["round_decimal"] = round_decimal
-        return self._execute_search_requests(requests, timeout, **kwargs)
-
-    @error_handler
-    def _total_search(self, collection_name, query_entities, partition_names=None, fields=None, timeout=None,
-                      round_decimal=-1, **kwargs):
-        request, auto_id = self._prepare_search_request(collection_name, query_entities, partition_names,
-                                                        fields, timeout, round_decimal, **kwargs)
-        kwargs["auto_id"] = auto_id
-        kwargs["round_decimal"] = round_decimal
-        return self._execute_search_requests([request], timeout, **kwargs)
 
     @retry_on_rpc_failure(retry_times=10, wait=1, retry_on_deadline=False)
     @error_handler

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -44,13 +44,13 @@ def retry_on_rpc_failure(retry_times=10, wait=1, retry_on_deadline=True):
                     # UNAVAILABLE means that the service is not reachable currently
                     # Reference: https://grpc.github.io/grpc/python/grpc.html#grpc-status-code
                     if e.code() != grpc.StatusCode.DEADLINE_EXCEEDED and e.code() != grpc.StatusCode.UNAVAILABLE:
-                        raise e
+                        raise BaseException(Status.UNEXPECTED_ERROR, str(e)) from e
                     if not retry_on_deadline and e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
-                        raise e
+                        raise BaseException(Status.UNEXPECTED_ERROR, str(e)) from e
                     if counter >= retry_times:
                         if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
-                            raise BaseException(Status.UNEXPECTED_ERROR, "rpc timeout")
-                        raise e
+                            raise BaseException(Status.UNEXPECTED_ERROR, "rpc timeout") from e
+                        raise BaseException(Status.UNEXPECTED_ERROR, str(e)) from e
                     time.sleep(wait)
                 except Exception as e:
                     raise e

--- a/tests/e2e_issues/test_issue_16835.py
+++ b/tests/e2e_issues/test_issue_16835.py
@@ -1,0 +1,86 @@
+# Problem: https://github.com/milvus-io/milvus/issues/16835
+# [Bug]: collection.search() timeout parameter not working
+# 1. Connect to Milvus
+# 2. Stop the Milvus Service
+# 3. Execute collection.search(xxx, ..., timeout=1)
+# 4. Wait
+# The process hangs forever
+
+# pymilvus==2.0.2           hang forever
+# pymilvus==2.1.0.dev53     fail for not affected by timeout
+
+from pymilvus import connections, Collection
+from pymilvus import DataType, FieldSchema, CollectionSchema
+from pymilvus import utility
+import numpy as np
+import time
+
+collection_name = "_test_issue_16835"
+
+
+def get_workable_collcetion(num_entites=1000, dim=8):
+    schema = get_schema()
+    print(f"get schema: {schema}")
+
+    issue_16853 = Collection(collection_name, schema)
+
+    rng = np.random.default_rng(seed=16835)
+    entities = [
+        [i for i in range(num_entites)],
+        rng.random((num_entites, dim)),
+    ]
+    insert_result = issue_16853.insert(entities)
+    issue_16853.load()
+
+    print(f"collection {collection_name}: inserted {num_entites} entites and loaded")
+    return issue_16853, insert_result
+
+
+def get_schema():
+    fields = [
+        FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=False),
+        FieldSchema(name="embeddings", dtype=DataType.FLOAT_VECTOR, dim=8)
+    ]
+
+    schema = CollectionSchema(fields)
+    return schema
+
+
+def main():
+    connections.connect("default", host="localhost", port="19530")
+
+    if utility.has_collection(collection_name):
+        utility.drop_collection(collection_name)
+
+    issue_16853, insert_result = get_workable_collcetion()
+    issue_16853.search(
+        [[1., 2., 3., 4., 5., 6., 7., 8.]],
+        "embeddings",
+        {},
+        limit=10, timeout=1)
+
+    y = ""
+    while y != "y":
+        y = input("Please turn-off the server [y/N]: ")
+
+    # should fail
+    try:
+        start = time.time()
+        issue_16853.search(
+            [[1., 2., 3., 4., 5., 6., 7., 8.]],
+            "embeddings",
+            {},
+            limit=10, timeout=20)
+    except BaseException:
+        end = time.time()
+        if end - start >= 10:
+            print(f"=== test PASS: raise error by the timeout ===")
+        else:
+            print(f"=== test FAIL: Not influenced by the timeout ===")
+        return
+
+    print(f"=== test FAIL ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Add the corresponding e2e issue cases

- `wait_for_ready` is an experimental API in grpc, causes
API hanging forever of the server failed. So remove this
from search.

- Remove some not in-used search methods

See also: milvus-io/milvus#16835

Signed-off-by: XuanYang-cn <xuan.yang@zilliz.com>