### PR TITLE
Fix mergify unable to label ci-pass on branch 2.0

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,8 +1,9 @@
 pull_request_rules:
   - name: Test passed
     conditions:
-      - base=master
-      - base=2.0
+      - or:
+        - base=master
+        - base=2.0
       - "status-success=Run Python Tests (3.8)"
     actions:
       label:


### PR DESCRIPTION
Signed-off-by: XuanYang-cn <xuan.yang@zilliz.com>

/assign @longjiquan 