### PR TITLE
Added grpc as a valid protocol for uri

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -363,6 +363,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
             "http",
             "https",
             "tcp",
+            "grpc"
         ]:
             # start and connect milvuslite
             if kwargs["uri"].endswith("/"):

--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -363,7 +363,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
             "http",
             "https",
             "tcp",
-            "grpc"
+            "grpc",
         ]:
             # start and connect milvuslite
             if kwargs["uri"].endswith("/"):


### PR DESCRIPTION
Added grpc protocol to connection uri validation. Not having it was preventing grpc connections with the following error: <ConnectionConfigException: (code=1, message=Open local milvus failed, dir: grpc: is not exists)>