### PR TITLE
Multi cherry-picks of 2.2

### DIFF
--- a/pymilvus/grpc_gen/python_gen.sh
+++ b/pymilvus/grpc_gen/python_gen.sh
@@ -3,6 +3,8 @@
 OUTDIR=.
 PROTO_DIR="milvus-proto/proto"
 
+python -m pip install "grpcio-tools==$(python3 -c 'import grpc; print(grpc.__version__)')"
+
 python -m grpc_tools.protoc -I ${PROTO_DIR} --python_out=${OUTDIR} --pyi_out=${OUTDIR} ${PROTO_DIR}/common.proto
 python -m grpc_tools.protoc -I ${PROTO_DIR} --python_out=${OUTDIR} --pyi_out=${OUTDIR} ${PROTO_DIR}/schema.proto
 python -m grpc_tools.protoc -I ${PROTO_DIR} --python_out=${OUTDIR} --pyi_out=${OUTDIR} ${PROTO_DIR}/feder.proto

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         "grpcio>=1.49.1,<=1.53.0",
-        "grpcio-tools>=1.49.1,<=1.53.0",
+        "protobuf>=3.20.0",
         "mmh3>=2.0",
         "ujson>=2.0.0",
         "pandas>=1.2.4",


### PR DESCRIPTION
- Improvement support colab (milvus-io#1353)
- Fix missing dependency with protobuf (milvus-io#1358)

Google colab notebook already installed protobuf==3.20.3 at the moment.
And installing grpcio-tools will request a higher version protobuf.
So a restart for notebook kernel is needed.
Indeed grpcio-tools is not mandatory for pymilvus.

Issue: milvus-io#1356

Signed-off-by: yangxuan <xuan.yang@zilliz.com>
Co-Authored-By: Ji Bin <matrixji@live.com>