### PR TITLE
fix:release partition before drop it

### DIFF
--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -1242,6 +1242,7 @@ class Collection:
             False
         """
         conn = self._get_connection()
+        conn.release_partitions(self._name, [partition_name])
         return conn.drop_partition(self._name, partition_name, timeout=timeout, **kwargs)
 
     @property


### PR DESCRIPTION
when call  Collection drop_partition func，has error:

pymilvus.decorators | RPC error: [drop_partition], <MilvusException: (code=1, message=partition cannot be dropped, partition is loaded, please release it first)>, <Time:{'RPC start': '2024-03-28 16:13:04.921025', 'RPC error': '2024-03-28 16:13:04.923609'}>

fix Collection drop_partition func call，release partition before drop it