### PR TITLE
Fix CVE-2022-31116 by allow upgrade ujson include 5.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ protobuf==3.17.1
 pyparsing==2.4.7
 six==1.16.0
 toml==0.10.2
-ujson>=2.0.0,<=5.1.0
+ujson>=2.0.0,<=5.4.0
 urllib3==1.26.5
 sklearn==0.0
 m2r==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         "grpcio>=1.47.0",
-        "ujson>=2.0.0,<=5.1.0",
+        "ujson>=2.0.0,<=5.4.0",
         "mmh3>=2.0,<=3.0.0",
         "pandas==1.1.5; python_version<'3.7'",
         "pandas>=1.2.4; python_version>'3.6'",


### PR DESCRIPTION
ujson 5.4.0 is required to resolve https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-31116

> UltraJSON is a fast JSON encoder and decoder written in pure C with bindings for Python 3.7+. Affected versions were found to improperly decode certain characters. JSON strings that contain escaped surrogate characters not part of a proper surrogate pair were decoded incorrectly. Besides corrupting strings, this allowed for potential key confusion and value overwriting in dictionaries. All users parsing JSON from untrusted sources are vulnerable. **From version 5.4.0, UltraJSON decodes lone surrogates in the same way as the standard library's `json` module does, preserving them in the parsed output. Users are advised to upgrade.** There are no known workarounds for this issue. 