### PR TITLE
Do not let logger.setLevel affect other modules

### DIFF
--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -15,7 +15,7 @@ from pymilvus.orm.collection import CollectionSchema
 from pymilvus.orm.connections import connections
 from pymilvus.orm.types import DataType
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 


### PR DESCRIPTION
If you want logging.getLogger, please only affect the current module, do not change all third-party modules the same, if you do not add the name parameter in getLogger, it will cause setLevel to affect all third-party treasures, which is extremely bad and stupid


