### PR TITLE
Change `raise e from e` calls to be just `raise` and remove unneeded ones

### DIFF
--- a/pymilvus/bulk_writer/local_bulk_writer.py
+++ b/pymilvus/bulk_writer/local_bulk_writer.py
@@ -139,7 +139,7 @@ class LocalBulkWriter(BulkWriter):
                     call_back(file_list)
         except Exception as e:
             logger.error(f"Failed to fulsh, error: {e}")
-            raise e from e
+            raise
         finally:
             del self._working_thread[threading.current_thread().name]
             logger.info(f"Flush thread finished, name: {threading.current_thread().name}")

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -151,8 +151,6 @@ class GrpcHandler:
                 code=Status.CONNECT_FAILED,
                 message=f"Fail connecting to server on {self._address}, illegal connection params or server unavailable",
             ) from e
-        except Exception as e:
-            raise e from e
 
     def close(self):
         self.deregister_state_change_callbacks()
@@ -579,7 +577,7 @@ class GrpcHandler:
         except Exception as err:
             if kwargs.get("_async", False):
                 return MutationFuture(None, None, err)
-            raise err from err
+            raise
         else:
             return m
 
@@ -616,7 +614,7 @@ class GrpcHandler:
         except Exception as err:
             if kwargs.get("_async", False):
                 return MutationFuture(None, None, err)
-            raise err from err
+            raise
         else:
             return m
 
@@ -676,7 +674,7 @@ class GrpcHandler:
         except Exception as err:
             if kwargs.get("_async", False):
                 return MutationFuture(None, None, err)
-            raise err from err
+            raise
         else:
             return m
 
@@ -738,7 +736,7 @@ class GrpcHandler:
         except Exception as e:
             if kwargs.get("_async", False):
                 return SearchFuture(None, None, e)
