### PR TITLE
fix: remove grant/revoke v2 optional collection name

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1877,8 +1877,8 @@ class GrpcHandler:
         self,
         role_name: str,
         privilege: str,
+        collection_name: str,
         db_name: Optional[str] = None,
-        collection_name: Optional[str] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -1897,8 +1897,8 @@ class GrpcHandler:
         self,
         role_name: str,
         privilege: str,
+        collection_name: str,
         db_name: Optional[str] = None,
-        collection_name: Optional[str] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1484,12 +1484,11 @@ class Prepare:
         check_pass_param(
             role_name=role_name,
             privilege=privilege,
+            collection_name=collection_name,
             operate_privilege_type=operate_privilege_type,
         )
         if db_name:
             check_pass_param(db_name=db_name)
-        if collection_name:
-            check_pass_param(collection_name=collection_name)
         return milvus_types.OperatePrivilegeV2Request(
             role=milvus_types.RoleEntity(name=role_name),
             grantor=milvus_types.GrantorEntity(

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -1007,8 +1007,8 @@ class MilvusClient:
         self,
         role_name: str,
         privilege: str,
+        collection_name: str,
         db_name: Optional[str] = None,
-        collection_name: Optional[str] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -1016,8 +1016,8 @@ class MilvusClient:
         conn.grant_privilege_v2(
             role_name,
             privilege,
+            collection_name,
             db_name=db_name,
-            collection_name=collection_name,
             timeout=timeout,
             **kwargs,
         )
@@ -1026,8 +1026,8 @@ class MilvusClient:
         self,
         role_name: str,
         privilege: str,
+        collection_name: str,
         db_name: Optional[str] = None,
-        collection_name: Optional[str] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -1035,8 +1035,8 @@ class MilvusClient:
         conn.revoke_privilege_v2(
             role_name,
             privilege,
+            collection_name,
             db_name=db_name,
-            collection_name=collection_name,
             timeout=timeout,
             **kwargs,
         )

--- a/pymilvus/orm/role.py
+++ b/pymilvus/orm/role.py
@@ -178,48 +178,50 @@ class Role:
             self._name, object, object_name, privilege, db_name
         )
 
-    def grant_v2(
-        self, privilege: str, db_name: Optional[str] = None, collection_name: Optional[str] = None
-    ):
+    def grant_v2(self, privilege: str, collection_name: str, db_name: Optional[str] = None):
         """Grant a privilege for the role
             :param privilege: privilege name.
             :type  privilege: str
-            :param db_name: db name. Optional
-            :type  db_name: str
-            :param collection_name: collection name. Optional
+            :param collection_name: collection name.
             :type  collection_name: str
+            :param db_name: db name. Optional. If None, use the default db.
+            :type  db_name: str
 
         :example:
             >>> from pymilvus import connections
             >>> from pymilvus.orm.role import Role
             >>> connections.connect()
             >>> role = Role(role_name)
-            >>> role.grant_v2("Insert", db_name, collection_name)
+            >>> role.grant_v2("Insert", collection_name, db_name=db_name)
         """
         return self._get_connection().grant_privilege_v2(
-            self._name, privilege, db_name=db_name, collection_name=collection_name
+            self._name,
+            privilege,
+            collection_name,
+            db_name=db_name,
         )
 
-    def revoke_v2(
-        self, privilege: str, db_name: Optional[str] = None, collection_name: Optional[str] = None
-    ):
+    def revoke_v2(self, privilege: str, collection_name: str, db_name: Optional[str] = None):
         """Revoke a privilege for the role
             :param privilege: privilege name.
             :type  privilege: str
-            :param db_name: db name. Optional
-            :type  db_name: str
-            :param collection_name: collection name. Optional
+            :param collection_name: collection name.
             :type  collection_name: str
+            :param db_name: db name. Optional. If None, use the default db.
+            :type  db_name: str
 
         :example:
             >>> from pymilvus import connections
             >>> from pymilvus.orm.role import Role
             >>> connections.connect()
             >>> role = Role(role_name)
-            >>> role.revoke_v2("Insert", db_name, collection_name)
+            >>> role.revoke_v2("Insert", collection_name, db_name=db_name)
         """
         return self._get_connection().revoke_privilege_v2(
-            self._name, privilege, db_name=db_name, collection_name=collection_name
+            self._name,
+            privilege,
+            collection_name,
+            db_name=db_name,
         )
 
     def list_grant(self, object: str, object_name: str, db_name: str = ""):


### PR DESCRIPTION
Since built-in privilege group level adjustment is not supported, remove the optional collection name from the grant/revoke v2 API. The empty db_name uses default db which follows the same rule as grant/revoke v1.
issue: https://github.com/milvus-io/milvus/issues/37031