### PR TITLE
fix: [AddField] Fill default value in `get_field_schema`

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -219,6 +219,7 @@ class Prepare:
             is_partition_key=field.get("is_partition_key", False),
             is_clustering_key=field.get("is_clustering_key", False),
             nullable=nullable,
+            default_value=field.get("default_value"),
         )
 
         type_params = field.get("params", {})


### PR DESCRIPTION
Related to milvus-io/milvus#39718

This PR fixes the issue that default value in input dict is not convert to result FieldSchema.default_value.