### PR TITLE
Fix broken link to docs in README (2.2.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ python setup.py install
 
 ## Documentation
 
-Documentation is available online: https://milvus.io/api-reference/pymilvus/v2.2.3/About.md
+Documentation is available online: https://milvus.io/api-reference/pymilvus/v2.2.7/About.md
 
 ## Developing package releases
 


### PR DESCRIPTION
Duplicate of #1350, except that one is already outdated.