### PR TITLE
Added "grpc" protocol to connection validation.

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -363,6 +363,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
             "http",
             "https",
             "tcp",
+            "grpc"
         ]:
             # start and connect milvuslite
             if kwargs["uri"].endswith("/"):


### PR DESCRIPTION
I was getting error <ConnectionConfigException: (code=1, message=Open local milvus failed, dir: grpc: is not exists)> on version 2.4.2 looks like grpc is missing as an option of valid protocol. Adding the protocol fixed the error.