### PR TITLE
Persist db name in alias dict to return it when list_connections invoked

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -406,7 +406,6 @@ class Connections(metaclass=SingleInstanceMetaClass):
                 )
             kwargs.pop("password")
             kwargs.pop("token", None)
-            kwargs.pop("db_name", "")
 
             self._connected_alias[alias] = gh
             self._alias[alias] = copy.deepcopy(kwargs)


### PR DESCRIPTION
Fix: https://github.com/milvus-io/pymilvus/issues/2161
@XuanYang-cn Please have a look on this as `langchain`made a fix based on the `db_name` property which create new connection on every request. 