### PR TITLE
feat: Add sparse float vector support to PyMilvus

### DIFF
--- a/examples/hello_sparse.py
+++ b/examples/hello_sparse.py
@@ -1,0 +1,154 @@
+# hello_sprase.py demonstrates the basic operations of PyMilvus, a Python SDK of Milvus,
+# while operating on sparse float vectors.
+# 1. connect to Milvus
+# 2. create collection
+# 3. insert data
+# 4. create index
+# 5. search, query, and hybrid search on entities
+# 6. delete entities by PK
+# 7. drop collection
+import time
+
+import numpy as np
+from scipy.sparse import rand
+from pymilvus import (
+    connections,
+    utility,
+    FieldSchema, CollectionSchema, DataType,
+    Collection,
+)
+
+fmt = "=== {:30} ==="
+search_latency_fmt = "search latency = {:.4f}s"
+num_entities, dim, density = 1000, 3000, 0.005
+
+def log(msg):
+    print(time.strftime("%Y-%m-%d %H:%M:%S", time.localtime()) + " " + msg)
+
+# -----------------------------------------------------------------------------
+# connect to Milvus
+log(fmt.format("start connecting to Milvus"))
+connections.connect("default", host="localhost", port="19530")
+
+has = utility.has_collection("hello_sparse")
+log(f"Does collection hello_sparse exist in Milvus: {has}")
+
+# -----------------------------------------------------------------------------
+# create collection with a sparse float vector column
+hello_sparse = None
+if not has:
+    fields = [
+        FieldSchema(name="pk", dtype=DataType.VARCHAR, is_primary=True, auto_id=True, max_length=100),
+        FieldSchema(name="random", dtype=DataType.DOUBLE),
+        FieldSchema(name="embeddings", dtype=DataType.SPARSE_FLOAT_VECTOR),
+    ]
+    schema = CollectionSchema(fields, "hello_sparse is the simplest demo to introduce sparse float vector usage")
+    log(fmt.format("Create collection `hello_sparse`"))
+    hello_sparse = Collection("hello_sparse", schema, consistency_level="Strong")
+else:
+    hello_sparse = Collection("hello_sparse")
+
+log(f"hello_sparse has {hello_sparse.num_entities} entities({hello_sparse.num_entities/1000000}M), indexed {hello_sparse.has_index()}")
+
+# -----------------------------------------------------------------------------
+# insert
+log(fmt.format("Start creating entities to insert"))
+rng = np.random.default_rng(seed=19530)
+# this step is so damn slow
+matrix_csr = rand(num_entities, dim, density=density, format='csr')
+entities = [
+    rng.random(num_entities).tolist(),
+    matrix_csr,
+]
+
+log(fmt.format("Start inserting entities"))
+insert_result = hello_sparse.insert(entities)
+
+# -----------------------------------------------------------------------------
+# create index
+if not hello_sparse.has_index():
+    log(fmt.format("Start Creating index SPARSE_INVERTED_INDEX"))
+    index = {
+        "index_type": "SPARSE_INVERTED_INDEX",
+        "metric_type": "IP",
+        "params":{
+            "drop_ratio_build": 0.2,
+        }
+    }
+    hello_sparse.create_index("embeddings", index)
+
+log(fmt.format("Start loading"))
+hello_sparse.load()
+
+# -----------------------------------------------------------------------------
+# search based on vector similarity
+log(fmt.format("Start searching based on vector similarity"))
+vectors_to_search = entities[-1][-1:]
+search_params = {
+    "metric_type": "IP",
+    "params": {
+        "drop_ratio_search": "0.2",
+    }
+}
+
+start_time = time.time()
+result = hello_sparse.search(vectors_to_search, "embeddings", search_params, limit=3, output_fields=["pk", "random", "embeddings"])
+end_time = time.time()
+
+for hits in result:
+    for hit in hits:
+        print(f"hit: {hit}")
+log(search_latency_fmt.format(end_time - start_time))
+# -----------------------------------------------------------------------------
+# query based on scalar filtering(boolean, int, etc.)
+print(fmt.format("Start querying with `random > 0.5`"))
+
+start_time = time.time()
+result = hello_sparse.query(expr="random > 0.5", output_fields=["random", "embeddings"])
+end_time = time.time()
+
+print(f"query result:\n-{result[0]}")
+print(search_latency_fmt.format(end_time - start_time))
+
+# -----------------------------------------------------------------------------
+# pagination
+r1 = hello_sparse.query(expr="random > 0.5", limit=4, output_fields=["random"])
+r2 = hello_sparse.query(expr="random > 0.5", offset=1, limit=3, output_fields=["random"])
+print(f"query pagination(limit=4):\n\t{r1}")
+print(f"query pagination(offset=1, limit=3):\n\t{r2}")
+
+
+# -----------------------------------------------------------------------------
+# hybrid search
+print(fmt.format("Start hybrid searching with `random > 0.5`"))
+
+start_time = time.time()
+result = hello_sparse.search(vectors_to_search, "embeddings", search_params, limit=3, expr="random > 0.5", output_fields=["random"])
+end_time = time.time()
+
+for hits in result:
+    for hit in hits:
+        print(f"hit: {hit}, random field: {hit.entity.get('random')}")
+print(search_latency_fmt.format(end_time - start_time))
+
+# -----------------------------------------------------------------------------
+# delete entities by PK
+# You can delete entities by their PK values using boolean expressions.
+ids = insert_result.primary_keys
+
+expr = f'pk in ["{ids[0]}" , "{ids[1]}"]'
+print(fmt.format(f"Start deleting with expr `{expr}`"))
+
+result = hello_sparse.query(expr=expr, output_fields=["random", "embeddings"])
+print(f"query before delete by expr=`{expr}` -> result: \n-{result[0]}\n-{result[1]}\n")
+
+hello_sparse.delete(expr)
+
+result = hello_sparse.query(expr=expr, output_fields=["random", "embeddings"])
+print(f"query after delete by expr=`{expr}` -> result: {result}\n")
+
+
+# -----------------------------------------------------------------------------
+# drop collection
+print(fmt.format("Drop collection `hello_sparse`"))
+utility.drop_collection("hello_sparse")

