### PR TITLE
fix [2.4]: Allow empty sparse

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -46,6 +46,8 @@ def entity_is_sparse_matrix(entity: Any):
         for item in entity:
             if SciPyHelper.is_scipy_sparse(item):
                 return item.shape[0] == 1
+            if not isinstance(item, dict) and not isinstance(item, list):
+                return False
             pairs = item.items() if isinstance(item, dict) else item
             # each row must be a list of Tuple[int, float]. we allow empty sparse row
             for pair in pairs:

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -47,9 +47,7 @@ def entity_is_sparse_matrix(entity: Any):
             if SciPyHelper.is_scipy_sparse(item):
                 return item.shape[0] == 1
             pairs = item.items() if isinstance(item, dict) else item
-            # each row must be a non-empty list of Tuple[int, float]
-            if len(pairs) == 0:
-                return False
+            # each row must be a list of Tuple[int, float]. we allow empty sparse row
             for pair in pairs:
                 if len(pair) != 2 or not is_int_type(pair[0]) or not is_float_type(pair[1]):
                     return False
@@ -118,7 +116,10 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
                     indices.append(int(index))
                     values.append(float(value))
                 result.contents.append(sparse_float_row_to_bytes(indices, values))
-                dim = max(dim, indices[-1] + 1)
+                row_dim = 0
+                if len(indices) > 0:
+                    row_dim = indices[-1] + 1
+                dim = max(dim, row_dim)
         result.dim = dim
     return result
 


### PR DESCRIPTION
cherry pick https://github.com/milvus-io/pymilvus/pull/2309 and https://github.com/milvus-io/pymilvus/pull/2291.

support for empty sparse vector is added in 2.4.12 https://github.com/milvus-io/milvus/releases/tag/v2.4.12.