-            raise e from e
+            raise
 
     def _execute_hybrid_search(
         self, request: milvus_types.HybridSearchRequest, timeout: Optional[float] = None, **kwargs
@@ -757,7 +755,7 @@ class GrpcHandler:
         except Exception as e:
             if kwargs.get("_async", False):
                 return SearchFuture(None, None, e)
-            raise e from e
+            raise
 
     @retry_on_rpc_failure()
     def search(

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -87,7 +87,7 @@ def retry_on_rpc_failure(
                 except grpc.RpcError as e:
                     # Do not retry on these codes
                     if e.code() in IGNORE_RETRY_CODES:
-                        raise e from e
+                        raise
                     if timeout(start_time):
                         raise MilvusException(e.code, f"{to_msg}, message={e.details()}") from e
 
@@ -113,9 +113,7 @@ def retry_on_rpc_failure(
                         time.sleep(back_off)
                         back_off = min(back_off * back_off_multiplier, max_back_off)
                     else:
-                        raise e from e
-                except Exception as e:
-                    raise e from e
+                        raise
                 finally:
                     counter += 1
 
@@ -138,21 +136,21 @@ def error_handler(func_name: str = ""):
             except MilvusException as e:
                 record_dict["RPC error"] = str(datetime.datetime.now())
                 LOGGER.error(f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>")
-                raise e from e
+                raise
             except grpc.FutureTimeoutError as e:
                 record_dict["gRPC timeout"] = str(datetime.datetime.now())
                 LOGGER.error(
                     f"grpc Timeout: [{inner_name}], <{e.__class__.__name__}: "
                     f"{e.code()}, {e.details()}>, <Time:{record_dict}>"
                 )
-                raise e from e
+                raise
             except grpc.RpcError as e:
                 record_dict["gRPC error"] = str(datetime.datetime.now())
                 LOGGER.error(
                     f"grpc RpcError: [{inner_name}], <{e.__class__.__name__}: "
                     f"{e.code()}, {e.details()}>, <Time:{record_dict}>"
                 )
-                raise e from e
+                raise
             except Exception as e:
                 record_dict["Exception"] = str(datetime.datetime.now())
                 LOGGER.error(f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>")
@@ -190,9 +188,7 @@ def ignore_unimplemented(default_return_value: Any):
                 if e.code() == grpc.StatusCode.UNIMPLEMENTED:
                     LOGGER.debug(f"{func.__name__} unimplemented, ignore it")
                     return default_return_value
-                raise e from e
-            except Exception as e:
-                raise e from e
+                raise
 
         return handler
 
@@ -211,8 +207,6 @@ def upgrade_reminder(func: Callable):
                     "please downgrade your sdk or upgrade your server"
                 )
                 raise MilvusException(message=msg) from e
-            raise e from e
-        except Exception as e:
-            raise e from e
+            raise
 
     return handler

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -136,7 +136,7 @@ class MilvusClient:
             logger.debug("Successfully created collection: %s", collection_name)
         except Exception as ex:
             logger.error("Failed to create collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         index_params = IndexParams()
         index_params.add_index(vector_field_name, "", "", metric_type=metric_type)
@@ -173,7 +173,7 @@ class MilvusClient:
             logger.debug("Successfully created an index on collection: %s", collection_name)
         except Exception as ex:
             logger.error("Failed to create an index on collection: %s", collection_name)
-            raise ex from ex
+            raise
 
     def insert(
         self,
@@ -216,12 +216,9 @@ class MilvusClient:
 
         conn = self._get_connection()
         # Insert into the collection.
-        try:
-            res = conn.insert_rows(
-                collection_name, data, partition_name=partition_name, timeout=timeout
-            )
-        except Exception as ex:
-            raise ex from ex
+        res = conn.insert_rows(
+            collection_name, data, partition_name=partition_name, timeout=timeout
+        )
         return OmitZeroDict(
             {
                 "insert_count": res.insert_count,
@@ -268,13 +265,9 @@ class MilvusClient:
 
         conn = self._get_connection()
         # Upsert into the collection.
-        try:
-            res = conn.upsert_rows(
-                collection_name, data, partition_name=partition_name, timeout=timeout, **kwargs
-            )
-        except Exception as ex:
-            raise ex from ex
-
+        res = conn.upsert_rows(
+            collection_name, data, partition_name=partition_name, timeout=timeout, **kwargs
+        )
         return OmitZeroDict(
             {
                 "upsert_count": res.upsert_count,
@@ -333,7 +326,7 @@ class MilvusClient:
             )
         except Exception as ex:
             logger.error("Failed to search collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         ret = []
         for hits in res:
@@ -384,7 +377,7 @@ class MilvusClient:
             schema_dict = conn.describe_collection(collection_name, timeout=timeout, **kwargs)
         except Exception as ex:
             logger.error("Failed to describe collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         if ids:
             filter = self._pack_pks_expr(schema_dict, ids)
@@ -406,7 +399,7 @@ class MilvusClient:
             )
         except Exception as ex:
             logger.error("Failed to query collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         return res
 
@@ -446,7 +439,7 @@ class MilvusClient:
             schema_dict = conn.describe_collection(collection_name, timeout=timeout, **kwargs)
         except Exception as ex:
             logger.error("Failed to describe collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         if not output_fields:
             output_fields = ["*"]
@@ -466,7 +459,7 @@ class MilvusClient:
             )
         except Exception as ex:
             logger.error("Failed to get collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         return res
 
@@ -528,7 +521,7 @@ class MilvusClient:
                 schema_dict = conn.describe_collection(collection_name, timeout=timeout, **kwargs)
             except Exception as ex:
                 logger.error("Failed to describe collection: %s", collection_name)
-                raise ex from ex
+                raise
 
             expr = self._pack_pks_expr(schema_dict, pks)
 
@@ -555,7 +548,7 @@ class MilvusClient:
                 ret_pks.extend(res.primary_keys)
         except Exception as ex:
             logger.error("Failed to delete primary keys in collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         if ret_pks:
             return ret_pks
@@ -625,7 +618,7 @@ class MilvusClient:
             logger.debug("Successfully created collection: %s", collection_name)
         except Exception as ex:
             logger.error("Failed to create collection: %s", collection_name)
-            raise ex from ex
+            raise
 
         if index_params:
             self.create_index(collection_name, index_params, timeout=timeout)
@@ -653,7 +646,7 @@ class MilvusClient:
             connections.connect(using, user, password, db_name, token, uri=uri, **kwargs)
         except Exception as ex:
             logger.error("Failed to create new connection using: %s", using)
-            raise ex from ex
+            raise
         else:
             logger.debug("Created new connection using: %s", using)
             return using
@@ -700,7 +693,7 @@ class MilvusClient:
             conn.load_collection(collection_name, timeout=timeout, **kwargs)
         except MilvusException as ex:
             logger.error("Failed to load collection: %s", collection_name)
-            raise ex from ex
+            raise
 
     def release_collection(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         conn = self._get_connection()
@@ -708,7 +701,7 @@ class MilvusClient:
             conn.release_collection(collection_name, timeout=timeout, **kwargs)
         except MilvusException as ex:
             logger.error("Failed to load collection: %s", collection_name)
-            raise ex from ex
+            raise
 
     def get_load_state(
         self,
@@ -721,10 +714,7 @@ class MilvusClient:
         partition_names = None
         if partition_name:
             partition_names = [partition_name]
-        try:
-            state = conn.get_load_state(collection_name, partition_names, timeout=timeout, **kwargs)
-        except Exception as ex:
-            raise ex from ex
+        state = conn.get_load_state(collection_name, partition_names, timeout=timeout, **kwargs)
 
         ret = {"state": state}
         if state == LoadState.Loading:
@@ -865,10 +855,7 @@ class MilvusClient:
 
     def describe_user(self, user_name: str, timeout: Optional[float] = None, **kwargs):
         conn = self._get_connection()
-        try:
-            res = conn.select_one_user(user_name, True, timeout=timeout, **kwargs)
-        except Exception as ex:
-            raise ex from ex
+        res = conn.select_one_user(user_name, True, timeout=timeout, **kwargs)
         if res.groups:
             item = res.groups[0]
             return {"user_name": user_name, "roles": item.roles}
@@ -897,10 +884,7 @@ class MilvusClient:
     ) -> List[Dict]:
         conn = self._get_connection()
         db_name = kwargs.pop("db_name", "")
-        try:
-            res = conn.select_grant_for_one_role(role_name, db_name, timeout=timeout, **kwargs)
-        except Exception as ex:
-            raise ex from ex
+        res = conn.select_grant_for_one_role(role_name, db_name, timeout=timeout, **kwargs)
         ret = {}
         ret["role"] = role_name
         ret["privileges"] = [dict(i) for i in res.groups]
@@ -908,10 +892,7 @@ class MilvusClient:
 
     def list_roles(self, timeout: Optional[float] = None, **kwargs):
         conn = self._get_connection()
-        try:
-            res = conn.select_all_role(False, timeout=timeout, **kwargs)
-        except Exception as ex:
-            raise ex from ex
+        res = conn.select_all_role(False, timeout=timeout, **kwargs)
 
         groups = res.groups
         return [g.role_name for g in groups]


### PR DESCRIPTION
# Description
As per the discussion from #2221, the pattern,
```python
try:
    <do something that might raise Exception>
except ExceptionType as exc
    <maybe do some additional stuff here>
    raise exc from exc
```
can break downstream tooling that seeks to unroll `exc.__cause__` (e.g. for processing the stack trace).

This PR tweaks all spots in the `pymilvus` codebase that were using that pattern to instead either just use this pattern
```python
try:
    <do something that might raise Exception>
except ExceptionType as exc
    <maybe do some additional stuff here>
    raise
```
or, if the `try/except` didn't have any additional logic in the `except` block, I removed the `try/except` entirely as a direct `reraise` would be redundant in those cases.

**NB** As mentioned in #2221, I originally only noticed three spots where the `raise err from err` pattern was used. While working on this PR I found a number of others and I ended up changing all of them. As per @XuanYang-cn's [comment](https://github.com/milvus-io/pymilvus/issues/2221#issuecomment-2277062379), if there are important reasons for one or more of these spots to stay as-is, please let me know and I can revert the changes to that section accordingly.
## Testing
### Finding all the spots
To find all the spots, I ran this `grep`
```bash
$ grep "raise \(.*\) from \1" pymilvus/**/*.py 
```
On `master` branch, we get a non-zero number of hits with the expected pattern. On the branch for this PR, the `grep` returns no values
### Testing the fix
In one process, run
```python
In [1]: from milvus_lite.server import Server

In [2]: s = Server('test.db', '127.0.0.1:9999')

In [3]: s.start()
Out[3]: True

In [4]: s._p.wait()
```
In another process, run
```python
In [1]: import pymilvus

In [2]: client = pymilvus.MilvusClient("http://localhost:9999")
   ...: collection_name = "fake_embeddings"
   ...: if client.has_collection(collection_name=collection_name):
   ...:     client.drop_collection(collection_name=collection_name)
   ...: 

In [3]: vector_dim = 512
   ...: client.create_collection(
   ...:     collection_name=collection_name,
   ...:     vector_field_name="vector",
   ...:     dimension=vector_dim,
   ...:     auto_id=True,
   ...:     enable_dynamic_field=True,
   ...:     metric_type="COSINE",
   ...: )

In [4]: import numpy as np

In [5]: vectors = np.random.normal(loc=0, scale=1, size=(vector_dim + 2,))

In [6]: try:
   ...:     client.insert(collection_name, {"vector": vectors})
   ...: except pymilvus.MilvusException as exc:
   ...:     assert exc.__cause__ is not exc, "Exception is its own cause"
```
The `In [6]:` step will not through an `AssertionError`