### PR TITLE
Add Optional CA Certificate Support to Bulk Import Functions

### DIFF
--- a/pymilvus/bulk_writer/bulk_import.py
+++ b/pymilvus/bulk_writer/bulk_import.py
@@ -45,24 +45,25 @@ def _handle_response(url: str, res: json):
 
 
 def _post_request(
-    url: str, api_key: str, params: {}, timeout: int = 20, verify: Optional[Union[bool, str]] = True, **kwargs
+    url: str, api_key: str, params: {}, timeout: int = 20, verify: Optional[Union[bool, str]] = True, cert: Optional[Union[str, tuple]] = None, **kwargs
 ) -> requests.Response:
-    """Send a POST request with optional server certificate verification
+    """Send a POST request with 1-way / 2-way optional certificate validation
 
     Args:
         url (str): The endpoint URL
         api_key (str): API key for authentication
         params (dict): JSON parameters for the request
         timeout (int): Timeout for the request
-        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+        verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
+        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
 
     Returns:
         requests.Response: Response object.
     """
     try:
         resp = requests.post(
-            url=url, headers=_http_headers(api_key), json=params, timeout=timeout, verify=verify, **kwargs
+            url=url, headers=_http_headers(api_key), json=params, timeout=timeout, verify=verify, cert=cert, **kwargs
         )
         if resp.status_code != 200:
             _throw(f"Failed to post url: {url}, status code: {resp.status_code}")
@@ -99,6 +100,7 @@ def bulk_import(
     access_key: str = "",
     secret_key: str = "",
     verify: Optional[Union[bool, str]] = True, 
+    cert: Optional[Union[str, tuple]] = None, 
     **kwargs,
 ) -> requests.Response:
     """call bulkinsert restful interface to import files
@@ -117,8 +119,9 @@ def bulk_import(
         api_key (str): API key to authenticate your requests.
         access_key (str): access key to access the object storage
         secret_key (str): secret key to access the object storage
-        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+        verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
+        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
 
     Returns:
         response of the restful interface
@@ -141,7 +144,7 @@ def bulk_import(
     if isinstance(options, dict):
         params["options"] = options
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, **kwargs)
+    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs)
     _handle_response(request_url, resp.json())
     return resp
 
@@ -152,6 +155,7 @@ def get_import_progress(
     cluster_id: str = "", 
     api_key: str = "",
     verify: Optional[Union[bool, str]] = True, 
+    cert: Optional[Union[str, tuple]] = None, 
     **kwargs
 ) -> requests.Response:
     """get job progress
@@ -161,8 +165,9 @@ def get_import_progress(
         job_id (str): a job id
         cluster_id (str): id of a milvus instance(for cloud)
         api_key (str): API key to authenticate your requests.
-        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+        verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
+        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
 
     Returns:
         response of the restful interface
@@ -174,7 +179,7 @@ def get_import_progress(
         "clusterId": cluster_id,
     }
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, **kwargs)
+    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs)
     _handle_response(request_url, resp.json())
     return resp
 
@@ -187,6 +192,7 @@ def list_import_jobs(
     page_size: int = 10,
     current_page: int = 1,
     verify: Optional[Union[bool, str]] = True,
+    cert: Optional[Union[str, tuple]] = None,
     **kwargs,
 ) -> requests.Response:
     """list jobs in a cluster
@@ -198,8 +204,9 @@ def list_import_jobs(
         api_key (str): API key to authenticate your requests.
         page_size (int): pagination size
         current_page (int): pagination
-        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+        verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
+        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
 
     Returns:
         response of the restful interface
@@ -213,6 +220,6 @@ def list_import_jobs(
         "currentPage": current_page,
     }
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, **kwargs)
+    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs)
     _handle_response(request_url, resp.json())
     return resp

