### PR TITLE
remove analyzer_params, added enable_tokenizer and tokenizer_params

### DIFF
--- a/pymilvus/orm/constants.py
+++ b/pymilvus/orm/constants.py
@@ -10,7 +10,14 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
-COMMON_TYPE_PARAMS = ("dim", "max_length", "max_capacity", "enable_match", "analyzer_params")
+COMMON_TYPE_PARAMS = (
+    "dim",
+    "max_length",
+    "max_capacity",
+    "enable_match",
+    "enable_tokenizer",
+    "tokenizer_params",
+)
 
 CALC_DIST_IDS = "ids"
 CALC_DIST_FLOAT_VEC = "float_vectors"


### PR DESCRIPTION
the API for `enable_match` has changed to: only VarChar fields that set `enable_tokenizer=true`, is allowed to set `enable_match=true`, or to be used as a BM25 Function input field. Params for such tokenizer is renamed from `analyzer_params` to `tokenizer_params`.