### PR TITLE
Make milvus-lite a optional dependency

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -385,9 +385,14 @@ class Connections(metaclass=SingleInstanceMetaClass):
                     message=f"Open local milvus failed, dir: {parent_path} not exists"
                 )
 
-            from milvus_lite.server_manager import (
-                server_manager_instance,
-            )
+            try:
+                from milvus_lite.server_manager import (
+                    server_manager_instance,
+                )
+            except ImportError:
+                raise ConnectionConfigException(
+                    message="milvus-lite is not installed. Please install it using 'pip install pymilvus[milvus_lite]' or pip install milvus-lite"
+                )
 
             local_uri = server_manager_instance.start_and_get_uri(kwargs["uri"])
             if local_uri is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies=[
     "ujson>=2.0.0",
     "pandas>=1.2.4",
     "numpy<1.25.0;python_version<='3.8'",
-    "milvus-lite>=2.4.0;sys_platform!='win32'",
 ]
 
 classifiers=[
@@ -49,6 +48,9 @@ bulk_writer = [
     "minio>=7.0.0",
     "pyarrow>=12.0.0",
     "azure-storage-blob",
+]
+milvus_lite = [
+    "milvus-lite>=2.4.0;sys_platform!='win32'",
 ]
 
 model = [


### PR DESCRIPTION
Right now, milvus lite is a required dependency. When trying to use it under docker, milvus-lite alone uses ~150MB.

This space is mostly unwanted if we dont use local DB (using localdb is unlikely in docker deployments)