--- a/pymilvus/bulk_writer/bulk_import.py
+++ b/pymilvus/bulk_writer/bulk_import.py
@@ -45,7 +45,13 @@ def _handle_response(url: str, res: json):
 
 
 def _post_request(
-    url: str, api_key: str, params: {}, timeout: int = 20, verify: Optional[Union[bool, str]] = True, cert: Optional[Union[str, tuple]] = None, **kwargs
+    url: str,
+    api_key: str,
+    params: {},
+    timeout: int = 20,
+    verify: Optional[Union[bool, str]] = True,
+    cert: Optional[Union[str, tuple]] = None,
+    **kwargs,
 ) -> requests.Response:
     """Send a POST request with 1-way / 2-way optional certificate validation
 
@@ -56,14 +62,21 @@ def _post_request(
         timeout (int): Timeout for the request
         verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
-        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
+        cert (str, tuple, optional): if String, path to ssl client cert file.
+                                     if Tuple, ('cert', 'key') pair.
 
     Returns:
         requests.Response: Response object.
     """
     try:
         resp = requests.post(
-            url=url, headers=_http_headers(api_key), json=params, timeout=timeout, verify=verify, cert=cert, **kwargs
+            url=url,
+            headers=_http_headers(api_key),
+            json=params,
+            timeout=timeout,
+            verify=verify,
+            cert=cert,
+            **kwargs,
         )
         if resp.status_code != 200:
             _throw(f"Failed to post url: {url}, status code: {resp.status_code}")
@@ -99,8 +112,8 @@ def bulk_import(
     api_key: str = "",
     access_key: str = "",
     secret_key: str = "",
-    verify: Optional[Union[bool, str]] = True, 
-    cert: Optional[Union[str, tuple]] = None, 
+    verify: Optional[Union[bool, str]] = True,
+    cert: Optional[Union[str, tuple]] = None,
     **kwargs,
 ) -> requests.Response:
     """call bulkinsert restful interface to import files
@@ -121,7 +134,8 @@ def bulk_import(
         secret_key (str): secret key to access the object storage
         verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
-        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
+        cert (str, tuple, optional): if String, path to ssl client cert file.
+                                     if Tuple, ('cert', 'key') pair.
 
     Returns:
         response of the restful interface
@@ -144,19 +158,21 @@ def bulk_import(
     if isinstance(options, dict):
         params["options"] = options
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs)
+    resp = _post_request(
+        url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs
+    )
     _handle_response(request_url, resp.json())
     return resp
 
 
 def get_import_progress(
-    url: str, 
-    job_id: str, 
-    cluster_id: str = "", 
+    url: str,
+    job_id: str,
+    cluster_id: str = "",
     api_key: str = "",
-    verify: Optional[Union[bool, str]] = True, 
-    cert: Optional[Union[str, tuple]] = None, 
-    **kwargs
+    verify: Optional[Union[bool, str]] = True,
+    cert: Optional[Union[str, tuple]] = None,
+    **kwargs,
 ) -> requests.Response:
     """get job progress
 
@@ -167,7 +183,8 @@ def get_import_progress(
         api_key (str): API key to authenticate your requests.
         verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
-        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
+        cert (str, tuple, optional): if String, path to ssl client cert file.
+                                     if Tuple, ('cert', 'key') pair.
 
     Returns:
         response of the restful interface
@@ -179,7 +196,9 @@ def get_import_progress(
         "clusterId": cluster_id,
     }
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs)
+    resp = _post_request(
+        url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs
+    )
     _handle_response(request_url, resp.json())
     return resp
 
@@ -206,7 +225,8 @@ def list_import_jobs(
         current_page (int): pagination
         verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
              or a string, which must be server's certificate path. Defaults to `True`.
-        cert (str, tuple, optional): if String, path to ssl client cert file. If Tuple, ('cert', 'key') pair.
+        cert (str, tuple, optional): if String, path to ssl client cert file.
+                                     if Tuple, ('cert', 'key') pair.
 
     Returns:
         response of the restful interface
@@ -220,6 +240,8 @@ def list_import_jobs(
         "currentPage": current_page,
     }
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs)
+    resp = _post_request(
+        url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs
+    )
     _handle_response(request_url, resp.json())
     return resp

--- a/pymilvus/bulk_writer/bulk_import.py
+++ b/pymilvus/bulk_writer/bulk_import.py
@@ -12,7 +12,7 @@
 
 import json
 import logging
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import requests
 
