### PR TITLE
enhance: update float16/bfloat16 examples

### DIFF
--- a/examples/datatypes/float16_example.py
+++ b/examples/datatypes/float16_example.py
@@ -13,13 +13,16 @@ fp16_index_types = ["FLAT"]
 
 default_fp16_index_params = [{"nlist": 128}]
 
+# float16, little endian
+fp16_little = np.dtype('e').newbyteorder('<')
+
 def gen_fp16_vectors(num, dim):
     raw_vectors = []
     fp16_vectors = []
     for _ in range(num):
         raw_vector = [random.random() for _ in range(dim)]
         raw_vectors.append(raw_vector)
-        fp16_vector = np.array(raw_vector, dtype=np.float16)
+        fp16_vector = np.array(raw_vector, dtype=fp16_little)
         fp16_vectors.append(fp16_vector)
     return raw_vectors, fp16_vectors
 
@@ -57,8 +60,9 @@ def fp16_vector_search():
                                   index_params={"index_type": index_type, "params": index_params, "metric_type": "L2"})
         hello_milvus.load()
         print("index_type = ", index_type)
-        res = hello_milvus.search(vectors[0:10], vector_field_name, {"metric_type": "L2"}, limit=1)
-        print(res)
+        res = hello_milvus.search(vectors[0:10], vector_field_name, {"metric_type": "L2"}, limit=1, output_fields=["float16_vector"])
+        print("raw bytes: ", res[0][0].get("float16_vector"))
+        print("numpy ndarray: ", np.frombuffer(res[0][0].get("float16_vector"), dtype=fp16_little))
         hello_milvus.release()
         hello_milvus.drop_index()
 


### PR DESCRIPTION
In the Python ecosystem, users may use basic libraries such as numpy,
Pandas, TensorFlow, PyTorch... to process float16/bfloat16 vectors.
However, users may have float32 vectors and are not clear about
how to handle float16/bfloat16 vectors in pymilvus.

Currently, pymilvus supports numpy array as embedding vector inputs.
However, numpy itself does not support bfloat16 type.

This PR demonstrates the way of converting float arrays in insert/search
API.

**insert (accept numpy array as input)**:

- float32 vector (owned by users) -> float16 vector (input param of insert API). numpy is enough, no more dependency.
- float32 vector (owned by users) -> bfloat16 vector (input param of insert API). Depends on `tf.bfloat16`. Pytorch can not convert `torch.bfloat16` to numpy array.

**search (the API returns bytes as float16/bfloat16 vector)**:

- float16 vector (bytes). User can convert it into numpy array, PyTorch Tensor or TensorFlow Tensor.
- bfloat16 vector (bytes). User can convert it into PyTorch Tensor or TensorFlow Tensor.

There are many deep learning platforms available in Python, and
we can't determine which ecosystem users want. Therefore, this PR
doesn't add the method for float vector conversion in pymilvus.

References:

- https://github.com/numpy/numpy/issues/19808
- https://github.com/pytorch/pytorch/issues/90574

issue: milvus-io/milvus#37448