### PR TITLE
fix: fix list aliases rpc call

### DIFF
--- a/pymilvus/orm/utility.py
+++ b/pymilvus/orm/utility.py
@@ -774,7 +774,7 @@ def list_aliases(collection_name: str, timeout: Optional[float] = None, using: s
         ['tom']
     """
     conn = _get_connection(using)
-    resp = conn.describe_collection(collection_name, timeout=timeout)
+    resp = conn.list_aliases(collection_name, timeout=timeout)
     return resp["aliases"]
 
 


### PR DESCRIPTION
ListAliases SDK rpc call is `describeCollection`, which causes listing aliases successfully without granted.
issue: https://github.com/milvus-io/milvus/issues/38052