### PR TITLE
fix: hybrid search, SequenceIterator is not iterable

### DIFF
--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -357,7 +357,10 @@ class MilvusClient:
 
         ret = []
         for hits in res:
-            ret.append([hit.to_dict() for hit in hits])
+            query_result = []
+            for hit in hits:
+                query_result.append(hit.to_dict())
+            ret.append(query_result)
 
         return ExtraList(ret, extra=construct_cost_extra(res.cost))
 


### PR DESCRIPTION
This fixes the issue [#40391](https://github.com/milvus-io/pymilvus/issues/2681)

By just doing the same as the search method, instead of using the list comprehension syntax.