### PR TITLE
fix: remove duplicate field name check in pymilvus

### DIFF
--- a/pymilvus/exceptions.py
+++ b/pymilvus/exceptions.py
@@ -227,7 +227,6 @@ class ExceptionsMessage:
     FunctionIncorrectType = "The function of schema type must be Function."
     FieldType = "The field of schema type must be FieldSchema."
     FieldDtype = "Field dtype must be of DataType"
-    FieldNamesDuplicate = "Duplicate field names are not allowed."
     ExprType = "The type of expr must be string ,but %r is given."
     EnvConfigErr = "Environment variable %s has a wrong format, please check it: %s"
     AmbiguousIndexName = "There are multiple indexes, please specify the index_name."

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -140,9 +140,6 @@ class CollectionSchema:
         primary_field_name = self._kwargs.get("primary_field", None)
         partition_key_field_name = self._kwargs.get("partition_key_field", None)
         clustering_key_field_name = self._kwargs.get("clustering_key_field", None)
-        field_names = [field.name for field in self._fields]
-        if len(field_names) != len(set(field_names)):
-            raise ParamError(message=ExceptionsMessage.FieldNamesDuplicate)
         for field in self._fields:
             if primary_field_name and primary_field_name == field.name:
                 field.is_primary = True


### PR DESCRIPTION

this check was added in https://github.com/milvus-io/pymilvus/pull/2257. 

this caused an test in milvus to fail. the test expects the error to be thrown on server side instead of sdk side. it is ok to check on sdk side but I choose to remove it to keep the behavior consistent and comfort the ut without modifying it. 

Failed test: https://github.com/milvus-io/milvus/blob/5b2658327d676453e8a251ffc3273f4a218fb278/tests/python_client/testcases/test_collection.py#L318