--- a/examples/milvus_client/sparse.py
+++ b/examples/milvus_client/sparse.py
@@ -1,0 +1,88 @@
+from pymilvus import (
+    MilvusClient,
+    FieldSchema, CollectionSchema, DataType,
+)
+
+import random
+
+def generate_sparse_vector(dimension: int, non_zero_count: int) -> dict:
+    indices = random.sample(range(dimension), non_zero_count)
+    values = [random.random() for _ in range(non_zero_count)]
+    sparse_vector = {index: value for index, value in zip(indices, values)}
+    return sparse_vector
+
+
+fmt = "\n=== {:30} ===\n"
+dim = 100
+non_zero_count = 20
+collection_name = "hello_sparse"
+milvus_client = MilvusClient("http://localhost:19530")
+
+has_collection = milvus_client.has_collection(collection_name, timeout=5)
+if has_collection:
+    milvus_client.drop_collection(collection_name)
+fields = [
+    FieldSchema(name="pk", dtype=DataType.VARCHAR,
+                is_primary=True, auto_id=True, max_length=100),
+    FieldSchema(name="random", dtype=DataType.DOUBLE),
+    FieldSchema(name="embeddings", dtype=DataType.SPARSE_FLOAT_VECTOR),
+]
+schema = CollectionSchema(
+    fields, "demo for using sparse float vector with milvus client")
+index_params = milvus_client.prepare_index_params()
+index_params.add_index(field_name="embeddings", index_name="sparse_inverted_index",
+                       index_type="SPARSE_INVERTED_INDEX", metric_type="IP", params={"drop_ratio_build": 0.2})
+milvus_client.create_collection(collection_name, schema=schema,
+                                index_params=index_params, timeout=5, consistency_level="Strong")
+
+print(fmt.format("    all collections    "))
+print(milvus_client.list_collections())
+
+print(fmt.format(f"schema of collection {collection_name}"))
+print(milvus_client.describe_collection(collection_name))
+
+N = 6
+rows = [{"random": i, "embeddings": generate_sparse_vector(
+    dim, non_zero_count)} for i in range(N)]
+
+print(fmt.format("Start inserting entities"))
+insert_result = milvus_client.insert(collection_name, rows, progress_bar=True)
+print(fmt.format("Inserting entities done"))
+print(insert_result)
+
+print(fmt.format(f"Start vector anns search."))
+vectors_to_search = [generate_sparse_vector(dim, non_zero_count)]
+search_params = {
+    "metric_type": "IP",
+    "params": {
+        "drop_ratio_search": 0.2,
+    }
+}
+# no need to specify anns_field for collections with only 1 vector field
+result = milvus_client.search(collection_name, vectors_to_search, limit=3, output_fields=[
+                              "pk", "random", "embeddings"], search_params=search_params)
+for hits in result:
+    for hit in hits:
+        print(f"hit: {hit}")
+
+print(fmt.format("Start query by specifying filtering expression"))
+query_results = milvus_client.query(collection_name, filter="random < 3")
+pks = [ret['pk'] for ret in query_results]
+for ret in query_results:
+    print(ret)
+
+print(fmt.format("Start query by specifying primary keys"))
+query_results = milvus_client.query(
+    collection_name, filter=f"pk == '{pks[0]}'")
+print(query_results[0])
+
+print(f"start to delete by specifying filter in collection {collection_name}")
+delete_result = milvus_client.delete(collection_name, ids=pks[:1])
+print(delete_result)
+
+print(fmt.format("Start query by specifying primary keys"))
+query_results = milvus_client.query(
+    collection_name, filter=f"pk == '{pks[0]}'")
+print(f'query result should be empty: {query_results}')
+
+milvus_client.drop_collection(collection_name)

