### PR TITLE
Cherry pick of (#1012) and (#1016)

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -60,7 +60,7 @@ from .exceptions import (
     BaseException,
 )
 
-from ..decorators import retry_on_rpc_failure, error_handler, check_has_collection
+from ..decorators import retry_on_rpc_failure, error_handler
 
 LOGGER = logging.getLogger(__name__)
 
@@ -374,10 +374,9 @@ class GrpcHandler:
 
     @retry_on_rpc_failure(retry_times=10, wait=1, retry_on_deadline=False)
     @error_handler
-    @check_has_collection
     def search(self, collection_name, data, anns_field, param, limit,
                expression=None, partition_names=None, output_fields=None,
-               timeout=None, round_decimal=-1, **kwargs):
+               round_decimal=-1, timeout=None, **kwargs):
         check_pass_param(
             limit=limit,
             round_decimal=round_decimal,
@@ -388,6 +387,10 @@ class GrpcHandler:
             travel_timestamp=kwargs.get("travel_timestamp", 0),
             guarantee_timestamp=kwargs.get("guarantee_timestamp", 0)
         )
+
+        if not self.has_collection(collection_name, timeout):
+            raise CollectionNotExistException(ErrorCode.CollectionNotExists,
+                                              f"collection {collection_name} doesn't exist!")
 
         _kwargs = copy.deepcopy(kwargs)
         collection_schema = self.describe_collection(collection_name, timeout)

--- a/pymilvus/client/stub.py
+++ b/pymilvus/client/stub.py
@@ -116,7 +116,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.drop_collection(collection_name, timeout)
+            return handler.drop_collection(collection_name, timeout=timeout)
 
     def has_collection(self, collection_name, timeout=None):
         """
@@ -137,7 +137,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.has_collection(collection_name, timeout)
+            return handler.has_collection(collection_name, timeout=timeout)
 
     def describe_collection(self, collection_name, timeout=None):
         """
@@ -162,7 +162,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.describe_collection(collection_name, timeout)
+            return handler.describe_collection(collection_name, timeout=timeout)
 
     def load_collection(self, collection_name, timeout=None, **kwargs):
         """
@@ -226,7 +226,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            stats = handler.get_collection_stats(collection_name, timeout, **kwargs)
+            stats = handler.get_collection_stats(collection_name, timeout=timeout, **kwargs)
             result = {stat.key: stat.value for stat in stats}
             result["row_count"] = int(result["row_count"])
             return result
@@ -247,7 +247,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.list_collections(timeout)
+            return handler.list_collections(timeout=timeout)
 
     def create_partition(self, collection_name, partition_name, timeout=None):
         """
@@ -273,7 +273,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.create_partition(collection_name, partition_name, timeout)
+            return handler.create_partition(collection_name, partition_name, timeout=timeout)
 
     def drop_partition(self, collection_name, partition_name, timeout=None):
         """
@@ -299,7 +299,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.drop_partition(collection_name, partition_name, timeout)
+            return handler.drop_partition(collection_name, partition_name, timeout=timeout)
 
     def has_partition(self, collection_name, partition_name, timeout=None):
         """
@@ -323,7 +323,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.has_partition(collection_name, partition_name, timeout)
+            return handler.has_partition(collection_name, partition_name, timeout=timeout)
 
     def load_partitions(self, collection_name, partition_names, timeout=None):
         """
@@ -394,7 +394,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.list_partitions(collection_name, timeout)
+            return handler.list_partitions(collection_name, timeout=timeout)
 
     def get_partition_stats(self, collection_name, partition_name, timeout=None, **kwargs):
         """
@@ -419,7 +419,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            stats = handler.get_partition_stats(collection_name, partition_name, timeout, **kwargs)
+            stats = handler.get_partition_stats(collection_name, partition_name, timeout=timeout, **kwargs)
             result = {stat.key: stat.value for stat in stats}
             result["row_count"] = int(result["row_count"])
             return result
