### PR TITLE
enhance: alterindex & altercollection supports altering properties 

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1003,7 +1003,7 @@ class GrpcHandler:
         return Status(status.code, status.reason)
 
     @retry_on_rpc_failure()
-    def alter_index(
+    def alter_index_properties(
         self,
         collection_name: str,
         index_name: str,
@@ -1012,10 +1012,27 @@ class GrpcHandler:
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, index_name=index_name, timeout=timeout)
-        if extra_params is None:
-            raise ParamError(message="extra_params should not be None")
+        request = Prepare.alter_index_properties_request(
+            collection_name, index_name, extra_params=extra_params
+        )
 
-        request = Prepare.alter_index_request(collection_name, index_name, extra_params)
+        rf = self._stub.AlterIndex.future(request, timeout=timeout)
+        response = rf.result()
+        check_status(response)
+
+    @retry_on_rpc_failure()
+    def drop_index_properties(
+        self,
+        collection_name: str,
+        index_name: str,
+        delete_keys: List[str],
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        check_pass_param(collection_name=collection_name, index_name=index_name, timeout=timeout)
+        request = Prepare.drop_index_properties_request(
+            collection_name, index_name, delete_keys=delete_keys
+        )
 
         rf = self._stub.AlterIndex.future(request, timeout=timeout)
         response = rf.result()

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1012,12 +1012,22 @@ class Prepare:
         return index_params
 
     @classmethod
-    def alter_index_request(cls, collection_name: str, index_name: str, extra_params: dict):
+    def alter_index_properties_request(
+        cls, collection_name: str, index_name: str, extra_params: dict
+    ):
         params = []
         for k, v in extra_params.items():
             params.append(common_types.KeyValuePair(key=str(k), value=utils.dumps(v)))
         return milvus_types.AlterIndexRequest(
             collection_name=collection_name, index_name=index_name, extra_params=params
+        )
+
+    @classmethod
+    def drop_index_properties_request(
+        cls, collection_name: str, index_name: str, delete_keys: List[str]
+    ):
+        return milvus_types.AlterIndexRequest(
+            collection_name=collection_name, index_name=index_name, delete_keys=delete_keys
         )
 
     @classmethod

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -846,6 +846,32 @@ class MilvusClient:
         conn = self._get_connection()
         return conn.describe_index(collection_name, index_name, timeout=timeout, **kwargs)
 
+    def alter_index_properties(
+        self,
+        collection_name: str,
+        index_name: str,
+        extra_params: dict,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        conn = self._get_connection()
+        conn.alter_index_properties(
+            collection_name, index_name, extra_params=extra_params, timeout=timeout, **kwargs
+        )
+
+    def drop_index_properties(
+        self,
+        collection_name: str,
+        index_name: str,
+        delete_keys: List[str],
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        conn = self._get_connection()
+        conn.alter_index_properties(
+            collection_name, index_name, delete_keys=delete_keys, timeout=timeout, **kwargs
+        )
+
     def create_partition(
         self, collection_name: str, partition_name: str, timeout: Optional[float] = None, **kwargs
     ):

--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -1372,7 +1372,7 @@ class Collection:
         conn = self._get_connection()
         return conn.create_index(self._name, field_name, index_params, timeout=timeout, **kwargs)
 
-    def alter_index(
+    def alter_index_properties(
         self,
         index_name: str,
         extra_params: dict,
@@ -1412,7 +1412,20 @@ class Collection:
             >>> collection.alter_index("idx", {"mmap.enabled": True})
         """
         conn = self._get_connection()
-        return conn.alter_index(self._name, index_name, extra_params, timeout=timeout)
+        return conn.alter_index_properties(
+            self._name, index_name, extra_params=extra_params, timeout=timeout
+        )
+
+    def drop_index_properties(
+        self,
+        index_name: str,
+        delete_keys: List[str],
+        timeout: Optional[float] = None,
+    ):
+        conn = self._get_connection()
+        return conn.drop_index_properties(
+            self._name, index_name, delete_keys=delete_keys, timeout=timeout
+        )
 
     def has_index(self, timeout: Optional[float] = None, **kwargs) -> bool:
         """Check whether a specified index exists.


### PR DESCRIPTION
enhance :

alterindex delete properties
We have introduced a new parameter deleteKeys to the alterindex functionality, which allows for the deletion of properties within an index. This enhancement provides users with the flexibility to manage index properties more effectively by removing specific keys as needed.
altercollection delete properties
We have introduced a new parameter deleteKeys to the altercollection functionality, which allows for the deletion of properties within an collection. This enhancement provides users with the flexibility to manage collection properties more effectively by removing specific keys as needed.
3.support altercollectionfield
We currently support modifying the fieldparams of a field in a collection using altercollectionfield, which only allows changes to the max-length attribute.
Key Points:

New Parameter - deleteKeys: This new parameter enables the deletion of specified properties from an index. By passing a list of keys to deleteKeys, users can remove the corresponding properties from the index.

Mutual Exclusivity: The deleteKeys parameter cannot be used in conjunction with the extraParams parameter. Users must choose one parameter to pass based on their requirement. If deleteKeys is provided, it indicates an intent to delete properties; if extraParams is provided, it signifies the addition or update of properties.
issue :https://github.com/milvus-io/pymilvus/issues/2338