### PR TITLE
feat: allow empty sparse row

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -47,9 +47,7 @@ def entity_is_sparse_matrix(entity: Any):
             if SciPyHelper.is_scipy_sparse(item):
                 return item.shape[0] == 1
             pairs = item.items() if isinstance(item, dict) else item
-            # each row must be a non-empty list of Tuple[int, float]
-            if len(pairs) == 0:
-                return False
+            # each row must be a list of Tuple[int, float]. we allow empty sparse row
             for pair in pairs:
                 if len(pair) != 2 or not is_int_type(pair[0]) or not is_float_type(pair[1]):
                     return False
@@ -118,7 +116,10 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
                     indices.append(int(index))
                     values.append(float(value))
                 result.contents.append(sparse_float_row_to_bytes(indices, values))
-                dim = max(dim, indices[-1] + 1)
+                row_dim = 0
+                if len(indices) > 0:
+                    row_dim = indices[-1] + 1
+                dim = max(dim, row_dim)
         result.dim = dim
     return result
 


### PR DESCRIPTION
currently pymilvus supports the following sparse vector formats:

* scipy sparse classes
* list of tuples: `[(dim, val), (dim, val), ...]`
* dict: `{dim: val, dim: val, ...}`

When dealing with input data, pymilvus doesn't check the schema to infer the data type, instead it tries to infer the data type based on the shape. that's why we have `entity_is_sparse_matrix` method.

Now we want to support empty sparse vector row, it is easy for scipy sparse classes, but for the other 2 format, it means we must infer empty list/dict `[]/{}` as sparse vector. 

Will this be problematic? what could be the other options?