@@ -452,7 +452,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.create_alias(collection_name, alias, timeout, **kwargs)
+            return handler.create_alias(collection_name, alias, timeout=timeout, **kwargs)
 
     def drop_alias(self, alias, timeout=None, **kwargs):
         """
@@ -479,7 +479,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.drop_alias(alias, timeout, **kwargs)
+            return handler.drop_alias(alias, timeout=timeout, **kwargs)
 
     def alter_alias(self, collection_name, alias, timeout=None, **kwargs):
         """
@@ -511,7 +511,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.alter_alias(collection_name, alias, timeout, **kwargs)
+            return handler.alter_alias(collection_name, alias, timeout=timeout, **kwargs)
 
     def create_index(self, collection_name, field_name, params, timeout=None, **kwargs):
         """
@@ -615,7 +615,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.create_index(collection_name, field_name, params, timeout, **kwargs)
+            return handler.create_index(collection_name, field_name, params, timeout=timeout, **kwargs)
 
     def drop_index(self, collection_name, field_name, timeout=None):
         """
@@ -665,7 +665,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.describe_index(collection_name, index_name, timeout)
+            return handler.describe_index(collection_name, index_name, timeout=timeout)
 
     def insert(self, collection_name, entities, partition_name=None, timeout=None, **kwargs):
         """
@@ -701,7 +701,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.bulk_insert(collection_name, entities, partition_name, timeout, **kwargs)
+            return handler.bulk_insert(collection_name, entities, partition_name, timeout=timeout, **kwargs)
 
     def delete(self, collection_name, expr, partition_name=None, timeout=None, **kwargs):
         """
@@ -729,7 +729,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.delete(collection_name, expr, partition_name, timeout, **kwargs)
+            return handler.delete(collection_name, expr, partition_name, timeout=timeout, **kwargs)
 
     def flush(self, collection_names=None, timeout=None, **kwargs):
         """
@@ -764,7 +764,7 @@ class Milvus:
         :raises BaseException: If the return result from server is not ok
         """
         with self._connection() as handler:
-            return handler.flush(collection_names, timeout, **kwargs)
+            return handler.flush(collection_names, timeout=timeout, **kwargs)
 
     def search(self, collection_name, data, anns_field, param, limit, expression=None, partition_names=None,
                output_fields=None, timeout=None, round_decimal=-1, **kwargs):
@@ -826,7 +826,7 @@ class Milvus:
         """
         with self._connection() as handler:
             return handler.search(collection_name, data, anns_field, param, limit, expression,
-                                  partition_names, output_fields, timeout, round_decimal, **kwargs)
+                                  partition_names, output_fields, timeout=timeout, round_decimal=round_decimal, **kwargs)
 
     def calc_distance(self, vectors_left, vectors_right, params=None, timeout=None, **kwargs):
         """
@@ -872,7 +872,7 @@ class Milvus:
 
         """
         with self._connection() as handler:
-            return handler.calc_distance(vectors_left, vectors_right, params, timeout, **kwargs)
+            return handler.calc_distance(vectors_left, vectors_right, params, timeout=timeout, **kwargs)
 
     def get_query_segment_info(self, collection_name, timeout=None, **kwargs):
         """
@@ -888,7 +888,7 @@ class Milvus:
         :rtype: QuerySegmentInfo
         """
         with self._connection() as handler:
-            return handler.get_query_segment_info(collection_name, timeout, **kwargs)
+            return handler.get_query_segment_info(collection_name, timeout=timeout, **kwargs)
 
     def load_collection_progress(self, collection_name, timeout=None):
         with self._connection() as handler:
@@ -985,7 +985,7 @@ class Milvus:
         :raises BaseException: If sealed segments not exist.
         """
         with self._connection() as handler:
-            return handler.load_balance(src_node_id, dst_node_ids, sealed_segment_ids, timeout, **kwargs)
+            return handler.load_balance(src_node_id, dst_node_ids, sealed_segment_ids, timeout=timeout, **kwargs)
 
     def compact(self, collection_name, timeout=None, **kwargs) -> int:
         """
@@ -1003,7 +1003,7 @@ class Milvus:
         :raises BaseException: If collection name not exist.
         """
         with self._connection() as handler:
