### PR TITLE
fix: load_state parameter type err

### DIFF
--- a/pymilvus/orm/utility.py
+++ b/pymilvus/orm/utility.py
@@ -222,7 +222,7 @@ def loading_progress(
 
 def load_state(
     collection_name: str,
-    partition_names: Optional[float] = None,
+    partition_names: Optional[List[str]] = None,
     using: str = "default",
     timeout: Optional[float] = None,
 ):


### PR DESCRIPTION
fix issue https://github.com/milvus-io/pymilvus/issues/1764

load_state parameter `partition_names` error