### PR TITLE
fix sparse: accpet int/float wrapped in string

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -107,8 +107,8 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
             values = []
             row = row_data.items() if isinstance(row_data, dict) else row_data
             for index, value in row:
-                indices.append(index)
-                values.append(value)
+                indices.append(int(index))
+                values.append(float(value))
             result.contents.append(sparse_float_row_to_bytes(indices, values))
             dim = max(dim, indices[-1] + 1)
         result.dim = dim


### PR DESCRIPTION
when providing sparse float vector using python dict/list, we allow the index/value to be wrapped in string:

both `{1:0.1, 2:0.2}` and `{1:"0.1", "2": 0.2}` are acceptable. this is defined in `entity_is_sparse_matrix` but `sparse_rows_to_proto` doesn't respect this. This pr fixes this.