### PR TITLE
[cherry-pick] covert params' value from string to int

### DIFF
--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -349,13 +349,13 @@ class FieldSchema:
             return
         if not self._kwargs:
             return
-        # currently only support ndim
+        # currently only support "dim", "max_length", "max_capacity"
         if self._kwargs:
             for k in COMMON_TYPE_PARAMS:
                 if k in self._kwargs:
                     if self._type_params is None:
                         self._type_params = {}
-                    self._type_params[k] = self._kwargs[k]
+                    self._type_params[k] = int(self._kwargs[k])
 
     @classmethod
     def construct_from_dict(cls, raw: Dict):


### PR DESCRIPTION
master pr: #2022

to avoid such param error:
```
pymilvus.exceptions.ParamError: <ParamError: (code=1, message=Collection field dim is 512, but entities field dim is 512)>
```