--- a/pymilvus/client/check.py
+++ b/pymilvus/client/check.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Union
 from pymilvus.exceptions import ParamError
 from pymilvus.grpc_gen import milvus_pb2 as milvus_types
 
+from . import entity_helper
 from .singleton_utils import Singleton
 
 
@@ -38,24 +39,6 @@ def is_legal_port(port: Any) -> bool:
         else:
             return True
     return False
-
-
-def is_legal_vector(array: Any) -> bool:
-    if not array or not isinstance(array, list) or len(array) == 0:
-        return False
-
-    return True
-
-
-def is_legal_bin_vector(array: Any) -> bool:
-    if not array or not isinstance(array, bytes) or len(array) == 0:
-        return False
-
-    return True
-
-
-def is_legal_numpy_array(array: Any) -> bool:
-    return not (array is None or array.size == 0)
 
 
 def int_or_str(item: Union[int, str]) -> str:
@@ -149,6 +132,10 @@ def is_legal_max_iterations(max_iterations: Any) -> bool:
     return isinstance(max_iterations, int)
 
 
+def is_legal_drop_ratio(drop_ratio: Any) -> bool:
+    return isinstance(drop_ratio, float) and 0 <= drop_ratio < 1
+
+
 def is_legal_team_size(team_size: Any) -> bool:
     return isinstance(team_size, int)
 
@@ -196,6 +183,9 @@ def is_legal_anns_field(field: Any) -> bool:
 
 def is_legal_search_data(data: Any) -> bool:
     import numpy as np
+
+    if entity_helper.entity_is_sparse_matrix(data):
+        return True
 
     if not isinstance(data, (list, np.ndarray)):
         return False
@@ -331,6 +321,8 @@ class ParamChecker(metaclass=Singleton):
             "team_size": is_legal_team_size,
             "index_name": is_legal_index_name,
             "timeout": is_legal_timeout,
+            "drop_ratio_build": is_legal_drop_ratio,
+            "drop_ratio_search": is_legal_drop_ratio,
         }
 
     def check(self, key: str, value: Callable):

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -757,7 +757,7 @@ class GrpcHandler:
     def search(
         self,
         collection_name: str,
-        data: List[List[float]],
+        data: Union[List[List[float]], entity_helper.SparseMatrixInputType],
         anns_field: str,
         param: Dict,
         limit: int,
@@ -940,6 +940,7 @@ class GrpcHandler:
                 DataType.BINARY_VECTOR,
                 DataType.FLOAT16_VECTOR,
                 DataType.BFLOAT16_VECTOR,
+                DataType.SPARSE_FLOAT_VECTOR,
             }:
                 break
 

--- a/pymilvus/client/types.py
+++ b/pymilvus/client/types.py
@@ -89,6 +89,7 @@ class DataType(IntEnum):
     FLOAT_VECTOR = 101
     FLOAT16_VECTOR = 102
     BFLOAT16_VECTOR = 103
+    SPARSE_FLOAT_VECTOR = 104
 
     UNKNOWN = 999
 
@@ -158,6 +159,7 @@ class PlaceholderType(IntEnum):
     FloatVector = 101
     FLOAT16_VECTOR = 102
     BFLOAT16_VECTOR = 103
+    SparseFloatVector = 104
 
 
 class State(IntEnum):

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -195,6 +195,8 @@ def len_of(field_data: Any) -> int:
                     message=f"Invalid bfloat16 or float16 vector length: total_len={total_len}, dim={dim}"
                 )
             return int(total_len / (dim * data_wide_in_bytes))
