### PR TITLE
feat: Disable installation of milvus-lite on windows platform

### DIFF
--- a/.github/workflows/check_milvus_proto.yml
+++ b/.github/workflows/check_milvus_proto.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e ".[dev]"
 
     - name: Try generate proto
       run: |

--- a/.github/workflows/code_checker.yml
+++ b/.github/workflows/code_checker.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: check pyproject.toml install
+      - name: Check pyproject.toml install
         run: |
           pip install -e .
       - name: Install requirements

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,10 +8,11 @@ on:
 jobs:
   build:
     name: Run Python Tests
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.8, 3.12]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ get_proto:
 	git submodule update --init
 
 gen_proto:
-	python3 -m pip install -e ".[dev]"
+	pip install -e ".[dev]"
 	cd pymilvus/grpc_gen && ./python_gen.sh
 
 check_proto_product: gen_proto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies=[
     "pandas>=1.2.4",
     "numpy<1.25.0;python_version<='3.8'",
     "milvus_lite>=2.4.0,<2.5.0",
+    "milvus-lite>=2.4.0,<2.5.0;sys_platform!='win32'",
 ]
 
 classifiers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies=[
     "ujson>=2.0.0",
     "pandas>=1.2.4",
     "numpy<1.25.0;python_version<='3.8'",
-    "milvus_lite>=2.4.0,<2.5.0",
     "milvus-lite>=2.4.0,<2.5.0;sys_platform!='win32'",
 ]
 

--- a/tests/test_milvus_lite.py
+++ b/tests/test_milvus_lite.py
@@ -1,12 +1,14 @@
 import os
+import sys
 from tempfile import TemporaryDirectory
 import numpy as np
+import pytest
 
 from pymilvus.milvus_client import MilvusClient
 
 
+@pytest.mark.skipif(sys.platform.startswith('win'), reason="Milvus Lite is not supported on Windows")
 class TestMilvusLite:
-
     def test_milvus_lite(self):
         with TemporaryDirectory(dir='./') as root:
             db_file = os.path.join(root, 'test.db')


### PR DESCRIPTION
Since the project is managed by setuptools, and according to the
[setuptools](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html),
we can disable the automatic installation of milvus-lite on windows
platform by adding environment markers.
Following [PEP508](https://peps.python.org/pep-0508/), I pick the
environment marker "sys_platform != 'win32'" to prevent the
installation.
I build packages after the modification. Then test the .tar.gz and the
.whl files both on my windows laptop and a linux docker. The issue
mentioned in #2131 seems gone.
Due the lack of macOS machine, I could not perform testing on that
particular platform. Please check validity before merging.

enhance: Check PyMilvus on Windows platform
