### PR TITLE
Optimize some low efficient code

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -431,10 +431,9 @@ class Prepare:
         return request
 
     @classmethod
-    def search_requests_with_expr(cls, collection_name, data, anns_field, param, limit, expr=None, partition_names=None,
+    def search_requests_with_expr(cls, collection_name, data, anns_field, param, limit, schema, expr=None, partition_names=None,
                                   output_fields=None, round_decimal=-1, **kwargs):
         # TODO Move this impl into server side
-        schema = kwargs.get("schema", None)
         fields_schema = schema.get("fields", None)  # list
         fields_name_locs = {fields_schema[loc]["name"]: loc for loc in range(len(fields_schema))}
 

--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -134,6 +134,9 @@ class Collection:
             else:
                 raise SchemaNotReadyException(message=ExceptionsMessage.SchemaType)
 
+        self._schema_dict = self._schema.to_dict()
+        self._schema_dict["consistency_level"] = self._consistency_level
+
     def __repr__(self):
         _dict = {
             'name': self.name,
@@ -653,10 +656,9 @@ class Collection:
             raise DataTypeNotMatchException(message=ExceptionsMessage.ExprType % type(expr))
 
         conn = self._get_connection()
-        schema_dict = self._schema.to_dict()
-        schema_dict["consistency_level"] = self._consistency_level
         res = conn.search(self._name, data, anns_field, param, limit, expr,
-                          partition_names, output_fields, round_decimal, timeout=timeout, schema=schema_dict, **kwargs)
+                          partition_names, output_fields, round_decimal, timeout=timeout,
+                          collection_schema=self._schema_dict, **kwargs)
         if kwargs.get("_async", False):
             return SearchFuture(res)
         return SearchResult(res)

--- a/pymilvus/orm/partition.py
+++ b/pymilvus/orm/partition.py
@@ -444,7 +444,7 @@ class Partition:
         schema_dict = self._schema.to_dict()
         schema_dict["consistency_level"] = self._consistency_level
         res = conn.search(self._collection.name, data, anns_field, param, limit, expr, [self._name], output_fields,
-                          round_decimal=round_decimal, timeout=timeout, schema=schema_dict, **kwargs)
+                          round_decimal=round_decimal, timeout=timeout, collection_schema=schema_dict, **kwargs)
         if kwargs.get("_async", False):
             return SearchFuture(res)
         return SearchResult(res)

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -26,7 +26,7 @@ class TestPrepare:
             "offset": 10,
         }
 
-        ret = Prepare.search_requests_with_expr("name", data, "v", search_params, 100, schema=schema)
+        ret = Prepare.search_requests_with_expr("name", data, "v", search_params, 100, schema)
 
         offset_exists = False
         for p in ret[0].search_params:


### PR DESCRIPTION
Signed-off-by: Li Liu <li.liu@zilliz.com>

This PR fix some low efficient code:
1. Call `to_dict()` of a collection at construction time and store it for search use.
2. Use a map instead of endless `if else` to check param.
3. For sync search, simply use serial execution instead of `async + get`
4. Remove deep copy in search path

For performance enhancement, I did some test in my 2C8M container:
*Pymilvus*: Set `grpc` to return empty response immediately, the QPS of `Pymilvus` increase from ~1200 to ~2100, increased about 75%
*End 2 End*: For nq1 serial execution, latency improved ~10%.


Notice: Still lots of similar style in other parts of the code, like deep copy, `to_dict()` call, `if else` param check and mixed sync/async call. We need to fix them all if needed.