### PR TITLE
feat: disable installation of milvus-lite on windows platform (#2131)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies=[
     "ujson>=2.0.0",
     "pandas>=1.2.4",
     "numpy<1.25.0;python_version<='3.8'",
-    "milvus-lite>=2.4.0",
+    "milvus-lite>=2.4.0;sys_platform!='win32'",
 ]
 
 classifiers=[


### PR DESCRIPTION
@XuanYang-cn 
Since the project is managed by setuptools, and according to the [setuptools](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html), we can disable the automatic installation of milvus-lite on windows platform by adding environment markers. 
Following [PEP508](https://peps.python.org/pep-0508/), I pick the environment marker "sys_platform != 'win32'" to prevent the installation. 
I build packages after the modification. Then test the .tar.gz and the .whl files both on my windows laptop and a linux docker. The issue mentioned in #2131 seems gone. 
Due the lack of macOS machine, I could not perform testing on that particular platform. Please check validity before merging.