### PR TITLE
fix: grant ManualCompact api doesn't work (#2396)

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1652,12 +1652,13 @@ class GrpcHandler:
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
+        # should be removed, but to be compatible with old milvus server, keep it for now.
         request = Prepare.describe_collection_request(collection_name)
         rf = self._stub.DescribeCollection.future(request, timeout=timeout)
         response = rf.result()
         check_status(response.status)
 
-        req = Prepare.manual_compaction(response.collectionID, is_clustering)
+        req = Prepare.manual_compaction(response.collectionID, collection_name, is_clustering)
         future = self._stub.ManualCompaction.future(req, timeout=timeout)
         response = future.result()
         check_status(response.status)

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1330,7 +1330,7 @@ class Prepare:
         )
 
     @classmethod
-    def manual_compaction(cls, collection_id: int, is_clustering: bool):
+    def manual_compaction(cls, collection_id: int, collection_name: str, is_clustering: bool):
         if collection_id is None or not isinstance(collection_id, int):
             raise ParamError(message=f"collection_id value {collection_id} is illegal")
 
@@ -1339,6 +1339,7 @@ class Prepare:
 
         request = milvus_types.ManualCompactionRequest()
         request.collectionID = collection_id
+        request.collection_name = collection_name
         request.majorCompaction = is_clustering
 
         return request


### PR DESCRIPTION
issue: milvus-io/milvus#38086
pr: #2396
cause RBAC require to check collection name, but ManualCompact rpc pass collection id in request, so grant ManualCompact api doesn't work.

This PR refine compact api impl to pass collection name in request.