### PR TITLE
fix: remove async function in AsyncClient connection initialization

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -400,7 +400,9 @@ class Connections(metaclass=SingleInstanceMetaClass):
             t = kwargs.get("timeout")
             timeout = t if isinstance(t, (int, float)) else Config.MILVUS_CONN_TIMEOUT
 
-            gh._wait_for_channel_ready(timeout=timeout)
+            if not _async:
+                gh._wait_for_channel_ready(timeout=timeout)
+
             if kwargs.get("keep_alive", False):
                 gh.register_state_change_callback(
                     ReconnectHandler(self, alias, kwargs_copy).reconnect_on_idle


### PR DESCRIPTION
- Move check for channel ready and identifier interceptor setup before each query call instead of during the AsyncClient connection initialization