+        if field_data.vectors.HasField("sparse_float_vector"):
+            return len(field_data.vectors.sparse_float_vector.contents)
 
         total_len = len(field_data.vectors.binary_vector)
         return int(total_len / (dim / 8))
@@ -239,7 +241,7 @@ def traverse_rows_info(fields_info: Any, entities: List):
             value = entity.get(field_name, None)
             if value is None:
                 raise ParamError(message=f"Field {field_name} don't match in entities[{j}]")
-
+            # no special check for sparse float vector field
             if field_type in [
                 DataType.FLOAT_VECTOR,
                 DataType.BINARY_VECTOR,

--- a/pymilvus/exceptions.py
+++ b/pymilvus/exceptions.py
@@ -155,7 +155,7 @@ class ExceptionsMessage:
     )
     AliasType = "Alias should be string, but %r is given."
     ConnLackConf = "You need to pass in the configuration of the connection named %r ."
-    ConnectFirst = "should create connect first."
+    ConnectFirst = "should create connection first."
     CollectionNotExistNoSchema = "Collection %r not exist, or you can pass in schema to create one."
     NoSchema = "Should be passed into the schema."
     EmptySchema = "The field of the schema cannot be empty."

--- a/pymilvus/orm/iterator.py
+++ b/pymilvus/orm/iterator.py
@@ -1,7 +1,8 @@
 import logging
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, Optional, TypeVar, Union
 
+from pymilvus.client import entity_helper
 from pymilvus.client.abstract import Hits, LoopBase
 from pymilvus.exceptions import (
     MilvusException,
@@ -282,7 +283,7 @@ class SearchIterator:
         self,
         connection: Connections,
         collection_name: str,
-        data: List,
+        data: Union[List, entity_helper.SparseMatrixInputType],
         ann_field: str,
         param: Dict,
         batch_size: Optional[int] = 1000,
@@ -295,11 +296,12 @@ class SearchIterator:
         schema: Optional[CollectionSchema] = None,
         **kwargs,
     ) -> SearchIterator:
-        if len(data) > 1:
+        rows = entity_helper.get_input_num_rows(data)
+        if rows > 1:
             raise ParamError(
                 message="Not support search iteration over multiple vectors at present"
             )
