### PR TITLE
fix: [AddField] Call `get_field_schema` with required params

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -218,6 +218,7 @@ class Prepare:
             autoID=auto_id,
             is_partition_key=field.get("is_partition_key", False),
             is_clustering_key=field.get("is_clustering_key", False),
+            nullable=nullable,
         )
 
         type_params = field.get("params", {})
@@ -279,7 +280,7 @@ class Prepare:
         collection_name: str,
         field_schema: FieldSchema,
     ) -> milvus_types.AddCollectionFieldRequest:
-        (field_schema_proto, _, _) = cls.get_field_schema(field=field_schema.to_dict())
+        (field_schema_proto, _, _) = cls.get_field_schema(field=field_schema.to_dict(), primary_field=None, auto_id_field=None)
         return milvus_types.AddCollectionFieldRequest(
             collection_name=collection_name,
             schema=bytes(field_schema_proto.SerializeToString()),


### PR DESCRIPTION
Related to milvus-io/milvus#39718

This PR:
- Make `get_schema_field` call have all required parameters
- Fill nullable attribute for the returned FieldSchema