-            return handler.compact(collection_name, timeout, **kwargs)
+            return handler.compact(collection_name, timeout=timeout, **kwargs)
 
     def get_compaction_state(self, compaction_id: int, timeout=None, **kwargs) -> CompactionState:
         """
@@ -1022,7 +1022,7 @@ class Milvus:
         """
 
         with self._connection() as handler:
-            return handler.get_compaction_state(compaction_id, timeout, **kwargs)
+            return handler.get_compaction_state(compaction_id, timeout=timeout, **kwargs)
 
     def wait_for_compaction_completed(self, compaction_id: int, timeout=None, **kwargs) -> CompactionState:
         with self._connection() as handler:
@@ -1044,4 +1044,4 @@ class Milvus:
         :raises BaseException: If compaction_id doesn't exist.
         """
         with self._connection() as handler:
-            return handler.get_compaction_plans(compaction_id, timeout, **kwargs)
+            return handler.get_compaction_plans(compaction_id, timeout=timeout, **kwargs)

--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -359,7 +359,7 @@ class Collection:
             """
         conn = self._get_connection()
         conn.flush([self._name])
-        stats = conn.get_collection_stats(db_name="", collection_name=self._name)
+        stats = conn.get_collection_stats(collection_name=self._name)
         result = {stat.key: stat.value for stat in stats}
         result["row_count"] = int(result["row_count"])
         return result["row_count"]
@@ -585,7 +585,7 @@ class Collection:
         """
 
         conn = self._get_connection()
-        res = conn.delete(self._name, expr, partition_name, timeout, **kwargs)
+        res = conn.delete(self._name, expr, partition_name, timeout=timeout, **kwargs)
         if kwargs.get("_async", False):
             return MutationFuture(res)
         return MutationResult(res)
@@ -688,7 +688,7 @@ class Collection:
 
         conn = self._get_connection()
         res = conn.search(self._name, data, anns_field, param, limit, expr,
-                          partition_names, output_fields, timeout, round_decimal, **kwargs)
+                          partition_names, output_fields, round_decimal, timeout=timeout, **kwargs)
         if kwargs.get("_async", False):
             return SearchFuture(res)
         return SearchResult(res)
@@ -767,7 +767,7 @@ class Collection:
             raise DataTypeNotMatchException(0, ExceptionsMessage.ExprType % type(expr))
 
         conn = self._get_connection()
-        res = conn.query(self._name, expr, output_fields, partition_names, timeout, **kwargs)
+        res = conn.query(self._name, expr, output_fields, partition_names, timeout=timeout, **kwargs)
         return res
 
     @property
@@ -1147,7 +1147,7 @@ class Collection:
         :example:
         """
         conn = self._get_connection()
-        return conn.wait_for_compaction_completed(self.compaction_id, timeout, **kwargs)
+        return conn.wait_for_compaction_completed(self.compaction_id, timeout=timeout, **kwargs)
 
     def get_compaction_plans(self, timeout=None, **kwargs) -> CompactionPlans:
         """

--- a/pymilvus/orm/partition.py
+++ b/pymilvus/orm/partition.py
@@ -320,7 +320,7 @@ class Partition:
         """
 
         conn = self._get_connection()
-        res = conn.delete(self._collection.name, expr, self.name, timeout, **kwargs)
+        res = conn.delete(self._collection.name, expr, self.name, timeout=timeout, **kwargs)
         if kwargs.get("_async", False):
             return MutationFuture(res)
         return MutationResult(res)
@@ -418,7 +418,7 @@ class Partition:
         """
         conn = self._get_connection()
         res = conn.search(self._collection.name, data, anns_field, param, limit,
-                          expr, [self._name], output_fields, timeout, round_decimal, **kwargs)
+                          expr, [self._name], output_fields, round_decimal, timeout=timeout, **kwargs)
         if kwargs.get("_async", False):
             return SearchFuture(res)
         return SearchResult(res)
@@ -491,5 +491,5 @@ class Partition:
             - Query results: [{'film_id': 0, 'film_date': 2000}, {'film_id': 1, 'film_date': 2001}]
         """
         conn = self._get_connection()
