### PR TITLE
Few fixes before 2.2.8 cherrypick

### DIFF
--- a/pymilvus/__init__.py
+++ b/pymilvus/__init__.py
@@ -73,6 +73,8 @@ from .orm.schema import FieldSchema, CollectionSchema
 from .orm.future import SearchFuture, MutationFuture
 from .orm.role import Role
 
+from .milvus_client.milvus_client import MilvusClient
+
 __all__ = [
     'Collection', 'Index', 'Partition',
     'connections',
@@ -91,5 +93,7 @@ __all__ = [
 
     'Milvus', 'Prepare', 'Status', 'DataType',
     'MilvusException',
-    '__version__'
+    '__version__',
+
+    'MilvusClient'
 ]


### PR DESCRIPTION
For the release notes here is a snipped example:
```python
from pymilvus import MilvusClient

client = MilvusClient(
    collection_name="qux",
    uri="http://localhost:19530",
    vector_field="float_vector",
    overwrite=True,
)

data = [
    {
        "float_vector": [1,2,3],
        "id": 1,
        "text": "foo"
    },
    {
        "float_vector": [4,5,6],
        "id": 2,
        "text": "bar"
    },
    {
        "float_vector": [7,8,9],
        "id": 3,
        "text": "baz"
    }
]
client.insert_data(data)

res = client.search_data(
    data = [1,3,5],
    top_k = 2,
    filter_expression= "id > 1"
)

# Result:
# [
#    [
#       {'data': {'id': 2, 'internal_pk_0373': 441112070275989578, 'text': 'bar'}, 'score': 14.0},
#       {'data': {'id': 3, 'internal_pk_0373': 441112070275989579, 'text': 'baz'},'score': 77.0}
#    ]
# ]
```   