### PR TITLE
Extend grpcio version requirements range

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ $ git sumodule update --init
 
 Q2. How to generate python files from milvus-proto?
 
+**Before generating python files, please install requirements in `requirements.txt`**
+
 A2.
 ```shell
 $ make gen_proto

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 build==0.4.0
 certifi==2021.5.30
 chardet==4.0.0
-grpcio==1.37.1
-grpcio-testing==1.37.1
-grpcio-tools==1.37.1
+grpcio>=1.37.1
+grpcio-testing>=1.37.1
+grpcio-tools>=1.37.1,<=1.43.0
 idna==2.10
 mmh3>=2.0,<=3.0.0
 packaging==20.9
@@ -28,7 +28,7 @@ sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
 sphinxcontrib-napoleon
 sphinxcontrib-prettyspecialmethods
-pytest==5.3.4
+pytest>=5.3.4
 pytest-cov==2.8.1
 pytest-timeout==1.3.4
 pylint==2.4.4

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=[
-        "grpcio==1.37.1",
-        "grpcio-tools==1.37.1",
+        "grpcio>=1.37.1",
         "ujson>=2.0.0,<=5.1.0",
         "mmh3>=2.0,<=3.0.0",
         "pandas==1.1.5; python_version<'3.7'",


### PR DESCRIPTION
To run pymilvus, we only need `grpcio`
To generate python files from protos, we need `grpcio-tools`

This PR:
1. Removes `grpcio-tools` from install requirements
2. Extends `grpcio` versions
3. Provides the compatible version ranges of `grpcio-tools` and `grpcio`

See also: #1030, #943, #946

Signed-off-by: XuanYang-cn <xuan.yang@zilliz.com>