### PR TITLE
Fix has_collection result with Milvus2.2

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -320,17 +320,17 @@ class GrpcHandler:
         rf = self._stub.DescribeCollection.future(request, timeout=timeout)
 
         reply = rf.result()
-        if reply.status.code == ErrorCode.SUCCESS:
-            return True
-
-        if reply.status.code == ErrorCode.COLLECTION_NOT_FOUND:
-            return False
-
         # For compatibility with Milvus less than 2.3.2, which does not support status.code.
         if (
             reply.status.error_code == common_pb2.UnexpectedError
             and "can't find collection" in reply.status.reason
         ):
+            return False
+
+        if reply.status.code == ErrorCode.SUCCESS:
+            return True
+
+        if reply.status.code == ErrorCode.COLLECTION_NOT_FOUND:
             return False
 
         raise MilvusException(reply.status.code, reply.status.reason, reply.status.error_code)

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -40,7 +40,7 @@ from .types import (
 
 def validate_primary_key(primary_field: Any):
     if primary_field is None:
-        raise PrimaryKeyException(message=ExceptionsMessage.PrimaryKeyNotExist)
+        raise PrimaryKeyException(message=ExceptionsMessage.NoPrimaryKey)
 
     if primary_field.dtype not in [DataType.INT64, DataType.VARCHAR]:
         raise PrimaryKeyException(message=ExceptionsMessage.PrimaryKeyType)


### PR DESCRIPTION
For Milvus2.2.x, PyMilvus needs to check for `error_code` before checking codes, cuz code will alwasy returns 0, which indicates rpc success