### PR TITLE
Modify highlevel delete to not return any value

### DIFF
--- a/examples/hello_milvus_simple.py
+++ b/examples/hello_milvus_simple.py
@@ -36,8 +36,8 @@ first_pk_data = milvus_client.get(collection_name, pks[0:1])
 print(f"data of primary key {pks[0]} is", first_pk_data)
 
 print(f"start to delete first 2 of primary keys in collection {collection_name}")
-delete_pks = milvus_client.delete(collection_name, pks[0:2])
-print("deleted:", delete_pks)
+milvus_client.delete(collection_name, pks[0:2])
+
 rng = np.random.default_rng(seed=19530)
 vectors_to_search = rng.random((1, dim))
 


### PR DESCRIPTION
Starting from version 2.3.2, Milvus no longer includes the primary keys in the result when processing the delete operation with expressions. This change is due to the large amount of data involved. The delete interface no longer returns any results. If no exceptions are thrown, it indicates a successful deletion. However, for backward compatibility, if the primary_keys returned from Milvus is not empty the list of primary keys is still returned.