### PR TITLE
while parse uri, overwrite the db_name with default

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -238,7 +238,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
         alias: str = Config.MILVUS_CONN_ALIAS,
         user: str = "",
         password: str = "",
-        db_name: str = "",
+        db_name: str = "default",
         token: str = "",
         **kwargs,
     ) -> None:
@@ -345,7 +345,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
                 password = parsed_uri.password or password
 
                 group = parsed_uri.path.split("/")
-                db_name = group[1] if len(group) > 1 else "default"
+                db_name = group[1] if len(group) > 1 else db_name
 
                 # Set secure=True if https scheme
                 if parsed_uri.scheme == "https":


### PR DESCRIPTION
/kind bug
[milvus #26833](https://github.com/milvus-io/milvus/issues/26833)

|||default value| user case1(as bug described)|user case2|user case 3|user case4|
|--|--|--|--|--|--|--|
|MilvusClient's arguments|uri|http://localhost:19530|http://localhost:19530|http://localhost:19530/test|http://localhost:19530/test|http://localhost:19530/test|
||db_name||test||default|test|
|connect with milvus server||found uri without dbname, use "default"|found uri without dbname, use "default"|found uri with dbname "test"|found uri with dbname "test"|found uri with dbname "test"|
|result||correct|**db_name didn't work**|corrent|uri priority higher|corrent|
|how to fix|||use db_name "test"|||||

