### PR TITLE
avoid collision on aliases in MilvusClient _create_connection

### DIFF
--- a/examples/hybrid_search.py
+++ b/examples/hybrid_search.py
@@ -49,7 +49,6 @@ print(fmt.format("Start loading"))
 milvus_client.load_collection(collection_name)
 
 field_names = ["embeddings", "embeddings2"]
-field_names = ["embeddings"]
 
 req_list = []
 nq = 1

--- a/examples/hybrid_search/hybrid_search.py
+++ b/examples/hybrid_search/hybrid_search.py
@@ -80,7 +80,7 @@ for i in range(len(field_names)):
     req_list.append(req)
 
 print(fmt.format("rank by WightedRanker"))
-hybrid_res = hello_milvus.hybrid_search(req_list, WeightedRanker(*weights), default_limit, output_fields=["random"])
+hybrid_res = hello_milvus.hybrid_search(req_list, WeightedRanker(*weights, norm_score=True), default_limit, output_fields=["random"])
 for hits in hybrid_res:
     for hit in hits:
         print(f" hybrid search hit: {hit}")

--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -381,16 +381,22 @@ class RRFRanker(BaseRanker):
 
 
 class WeightedRanker(BaseRanker):
-    def __init__(self, *nums):
+    def __init__(self, *nums, norm_score: bool = True):
         self._strategy = RANKER_TYPE_WEIGHTED
         weights = []
         for num in nums:
+            # isinstance(True, int) is True, thus we need to check bool first
+            if isinstance(num, bool) or not isinstance(num, (int, float)):
+                error_msg = f"Weight must be a number, got {type(num)}"
+                raise TypeError(error_msg)
             weights.append(num)
         self._weights = weights
+        self._norm_score = norm_score
 
     def dict(self):
         params = {
             "weights": self._weights,
+            "norm_score": self._norm_score,
         }
         return {
             "strategy": self._strategy,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -916,7 +916,7 @@ class MilvusClient:
     ) -> str:
         """Create the connection to the Milvus server."""
         # TODO: Implement reuse with new uri style
-        using = uuid4().hex
+        using = kwargs.pop('alias', None) or uuid4().hex
         try:
             connections.connect(using, user, password, db_name, token, uri=uri, **kwargs)
         except Exception as ex:

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -916,7 +916,7 @@ class MilvusClient:
     ) -> str:
         """Create the connection to the Milvus server."""
         # TODO: Implement reuse with new uri style
-        using = kwargs.pop('alias', None) or uuid4().hex
+        using = kwargs.pop("alias", None) or uuid4().hex
         try:
             connections.connect(using, user, password, db_name, token, uri=uri, **kwargs)
         except Exception as ex:


### PR DESCRIPTION
This PR handles the #2715 

It ensures that only one alias is used when calling connections.connect within the milvus client. This will allow users to create milvus connections to multiple milvus instances in the same context without worrying about collisions on aliases.