### PR TITLE
reuse grpc channel and clean connections

### DIFF
--- a/pymilvus/exceptions.py
+++ b/pymilvus/exceptions.py
@@ -137,6 +137,7 @@ class ExceptionsMessage:
     HostType = "Type of 'host' must be str."
     PortType = "Type of 'port' must be str or int."
     ConnDiffConf = "Alias of %r already creating connections, but the configure is not the same as passed in."
+    AliasUsed = "Alias %r already exists, please remove first."
     AliasType = "Alias should be string, but %r is given."
     ConnLackConf = "You need to pass in the configuration of the connection named %r ."
     ConnectFirst = "should create connect first."

--- a/pymilvus/settings.py
+++ b/pymilvus/settings.py
@@ -15,6 +15,12 @@ class Config:
     MILVUS_CONN_ALIAS = env.str("MILVUS_CONN_ALIAS", "default")
     MILVUS_CONN_TIMEOUT = env.float("MILVUS_CONN_TIMEOUT", 10)
 
+    MILVUS_USER = env.str("MILVUS_USER", "")
+    MILVUS_PASSWORD = env.str("MILVUS_PASSWORD", "")
+    MILVUS_TOKEN = env.str("MILVUS_TOKEN", "")
+
+    MILVUS_DB_NAME = env.str("MILVUS_DB_NAME", "")
+
     # legacy configs:
     DEFAULT_USING = MILVUS_CONN_ALIAS
     DEFAULT_CONNECT_TIMEOUT = MILVUS_CONN_TIMEOUT
@@ -26,6 +32,7 @@ class Config:
 
     DEFAULT_HOST = "localhost"
     DEFAULT_PORT = "19530"
+    DEFAULT_SECURE = False
 
     WaitTimeDurationWhenLoad = 0.5  # in seconds
     MaxVarCharLengthKey = "max_length"


### PR DESCRIPTION
This PR:
- adds in grpc reuse
- corrects user and db_name alias checks
- cleans up and reduces helper functions
- centralizes connection args logic
- enforces correct URI, does not attempt to attach default host and port to miss structed uri
