### PR TITLE
fix milvus client unable to custom index and metric type

### DIFF
--- a/pymilvus/milvus_client/index.py
+++ b/pymilvus/milvus_client/index.py
@@ -20,6 +20,7 @@ class IndexParam:
     def __iter__(self):
         yield "field_name", self._field_name
         yield "index_name", self._index_name
+        yield "index_type", self._index_type
         yield from self._kwargs.items()
 
     def __str__(self):

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -165,11 +165,18 @@ class MilvusClient:
         **kwargs,
     ):
         conn = self._get_connection()
+        params = {}
+        if 'index_type' in index_param:
+            params['index_type'] = index_param['index_type']
+        if 'metric_type' in index_param:
+            params['metric_type'] = index_param['metric_type']
+        if 'params' in index_param:
+            params['params'] = index_param['params']
         try:
             conn.create_index(
                 collection_name,
                 index_param["field_name"],
-                index_param.get("params", {}),
+                params,
                 index_name=index_param.get("index_name", ""),
                 timeout=timeout,
                 **kwargs,


### PR DESCRIPTION
Currently when creating collection/index using milvus client, we always create AUTOINDEX of IP metric, no matter what type of index/metric type is provided.