### PR TITLE
fix invalid 404 document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ python setup.py install
 
 ## Documentation
 
-Documentation is available online: https://milvus.io/api-reference/pymilvus/v2.2.3/About.md
+Documentation is available online: https://milvus.io/api-reference/pymilvus/v2.2.6/About.md
 
 ## Developing package releases
 


### PR DESCRIPTION
Online document link to an unavailable 404 page, fix it.
Using a default latest page would be better.