### PR TITLE
Add database operations to MilvusClient (#2152)

### DIFF
--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -970,3 +970,15 @@ class MilvusClient:
     def using_database(self, db_name: str, **kwargs):
         conn = self._get_connection()
         conn.reset_db_name(db_name)
+
+    def create_database(self, db_name: str, **kwargs):
+        conn = self._get_connection()
+        conn.create_database(db_name, **kwargs)
+
+    def drop_database(self, db_name: str, **kwargs):
+        conn = self._get_connection()
+        conn.drop_database(db_name, **kwargs)
+
+    def list_databases(self, **kwargs) -> List[str]:
+        conn = self._get_connection()
+        return conn.list_database(**kwargs)


### PR DESCRIPTION
Allows the following operations to be performed through the `MilvusClient` interface:
- create_database
- drop_database
- list_databases

Resolves https://github.com/milvus-io/pymilvus/issues/2151