-        if len(data) == 0:
+        if rows == 0:
             raise ParamError(message="vector_data for search cannot be empty")
         self._conn = connection
         self._iterator_params = {

--- a/pymilvus/orm/partition.py
+++ b/pymilvus/orm/partition.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, TypeVar, Union
 import pandas as pd
 import ujson
 
+from pymilvus.client import entity_helper
 from pymilvus.client.abstract import BaseRanker, SearchResult
 from pymilvus.client.types import Replica
 from pymilvus.exceptions import MilvusException
@@ -238,14 +239,14 @@ class Partition:
 
     def insert(
         self,
-        data: Union[List, pd.DataFrame],
+        data: Union[List, pd.DataFrame, entity_helper.SparseMatrixInputType],
         timeout: Optional[float] = None,
         **kwargs,
     ) -> MutationResult:
         """Insert data into the partition, the same as Collection.insert(data, [partition])
 
         Args:
-            data (``list/tuple/pandas.DataFrame``): The specified data to insert
+            data (``list/tuple/pandas.DataFrame/sparse types``): The specified data to insert
             partition_name (``str``): The partition name which the data will be inserted to,
                 if partition name is not passed, then the data will be inserted to default partition
             timeout (``float``, optional): A duration of time in seconds to allow for the RPC
@@ -316,14 +317,14 @@ class Partition:
 
     def upsert(
         self,
-        data: Union[List, pd.DataFrame],
+        data: Union[List, pd.DataFrame, entity_helper.SparseMatrixInputType],
         timeout: Optional[float] = None,
         **kwargs,
     ) -> MutationResult:
         """Upsert data into the collection.
 
         Args:
-            data (``list/tuple/pandas.DataFrame``): The specified data to upsert
+            data (``list/tuple/pandas.DataFrame/sparse types``): The specified data to upsert
             partition_name (``str``): The partition name which the data will be upserted at,
                 if partition name is not passed, then the data will be upserted in default partition
             timeout (``float``, optional): A duration of time in seconds to allow for the RPC.
@@ -356,7 +357,7 @@ class Partition:
 
     def search(
         self,
-        data: List,
+        data: Union[List, entity_helper.SparseMatrixInputType],
         anns_field: str,
         param: Dict,
         limit: int,
@@ -369,7 +370,7 @@ class Partition:
         """Conducts a vector similarity search with an optional boolean expression as filter.
 
         Args:
-            data (``List[List[float]]``): The vectors of search data.
+            data (``List[List[float]]`` or sparse types): The vectors of search data.
                 the length of data is number of query (nq),
                 and the dim of every vector in data must be equal to the vector field of collection.
             anns_field (``str``): The name of the vector field used to search of collection.

--- a/pymilvus/orm/prepare.py
+++ b/pymilvus/orm/prepare.py
@@ -16,6 +16,7 @@ from typing import List, Tuple, Union
 import numpy as np
 import pandas as pd
 
+from pymilvus.client import entity_helper
 from pymilvus.exceptions import (
     DataNotMatchException,
     DataTypeNotSupportException,
@@ -46,6 +47,7 @@ class Prepare:
                 and not data[schema.primary_field.name].isnull().all()
             ):
                 raise DataNotMatchException(message=ExceptionsMessage.AutoIDWithData)
+            # TODO(SPARSE): support pd.SparseDtype for sparse float vector field
             for field in fields:
                 if field.is_primary and field.auto_id:
                     continue
@@ -79,7 +81,7 @@ class Prepare:
     @classmethod
     def prepare_upsert_data(
         cls,
-        data: Union[List, Tuple, pd.DataFrame],
+        data: Union[List, Tuple, pd.DataFrame, entity_helper.SparseMatrixInputType],
         schema: CollectionSchema,
     ) -> List:
         if schema.auto_id:

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -344,6 +344,7 @@ class FieldSchema:
             DataType.BFLOAT16_VECTOR,
             DataType.VARCHAR,
             DataType.ARRAY,
+            DataType.SPARSE_FLOAT_VECTOR,
         ):
             return
         if not self._kwargs:
@@ -537,6 +538,7 @@ def construct_fields_from_dataframe(df: pd.DataFrame) -> List[FieldSchema]:
 
 
 def prepare_fields_from_dataframe(df: pd.DataFrame):
+    # TODO: infer pd.SparseDtype as DataType.SPARSE_FLOAT_VECTOR
     d_types = list(df.dtypes)
     data_types = list(map(map_numpy_dtype_to_datatype, d_types))
     col_names = list(df.columns)
@@ -584,6 +586,7 @@ def check_schema(schema: CollectionSchema):
             DataType.BINARY_VECTOR,
             DataType.FLOAT16_VECTOR,
             DataType.BFLOAT16_VECTOR,
+            DataType.SPARSE_FLOAT_VECTOR,
         ):
             vector_fields.append(field.name)
     if len(vector_fields) < 1:

--- a/pymilvus/orm/types.py
+++ b/pymilvus/orm/types.py
@@ -72,7 +72,7 @@ def is_numeric_datatype(data_type: DataType):
 
 
 # pylint: disable=too-many-return-statements
-def infer_dtype_by_scaladata(data: Any):
+def infer_dtype_by_scalar_data(data: Any):
     if isinstance(data, float):
         return DataType.DOUBLE
     if isinstance(data, bool):
@@ -108,7 +108,7 @@ def infer_dtype_by_scaladata(data: Any):
 def infer_dtype_bydata(data: Any):
     d_type = DataType.UNKNOWN
     if is_scalar(data):
-        return infer_dtype_by_scaladata(data)
+        return infer_dtype_by_scalar_data(data)
 
     if isinstance(data, dict):
         return DataType.JSON
@@ -130,7 +130,7 @@ def infer_dtype_bydata(data: Any):
             elem = None
 
         if elem is not None and is_scalar(elem):
-            d_type = infer_dtype_by_scaladata(elem)
+            d_type = infer_dtype_by_scalar_data(elem)
 
     if d_type == DataType.UNKNOWN:
         _dtype = getattr(data, "dtype", None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ ujson>=2.0.0
 urllib3==1.26.18
 sklearn==0.0
 m2r==0.3.1
+scipy>=1.9.3
 Sphinx==4.0.0
 sphinx-copybutton
 sphinx-rtd-theme


### PR DESCRIPTION
This PR adds the basic sparse float vector support to pymilvus. 

The following types of input are supported:

- any of the `scipy.sparse` matrix/array class family
- list of dicts: `[{0: 0.3, 20: 0.5}, {4: 0.4}, ...]`
- list of lists of tuples: `[[(0, 0.3), (20, 0.5)], [(4, 0.4)], ...]`

Sparse float vector support tracking issue: https://github.com/milvus-io/milvus/issues/29419 