### PR TITLE
fix: db_name will be overwritten by mistake

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -454,8 +454,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
                 user = parsed_uri.username or user
                 password = parsed_uri.password or password
 
-                group = [segment for segment in parsed_uri.path.split("/") if segment]
-                db_name = group[1] if len(group) > 1 else db_name
+                db_name = parsed_uri.path.lstrip("/").split("/", 1)[0] or db_name
 
                 # Set secure=True if https scheme
                 if parsed_uri.scheme == "https":

--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -454,7 +454,8 @@ class Connections(metaclass=SingleInstanceMetaClass):
                 user = parsed_uri.username or user
                 password = parsed_uri.password or password
 
-                db_name = parsed_uri.path.lstrip("/").split("/", 1)[0] or db_name
+                group = [segment for segment in parsed_uri.path.split("/") if segment]
+                db_name = group[0] if group else db_name
 
                 # Set secure=True if https scheme
                 if parsed_uri.scheme == "https":

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -373,8 +373,8 @@ class TestIssues:
                 config = connections.get_connection_addr("default")
                 assert config == {"address": 'localhost:19531', "user": 'root', "secure": True}
 
-    @pytest.mark.parametrize("uri, db_name", [("http://localhost:19530", "test_db"), ("http://localhost:19530/", "test_db"), ("http://localhost:19530/test_db", None)])
-    def test_issue_2670_2727(self, uri: str, db_name: str | None):
+    @pytest.mark.parametrize("uri, db_name", [("http://localhost:19530", "test_db"), ("http://localhost:19530/", "test_db"), ("http://localhost:19530/test_db", "")])
+    def test_issue_2670_2727(self, uri: str, db_name: str):
         """
         Issue 2670:
         

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -373,8 +373,11 @@ class TestIssues:
                 config = connections.get_connection_addr("default")
                 assert config == {"address": 'localhost:19531', "user": 'root', "secure": True}
 
-    def test_issue_2670(self):
+    @pytest.mark.parametrize("uri, db_name", [("http://localhost:19530", "test_db"), ("http://localhost:19530/", "test_db"), ("http://localhost:19530/test_db", None)])
+    def test_issue_2670_2727(self, uri: str, db_name: str | None):
         """
+        Issue 2670:
+        
         Test for db_name being overwritten with empty string, when the uri
         ends in a slash - e.g. http://localhost:19530/
 
@@ -384,16 +387,28 @@ class TestIssues:
             it will overwrite the db_name with an empty string.
         Expected and current behaviour: if db_name is passed explicitly,
             it should be used in the initialization of the GrpcHandler.
+
+        Issue 2727:
+        If db_name is passed as a path to the uri and not explicitly passed as an argument,
+        it is not overwritten with an empty string.
+
+        See: https://github.com/milvus-io/pymilvus/issues/2727
+
+        Actual behaviour before fix: if db_name is passed as a path to the uri,
+            it will overwrite the db_name with an empty string.
+        Expected and current behaviour: if db_name is passed as a path to the uri,
+            it should be used in the initialization of the GrpcHandler.
         
         """
-        db_name = "default"
-        alias = self.test_issue_2670.__name__
+        alias = self.test_issue_2670_2727.__name__
 
         with mock.patch(f"{mock_prefix}.__init__", return_value=None) as mock_init, mock.patch(
             f"{mock_prefix}._wait_for_channel_ready", return_value=None):
-            config = {"alias": alias, "uri": "http://localhost:19530/", "db_name": db_name}
+            config = {"alias": alias, "uri": uri, "db_name": db_name}
             connections.connect(**config)
             
+            db_name = db_name or uri.split("/")[-1]
+
             mock_init.assert_called_with(
                 **{'address': 'localhost:19530', 'user': '', 'password': '', 'token': '', 'db_name': db_name}
                 ) 


### PR DESCRIPTION
Fix for [2727](https://github.com/milvus-io/pymilvus/issues/2727). Ensures that both passing a db_name as an explicit argument and as a path to the connection uri is used and not overwritten with an empty string. Added a couple of test cases.