### PR TITLE
fix: entity_is_sparse_matrix: each row should be dict or list

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -46,6 +46,8 @@ def entity_is_sparse_matrix(entity: Any):
         for item in entity:
             if SciPyHelper.is_scipy_sparse(item):
                 return item.shape[0] == 1
+            if not isinstance(item, dict) and not isinstance(item, list):
+                return False
             pairs = item.items() if isinstance(item, dict) else item
             # each row must be a list of Tuple[int, float]. we allow empty sparse row
             for pair in pairs:

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -512,7 +512,7 @@ class Prepare:
                         ):
                             field_data.valid_data.append(v is not None)
                         entity_helper.pack_field_value_to_field_data(v, field_data, field_info)
-                for field in fields_info:
+                for field in input_fields_info:
                     key = field["name"]
                     if key in entity:
                         continue
@@ -538,7 +538,7 @@ class Prepare:
 
         request.fields_data.extend(fields_data.values())
 
-        for _, field in enumerate(fields_info):
+        for _, field in enumerate(input_fields_info):
             is_dynamic = False
             field_name = field["name"]
 


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/37022 and https://github.com/milvus-io/milvus/issues/37021

list of empty string is erroneously treated as sparse vector

adding a check to explicitly require that, if the input data will be seen as sparse vector, its data type, if not scipy format, should be list of list or list of dict.