### PR TITLE
fix: row based insert/upsert when there is Function in schema

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -432,7 +432,11 @@ class Prepare:
                         entity_helper.pack_field_value_to_field_data(v, field_data, field_info)
                 for field in fields_info:
                     key = field["name"]
-                    if key in entity or field.get("auto_id", False):
+                    if (
+                        key in entity
+                        or field.get("auto_id", False)
+                        or field.get("is_function_output", False)
+                    ):
                         continue
 
                     field_info, field_data = field_info_map[key], fields_data[key]
@@ -515,7 +519,7 @@ class Prepare:
                         entity_helper.pack_field_value_to_field_data(v, field_data, field_info)
                 for field in fields_info:
                     key = field["name"]
-                    if key in entity:
+                    if key in entity or field.get("is_function_output", False):
                         continue
 
                     field_info, field_data = field_info_map[key], fields_data[key]

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -11,6 +11,7 @@
 # the License.
 
 import copy
+import json
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
@@ -449,6 +450,12 @@ class FieldSchema:
                             continue
                         if self._kwargs[k].lower() == "false":
                             self._type_params[k] = False
+                            continue
+                        if k == "tokenizer_params":
+                            # TODO: a more complicate json may be reordered which
+                            # can still cause server_schema == schema to be False.
+                            # need a better approach.
+                            self._type_params[k] = json.loads(self._kwargs[k])
                             continue
                     self._type_params[k] = self._kwargs[k]
 


### PR DESCRIPTION
also fix schema comparison of tokenizer_params: tokenizer_params returned by the server is in string format, while the user may provide it in dict format. But this fix is not perfect and will likely fail when tokenizer_params become more complicate due to possible json key reordering.

@XuanYang-cn any idea? tracking this issue in https://github.com/milvus-io/pymilvus/issues/2299