-        res = conn.query(self._collection.name, expr, output_fields, [self._name], timeout, **kwargs)
+        res = conn.query(self._collection.name, expr, output_fields, [self._name], timeout=timeout, **kwargs)
         return res

--- a/pymilvus/orm/utility.py
+++ b/pymilvus/orm/utility.py
@@ -233,8 +233,8 @@ def wait_for_loading_complete(collection_name, partition_names=None, timeout=Non
         >>> utility.wait_for_loading_complete("test_collection")
     """
     if not partition_names or len(partition_names) == 0:
-        return _get_connection(using).wait_for_loading_collection(collection_name, timeout)
-    return _get_connection(using).wait_for_loading_partitions(collection_name, partition_names, timeout)
+        return _get_connection(using).wait_for_loading_collection(collection_name, timeout=timeout)
+    return _get_connection(using).wait_for_loading_partitions(collection_name, partition_names, timeout=timeout)
 
 
 def index_building_progress(collection_name, index_name="", using="default"):
@@ -328,7 +328,7 @@ def wait_for_index_building_complete(collection_name, index_name="", timeout=Non
         >>> utility.loading_progress("test_collection")
 
     """
-    return _get_connection(using).wait_for_creating_index(collection_name, index_name, timeout)[0]
+    return _get_connection(using).wait_for_creating_index(collection_name, index_name, timeout=timeout)[0]
 
 
 def has_collection(collection_name, using="default"):
@@ -404,7 +404,7 @@ def drop_collection(collection_name, timeout=None, using="default"):
         >>> utility.has_collection("drop_collection_test")
         >>> False
     """
-    return _get_connection(using).drop_collection(collection_name, timeout)
+    return _get_connection(using).drop_collection(collection_name, timeout=timeout)
 
 
 def list_collections(timeout=None, using="default") -> list:
@@ -428,7 +428,7 @@ def list_collections(timeout=None, using="default") -> list:
         >>> collection = Collection(name="test_collection", schema=schema)
         >>> utility.list_collections()
     """
-    return _get_connection(using).list_collections()
+    return _get_connection(using).list_collections(timeout=timeout)
 
 
 def calc_distance(vectors_left, vectors_right, params=None, timeout=None, using="default"):
@@ -485,7 +485,7 @@ def calc_distance(vectors_left, vectors_right, params=None, timeout=None, using=
         >>> params = {"metric": "L2", "sqrt": True}
         >>> results = utility.calc_distance(vectors_left=op_l, vectors_right=op_r, params=params)
     """
-    res = _get_connection(using).calc_distance(vectors_left, vectors_right, params, timeout)
+    res = _get_connection(using).calc_distance(vectors_left, vectors_right, params, timeout=timeout)
 
     def vector_count(op):
         x = 0
@@ -542,7 +542,7 @@ def load_balance(src_node_id, dst_node_ids=None, sealed_segment_ids=None, timeou
         dst_node_ids = []
     if sealed_segment_ids is None:
         sealed_segment_ids = []
-    return _get_connection(using).load_balance(src_node_id, dst_node_ids, sealed_segment_ids, timeout)
+    return _get_connection(using).load_balance(src_node_id, dst_node_ids, sealed_segment_ids, timeout=timeout)
 
 
 def get_query_segment_info(collection_name, timeout=None, using="default"):


### PR DESCRIPTION
1. Enable timeout to control retry times (#1012)

- Make sure ever timeout parameter is the last position param
- Remove check_has_collection
- Enable timeout to control retry times

2. Fix nightly index out of range (#1016)

- Get rid of dagerous args slice
- Make sure all the API passes timout by kwargs form

`search(..., timeout=timeout)`

See also: #16853
Fixes: #1015

Signed-off-by: XuanYang-cn <xuan.yang@zilliz.com>