### PR TITLE
fix: [2.5] add `authorization_interceptor` and `db_interceptor` to async channel

### DIFF
--- a/examples/simple_async.py
+++ b/examples/simple_async.py
@@ -31,6 +31,7 @@ index_params = milvus_client.prepare_index_params()
 index_params.add_index(field_name = "embeddings", index_type = "HNSW", metric_type="L2", nlist=128)
 index_params.add_index(field_name = "embeddings2",index_type = "HNSW", metric_type="L2", nlist=128)
 
+# Always use `await` when you want to guarantee the execution order of tasks.
 async def recreate_collection():
     print(fmt.format("Start dropping collection"))
     await async_milvus_client.drop_collection(collection_name)

--- a/pymilvus/client/async_interceptor.py
+++ b/pymilvus/client/async_interceptor.py
@@ -72,7 +72,7 @@ class _GenericAsyncClientInterceptor(
         return await continuation(new_details, new_request_iterator)
 
 
-def async_header_adder_interceptor(headers: List[str], values: List[str]):
+def async_header_adder_interceptor(headers: List[str], values: Union[List[str], List[bytes]]):
     def intercept_call(client_call_details: ClientCallDetails, request: Any):
         metadata = []
         if client_call_details.metadata:

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -117,7 +117,7 @@ class AsyncMilvusClient:
         if "consistency_level" not in kwargs:
             kwargs["consistency_level"] = DEFAULT_CONSISTENCY_LEVEL
         try:
-            await conn.async_create_collection(collection_name, schema, timeout=timeout, **kwargs)
+            await conn.create_collection(collection_name, schema, timeout=timeout, **kwargs)
             logger.debug("Successfully created collection: %s", collection_name)
         except Exception as ex:
             logger.error("Failed to create collection: %s", collection_name)


### PR DESCRIPTION
- add `authorization_interceptor` and `db_interceptor` to async channel
- fix call wrong function name when creating collection without schema