### PR TITLE
fix: [cp25]db_name overwritten by empty string (#2678)

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -451,7 +451,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
                 user = parsed_uri.username or user
                 password = parsed_uri.password or password
 
-                group = parsed_uri.path.split("/")
+                group = [segment for segment in parsed_uri.path.split("/") if segment]
                 db_name = group[1] if len(group) > 1 else db_name
 
                 # Set secure=True if https scheme


### PR DESCRIPTION
issue: https://github.com/milvus-io/pymilvus/issues/2670
pr: #2678

Added a unit test for it as well.