### PR TITLE
Remove unused index and metric_type check

### DIFF
--- a/pymilvus/client/check.py
+++ b/pymilvus/client/check.py
@@ -202,35 +202,6 @@ def is_legal_replica_number(replica_number: int) -> bool:
     return isinstance(replica_number, int)
 
 
-# https://milvus.io/cn/docs/v1.0.0/metric.md#floating
-def is_legal_index_metric_type(index_type: str, metric_type: str) -> bool:
-    if index_type not in (
-        "GPU_IVF_FLAT",
-        "GPU_IVF_PQ",
-        "FLAT",
-        "IVF_FLAT",
-        "IVF_SQ8",
-        "IVF_PQ",
-        "HNSW",
-        "AUTOINDEX",
-        "DISKANN",
-    ):
-        return False
-    if metric_type not in ("L2", "IP", "COSINE"):
-        return False
-    return True
-
-
-# https://milvus.io/cn/docs/v1.0.0/metric.md#binary
-def is_legal_binary_index_metric_type(index_type: str, metric_type: str) -> bool:
-    if index_type == "BIN_FLAT":
-        if metric_type in ("JACCARD", "TANIMOTO", "HAMMING", "SUBSTRUCTURE", "SUPERSTRUCTURE"):
-            return True
-    elif index_type == "BIN_IVF_FLAT" and metric_type in ("JACCARD", "TANIMOTO", "HAMMING"):
-        return True
-    return False
-
-
 def _raise_param_error(param_name: str, param_value: Any) -> None:
     raise ParamError(message=f"`{param_name}` value {param_value} is illegal")
 


### PR DESCRIPTION
When I want add a new index like scann(https://github.com/milvus-io/milvus/pull/26099), seems we do not need to add index support in pymilvus(all the check would be done in milvus), but the check functions still exist, just remove them.
/kind improvement