@@ -45,11 +45,24 @@ def _handle_response(url: str, res: json):
 
 
 def _post_request(
-    url: str, api_key: str, params: {}, timeout: int = 20, **kwargs
+    url: str, api_key: str, params: {}, timeout: int = 20, verify: Optional[Union[bool, str]] = True, **kwargs
 ) -> requests.Response:
+    """Send a POST request with optional server certificate verification
+
+    Args:
+        url (str): The endpoint URL
+        api_key (str): API key for authentication
+        params (dict): JSON parameters for the request
+        timeout (int): Timeout for the request
+        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+             or a string, which must be server's certificate path. Defaults to `True`.
+
+    Returns:
+        requests.Response: Response object.
+    """
     try:
         resp = requests.post(
-            url=url, headers=_http_headers(api_key), json=params, timeout=timeout, **kwargs
+            url=url, headers=_http_headers(api_key), json=params, timeout=timeout, verify=verify, **kwargs
         )
         if resp.status_code != 200:
             _throw(f"Failed to post url: {url}, status code: {resp.status_code}")
@@ -85,6 +98,7 @@ def bulk_import(
     api_key: str = "",
     access_key: str = "",
     secret_key: str = "",
+    verify: Optional[Union[bool, str]] = True, 
     **kwargs,
 ) -> requests.Response:
     """call bulkinsert restful interface to import files
@@ -103,6 +117,8 @@ def bulk_import(
         api_key (str): API key to authenticate your requests.
         access_key (str): access key to access the object storage
         secret_key (str): secret key to access the object storage
+        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+             or a string, which must be server's certificate path. Defaults to `True`.
 
     Returns:
         response of the restful interface
@@ -125,13 +141,18 @@ def bulk_import(
     if isinstance(options, dict):
         params["options"] = options
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, **kwargs)
+    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, **kwargs)
     _handle_response(request_url, resp.json())
     return resp
 
 
 def get_import_progress(
-    url: str, job_id: str, cluster_id: str = "", api_key: str = "", **kwargs
+    url: str, 
+    job_id: str, 
+    cluster_id: str = "", 
+    api_key: str = "",
+    verify: Optional[Union[bool, str]] = True, 
+    **kwargs
 ) -> requests.Response:
     """get job progress
 
@@ -140,6 +161,8 @@ def get_import_progress(
         job_id (str): a job id
         cluster_id (str): id of a milvus instance(for cloud)
         api_key (str): API key to authenticate your requests.
+        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+             or a string, which must be server's certificate path. Defaults to `True`.
 
     Returns:
         response of the restful interface
@@ -151,7 +174,7 @@ def get_import_progress(
         "clusterId": cluster_id,
     }
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, **kwargs)
+    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, **kwargs)
     _handle_response(request_url, resp.json())
     return resp
 
@@ -163,6 +186,7 @@ def list_import_jobs(
     api_key: str = "",
     page_size: int = 10,
     current_page: int = 1,
+    verify: Optional[Union[bool, str]] = True,
     **kwargs,
 ) -> requests.Response:
     """list jobs in a cluster
@@ -174,6 +198,8 @@ def list_import_jobs(
         api_key (str): API key to authenticate your requests.
         page_size (int): pagination size
         current_page (int): pagination
+        verify (bool, str, optional): Either a boolean, whether to verify the server's TLS certificate
+             or a string, which must be server's certificate path. Defaults to `True`.
 
     Returns:
         response of the restful interface
@@ -187,6 +213,6 @@ def list_import_jobs(
         "currentPage": current_page,
     }
 
-    resp = _post_request(url=request_url, api_key=api_key, params=params, **kwargs)
+    resp = _post_request(url=request_url, api_key=api_key, params=params, verify=verify, **kwargs)
     _handle_response(request_url, resp.json())
     return resp


### PR DESCRIPTION
### Description:

Issue: https://github.com/milvus-io/pymilvus/issues/2671
This PR addresses the above issue by adding optional CA certificate support to the below bulk import functions:
- **bulk_import**
- **get_import_progress**
- **list_import_jobs**

Now, users with TLS-mode milvus can use these functions in pymilvus, using their SSL-certificate.