### PR TITLE
fix: [25]db_name will be overwritten by mistake (#2734)

### DIFF
--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -452,7 +452,7 @@ class Connections(metaclass=SingleInstanceMetaClass):
                 password = parsed_uri.password or password
 
                 group = [segment for segment in parsed_uri.path.split("/") if segment]
-                db_name = group[1] if len(group) > 1 else db_name
+                db_name = group[0] if group else db_name
 
                 # Set secure=True if https scheme
                 if parsed_uri.scheme == "https":


### PR DESCRIPTION
Fix for [2727](https://github.com/milvus-io/pymilvus/issues/2727). Ensures that both passing a db_name as an explicit argument and as a path to the connection uri is used and not overwritten with an empty string. Added a couple of test cases.