### PR TITLE
fix: [cp25]Pass request-id in metadata per API (#2766)

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -31,6 +31,7 @@ from .check import (
     is_legal_port,
 )
 from .constants import ITERATOR_SESSION_TS_FIELD
+from .interceptor import _api_level_md
 from .prepare import Prepare
 from .search_result import SearchResult
 from .types import (
@@ -64,7 +65,6 @@ class AsyncGrpcHandler:
         addr = kwargs.get("address")
         self._address = addr if addr is not None else self.__get_address(uri, host, port)
         self._log_level = None
-        self._request_id = None
         self._user = kwargs.get("user")
         self._set_authorization(**kwargs)
         self._setup_db_name(kwargs.get("db_name"))
@@ -204,12 +204,6 @@ class AsyncGrpcHandler:
             )
             self._final_channel._unary_unary_interceptors.append(async_log_level_interceptor)
             self._log_level = None
-        if self._request_id:
-            async_request_id_interceptor = async_header_adder_interceptor(
-                ["client-request-id"], [self._request_id]
-            )
-            self._final_channel._unary_unary_interceptors.append(async_request_id_interceptor)
-            self._request_id = None
         self._async_stub = milvus_pb2_grpc.MilvusServiceStub(self._final_channel)
 
     @property
@@ -251,15 +245,21 @@ class AsyncGrpcHandler:
         await self.ensure_channel_ready()
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.create_collection_request(collection_name, fields, **kwargs)
-        response = await self._async_stub.CreateCollection(request, timeout=timeout)
+        response = await self._async_stub.CreateCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
-    async def drop_collection(self, collection_name: str, timeout: Optional[float] = None):
+    async def drop_collection(
+        self, collection_name: str, timeout: Optional[float] = None, **kwargs
+    ):
         await self.ensure_channel_ready()
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.drop_collection_request(collection_name)
-        response = await self._async_stub.DropCollection(request, timeout=timeout)
+        response = await self._async_stub.DropCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -290,14 +290,22 @@ class AsyncGrpcHandler:
             load_fields,
             skip_load_dynamic_field,
         )
-        response = await self._async_stub.LoadCollection(request, timeout=timeout)
+        response = await self._async_stub.LoadCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
-        await self.wait_for_loading_collection(collection_name, timeout, is_refresh=refresh)
+        await self.wait_for_loading_collection(
+            collection_name, timeout, is_refresh=refresh, **kwargs
+        )
 
     @retry_on_rpc_failure()
     async def wait_for_loading_collection(
-        self, collection_name: str, timeout: Optional[float] = None, is_refresh: bool = False
+        self,
+        collection_name: str,
+        timeout: Optional[float] = None,
+        is_refresh: bool = False,
+        **kwargs,
     ):
         start = time.time()
 
@@ -306,7 +314,7 @@ class AsyncGrpcHandler:
 
         while can_loop(time.time()):
             progress = await self.get_loading_progress(
-                collection_name, timeout=timeout, is_refresh=is_refresh
+                collection_name, timeout=timeout, is_refresh=is_refresh, **kwargs
             )
             if progress >= 100:
                 return
@@ -322,9 +330,12 @@ class AsyncGrpcHandler:
         partition_names: Optional[List[str]] = None,
         timeout: Optional[float] = None,
         is_refresh: bool = False,
+        **kwargs,
     ):
         request = Prepare.get_loading_progress(collection_name, partition_names)
-        response = await self._async_stub.GetLoadingProgress(request, timeout=timeout)
+        response = await self._async_stub.GetLoadingProgress(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         if is_refresh:
             return response.refresh_progress
@@ -337,7 +348,9 @@ class AsyncGrpcHandler:
         await self.ensure_channel_ready()
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.describe_collection_request(collection_name)
-        response = await self._async_stub.DescribeCollection(request, timeout=timeout)
+        response = await self._async_stub.DescribeCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
 
         if is_successful(status):
@@ -348,7 +361,7 @@ class AsyncGrpcHandler:
     async def _get_info(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         schema = kwargs.get("schema")
         if not schema:
-            schema = await self.describe_collection(collection_name, timeout=timeout)
+            schema = await self.describe_collection(collection_name, timeout=timeout, **kwargs)
 
         fields_info = schema.get("fields")
         enable_dynamic = schema.get("enable_dynamic_field", False)
@@ -362,7 +375,9 @@ class AsyncGrpcHandler:
         await self.ensure_channel_ready()
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.release_collection("", collection_name)
-        response = await self._async_stub.ReleaseCollection(request, timeout=timeout)
+        response = await self._async_stub.ReleaseCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -379,7 +394,9 @@ class AsyncGrpcHandler:
         request = await self._prepare_row_insert_request(
             collection_name, entities, partition_name, schema, timeout, **kwargs
         )
-        resp = await self._async_stub.Insert(request=request, timeout=timeout)
+        resp = await self._async_stub.Insert(
+            request=request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         ts_utils.update_collection_ts(collection_name, resp.timestamp)
         return MutationResult(resp)
@@ -397,7 +414,7 @@ class AsyncGrpcHandler:
             entity_rows = [entity_rows]
 
         if not isinstance(schema, dict):
-            schema = await self.describe_collection(collection_name, timeout=timeout)
+            schema = await self.describe_collection(collection_name, timeout=timeout, **kwargs)
 
         fields_info = schema.get("fields")
         enable_dynamic = schema.get("enable_dynamic_field", False)
@@ -430,7 +447,9 @@ class AsyncGrpcHandler:
                 **kwargs,
             )
 
-            response = await self._async_stub.Delete(req, timeout=timeout)
+            response = await self._async_stub.Delete(
+                req, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
 
             m = MutationResult(response)
             ts_utils.update_collection_ts(collection_name, m.timestamp)
@@ -478,18 +497,16 @@ class AsyncGrpcHandler:
         if not check_invalid_binary_vector(entities):
             raise ParamError(message="Invalid binary vector data exists")
 
-        try:
-            request = await self._prepare_batch_upsert_request(
-                collection_name, entities, partition_name, timeout, **kwargs
-            )
-            response = await self._async_stub.Upsert(request, timeout=timeout)
-            check_status(response.status)
-            m = MutationResult(response)
-            ts_utils.update_collection_ts(collection_name, m.timestamp)
-        except Exception as err:
-            raise err from err
-        else:
-            return m
+        request = await self._prepare_batch_upsert_request(
+            collection_name, entities, partition_name, timeout, **kwargs
+        )
+        response = await self._async_stub.Upsert(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
+        check_status(response.status)
+        m = MutationResult(response)
+        ts_utils.update_collection_ts(collection_name, m.timestamp)
+        return m
 
     async def _prepare_row_upsert_request(
         self,
@@ -526,7 +543,9 @@ class AsyncGrpcHandler:
         request = await self._prepare_row_upsert_request(
             collection_name, entities, partition_name, timeout, **kwargs
         )
-        response = await self._async_stub.Upsert(request, timeout=timeout)
+        response = await self._async_stub.Upsert(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         m = MutationResult(response)
         ts_utils.update_collection_ts(collection_name, m.timestamp)
@@ -535,30 +554,27 @@ class AsyncGrpcHandler:
     async def _execute_search(
         self, request: milvus_types.SearchRequest, timeout: Optional[float] = None, **kwargs
     ):
-        try:
-            response = await self._async_stub.Search(request, timeout=timeout)
-            check_status(response.status)
-            round_decimal = kwargs.get("round_decimal", -1)
-            return SearchResult(
-                response.results,
-                round_decimal,
-                status=response.status,
-                session_ts=response.session_ts,
-            )
-        except Exception as e:
-            raise e from e
+        response = await self._async_stub.Search(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
+        check_status(response.status)
+        round_decimal = kwargs.get("round_decimal", -1)
+        return SearchResult(
+            response.results,
+            round_decimal,
+            status=response.status,
+            session_ts=response.session_ts,
+        )
 
     async def _execute_hybrid_search(
         self, request: milvus_types.HybridSearchRequest, timeout: Optional[float] = None, **kwargs
     ):
-        try:
-            response = await self._async_stub.HybridSearch(request, timeout=timeout)
-            check_status(response.status)
-            round_decimal = kwargs.get("round_decimal", -1)
-            return SearchResult(response.results, round_decimal, status=response.status)
-
-        except Exception as e:
-            raise e from e
+        response = await self._async_stub.HybridSearch(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
+        check_status(response.status)
+        round_decimal = kwargs.get("round_decimal", -1)
+        return SearchResult(response.results, round_decimal, status=response.status)
 
     @retry_on_rpc_failure()
     async def search(
@@ -689,7 +705,9 @@ class AsyncGrpcHandler:
             collection_name, field_name, params, index_name=index_name
         )
 
-        status = await self._async_stub.CreateIndex(index_param, timeout=timeout)
+        status = await self._async_stub.CreateIndex(
+            index_param, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
         index_success, fail_reason = await self.wait_for_creating_index(
@@ -697,6 +715,7 @@ class AsyncGrpcHandler:
             index_name=index_name,
             timeout=timeout,
             field_name=field_name,
+            **kwargs,
         )
 
         if not index_success:
@@ -737,7 +756,9 @@ class AsyncGrpcHandler:
         **kwargs,
     ):
         request = Prepare.describe_index_request(collection_name, index_name, timestamp)
-        response = await self._async_stub.DescribeIndex(request, timeout=timeout)
+        response = await self._async_stub.DescribeIndex(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
 
@@ -765,7 +786,9 @@ class AsyncGrpcHandler:
         await self.ensure_channel_ready()
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.drop_index_request(collection_name, field_name, index_name)
-        response = await self._async_stub.DropIndex(request, timeout=timeout)
+        response = await self._async_stub.DropIndex(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -777,7 +800,9 @@ class AsyncGrpcHandler:
             collection_name=collection_name, partition_name=partition_name, timeout=timeout
         )
         request = Prepare.create_partition_request(collection_name, partition_name)
-        response = await self._async_stub.CreatePartition(request, timeout=timeout)
+        response = await self._async_stub.CreatePartition(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -790,7 +815,9 @@ class AsyncGrpcHandler:
         )
         request = Prepare.drop_partition_request(collection_name, partition_name)
 
-        response = await self._async_stub.DropPartition(request, timeout=timeout)
+        response = await self._async_stub.DropPartition(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -826,10 +853,14 @@ class AsyncGrpcHandler:
             load_fields,
             skip_load_dynamic_field,
         )
-        response = await self._async_stub.LoadPartitions(request, timeout=timeout)
+        response = await self._async_stub.LoadPartitions(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
-        await self.wait_for_loading_partitions(collection_name, partition_names, is_refresh=refresh)
+        await self.wait_for_loading_partitions(
+            collection_name, partition_names, is_refresh=refresh, **kwargs
+        )
 
     @retry_on_rpc_failure()
     async def wait_for_loading_partitions(
@@ -838,6 +869,7 @@ class AsyncGrpcHandler:
         partition_names: List[str],
         timeout: Optional[float] = None,
         is_refresh: bool = False,
+        **kwargs,
     ):
         start = time.time()
 
@@ -846,7 +878,7 @@ class AsyncGrpcHandler:
 
         while can_loop(time.time()):
             progress = await self.get_loading_progress(
-                collection_name, partition_names, timeout=timeout, is_refresh=is_refresh
+                collection_name, partition_names, timeout=timeout, is_refresh=is_refresh, **kwargs
             )
             if progress >= 100:
                 return
@@ -868,7 +900,9 @@ class AsyncGrpcHandler:
             collection_name=collection_name, partition_name_array=partition_names, timeout=timeout
         )
         request = Prepare.release_partitions("", collection_name, partition_names)
-        response = await self._async_stub.ReleasePartitions(request, timeout=timeout)
+        response = await self._async_stub.ReleasePartitions(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -879,11 +913,14 @@ class AsyncGrpcHandler:
         output_fields: Optional[List[str]] = None,
         partition_names: Optional[List[str]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ):
         # TODO: some check
         await self.ensure_channel_ready()
         request = Prepare.retrieve_request(collection_name, ids, output_fields, partition_names)
-        return await self._async_stub.Retrieve.get(request, timeout=timeout)
+        return await self._async_stub.Retrieve.get(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
 
     @retry_on_rpc_failure()
     async def query(
@@ -901,7 +938,9 @@ class AsyncGrpcHandler:
         request = Prepare.query_request(
             collection_name, expr, output_fields, partition_names, **kwargs
         )
-        response = await self._async_stub.Query(request, timeout=timeout)
+        response = await self._async_stub.Query(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
 
         num_fields = len(response.fields_data)
@@ -930,8 +969,10 @@ class AsyncGrpcHandler:
 
     @retry_on_rpc_failure()
     @ignore_unimplemented(0)
-    async def alloc_timestamp(self, timeout: Optional[float] = None) -> int:
+    async def alloc_timestamp(self, timeout: Optional[float] = None, **kwargs) -> int:
         request = milvus_types.AllocTimestampRequest()
-        response = await self._async_stub.AllocTimestamp(request, timeout=timeout)
+        response = await self._async_stub.AllocTimestamp(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         return response.timestamp

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -42,6 +42,7 @@ from .check import (
     is_legal_port,
 )
 from .constants import ITERATOR_SESSION_TS_FIELD
+from .interceptor import _api_level_md
 from .prepare import Prepare
 from .search_result import SearchResult
 from .types import (
@@ -94,7 +95,6 @@ class GrpcHandler:
         addr = kwargs.get("address")
         self._address = addr if addr is not None else self.__get_address(uri, host, port)
         self._log_level = None
-        self._request_id = None
         self._user = kwargs.get("user")
         self._set_authorization(**kwargs)
         self._setup_db_interceptor(kwargs.get("db_name"))
@@ -256,22 +256,10 @@ class GrpcHandler:
             )
             self._final_channel = grpc.intercept_channel(self._final_channel, log_level_interceptor)
             self._log_level = None
-        if self._request_id:
-            request_id_interceptor = interceptor.header_adder_interceptor(
-                ["client-request-id"], [self._request_id]
-            )
-            self._final_channel = grpc.intercept_channel(
-                self._final_channel, request_id_interceptor
-            )
-            self._request_id = None
         self._stub = milvus_pb2_grpc.MilvusServiceStub(self._final_channel)
 
     def set_onetime_loglevel(self, log_level: str):
         self._log_level = log_level
-        self._setup_grpc_channel()
-
-    def set_onetime_request_id(self, req_id: int):
-        self._request_id = req_id
         self._setup_grpc_channel()
 
     def _setup_identifier_interceptor(self, user: str, timeout: int = 10):
@@ -299,11 +287,12 @@ class GrpcHandler:
         old_password: str,
         new_password: str,
         timeout: Optional[float] = None,
+        **kwargs,
     ):
         """
         reset password and then setup the grpc channel.
         """
-        self.update_password(user, old_password, new_password, timeout=timeout)
+        self.update_password(user, old_password, new_password, timeout=timeout, **kwargs)
         self._setup_authorization_interceptor(user, new_password, None)
         self._setup_grpc_channel()
 
@@ -314,7 +303,9 @@ class GrpcHandler:
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.create_collection_request(collection_name, fields, **kwargs)
 
-        rf = self._stub.CreateCollection.future(request, timeout=timeout)
+        rf = self._stub.CreateCollection.future(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         if kwargs.get("_async", False):
             return rf
         status = rf.result()
@@ -322,12 +313,13 @@ class GrpcHandler:
         return None
 
     @retry_on_rpc_failure()
-    def drop_collection(self, collection_name: str, timeout: Optional[float] = None):
+    def drop_collection(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.drop_collection_request(collection_name)
 
-        rf = self._stub.DropCollection.future(request, timeout=timeout)
-        status = rf.result()
+        status = self._stub.DropCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
@@ -336,8 +328,9 @@ class GrpcHandler:
     ):
         check_pass_param(collection_name=collection_name, properties=properties, timeout=timeout)
         request = Prepare.alter_collection_request(collection_name, properties=properties)
-        rf = self._stub.AlterCollection.future(request, timeout=timeout)
-        status = rf.result()
+        status = self._stub.AlterCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
@@ -353,8 +346,9 @@ class GrpcHandler:
         request = Prepare.alter_collection_field_request(
             collection_name=collection_name, field_name=field_name, field_param=field_params
         )
-        rf = self._stub.AlterCollectionField.future(request, timeout=timeout)
-        status = rf.result()
+        status = self._stub.AlterCollectionField(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
@@ -367,17 +361,19 @@ class GrpcHandler:
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.alter_collection_request(collection_name, delete_keys=property_keys)
-        rf = self._stub.AlterCollection.future(request, timeout=timeout)
-        status = rf.result()
+        status = self._stub.AlterCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
     def has_collection(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.describe_collection_request(collection_name)
-        rf = self._stub.DescribeCollection.future(request, timeout=timeout)
+        reply = self._stub.DescribeCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
 
-        reply = rf.result()
         # For compatibility with Milvus less than 2.3.2, which does not support status.code.
         if (
             reply.status.error_code == common_pb2.UnexpectedError
@@ -400,8 +396,9 @@ class GrpcHandler:
     def describe_collection(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.describe_collection_request(collection_name)
-        rf = self._stub.DescribeCollection.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
 
         if is_successful(status):
@@ -410,10 +407,11 @@ class GrpcHandler:
         raise DescribeCollectionException(status.code, status.reason, status.error_code)
 
     @retry_on_rpc_failure()
-    def list_collections(self, timeout: Optional[float] = None):
+    def list_collections(self, timeout: Optional[float] = None, **kwargs):
         request = Prepare.show_collections_request()
-        rf = self._stub.ShowCollections.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.ShowCollections(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return list(response.collection_names)
@@ -425,15 +423,17 @@ class GrpcHandler:
         new_name: str,
         new_db_name: str = "",
         timeout: Optional[float] = None,
+        **kwargs,
     ):
         check_pass_param(collection_name=new_name, timeout=timeout)
         check_pass_param(collection_name=old_name)
         if new_db_name:
             check_pass_param(db_name=new_db_name)
         request = Prepare.rename_collections_request(old_name, new_name, new_db_name)
-        rf = self._stub.RenameCollection.future(request, timeout=timeout)
-        response = rf.result()
-        check_status(response)
+        status = self._stub.RenameCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
+        check_status(status)
 
     @retry_on_rpc_failure()
     def create_partition(
@@ -443,8 +443,9 @@ class GrpcHandler:
             collection_name=collection_name, partition_name=partition_name, timeout=timeout
         )
         request = Prepare.create_partition_request(collection_name, partition_name)
-        rf = self._stub.CreatePartition.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.CreatePartition(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -456,8 +457,9 @@ class GrpcHandler:
         )
         request = Prepare.drop_partition_request(collection_name, partition_name)
 
-        rf = self._stub.DropPartition.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DropPartition(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -468,8 +470,9 @@ class GrpcHandler:
             collection_name=collection_name, partition_name=partition_name, timeout=timeout
         )
         request = Prepare.has_partition_request(collection_name, partition_name)
-        rf = self._stub.HasPartition.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.HasPartition(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return response.value
@@ -477,11 +480,12 @@ class GrpcHandler:
     # TODO: this is not inuse
     @retry_on_rpc_failure()
     def get_partition_info(
-        self, collection_name: str, partition_name: str, timeout: Optional[float] = None
+        self, collection_name: str, partition_name: str, timeout: Optional[float] = None, **kwargs
     ):
         request = Prepare.partition_stats_request(collection_name, partition_name)
-        rf = self._stub.DescribePartition.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribePartition(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         statistics = response.statistics
@@ -495,8 +499,9 @@ class GrpcHandler:
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.show_partitions_request(collection_name)
 
-        rf = self._stub.ShowPartitions.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.ShowPartitions(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return list(response.partition_names)
@@ -507,12 +512,14 @@ class GrpcHandler:
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         req = Prepare.get_partition_stats_request(collection_name, partition_name)
-        future = self._stub.GetPartitionStatistics.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetPartitionStatistics(
+            req, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return response.stats
 
+    # Seems not inuse
     def _get_info(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         schema = kwargs.get("schema")
         if not schema:
@@ -536,20 +543,24 @@ class GrpcHandler:
         request = self._prepare_row_insert_request(
             collection_name, entities, partition_name, schema, timeout, **kwargs
         )
-        resp = self._stub.Insert(request=request, timeout=timeout)
+        resp = self._stub.Insert(request=request, timeout=timeout, metadata=_api_level_md(**kwargs))
         if resp.status.error_code == common_pb2.SchemaMismatch:
-            schema = self.update_schema(collection_name, timeout)
+            schema = self.update_schema(collection_name, timeout, **kwargs)
             request = self._prepare_row_insert_request(
                 collection_name, entities, partition_name, schema, timeout, **kwargs
             )
-            resp = self._stub.Insert(request=request, timeout=timeout)
+            resp = self._stub.Insert(
+                request=request, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
         check_status(resp.status)
         ts_utils.update_collection_ts(collection_name, resp.timestamp)
         return MutationResult(resp)
 
-    def update_schema(self, collection_name: str, timeout: Optional[float] = None):
+    def update_schema(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         self.schema_cache.pop(collection_name, None)
-        schema = self.describe_collection(collection_name, timeout=timeout)
+        schema = self.describe_collection(
+            collection_name, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         schema_timestamp = schema.get("update_timestamp", 0)
 
         self.schema_cache[collection_name] = {
@@ -652,7 +663,9 @@ class GrpcHandler:
             request = self._prepare_batch_insert_request(
                 collection_name, entities, partition_name, timeout, **kwargs
             )
-            rf = self._stub.Insert.future(request, timeout=timeout)
+            rf = self._stub.Insert.future(
+                request, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
             if kwargs.get("_async", False):
                 cb = kwargs.get("_callback")
                 f = MutationFuture(rf, cb, timeout=timeout, **kwargs)
@@ -688,7 +701,9 @@ class GrpcHandler:
                 consistency_level=kwargs.pop("consistency_level", 0),
                 **kwargs,
             )
-            future = self._stub.Delete.future(req, timeout=timeout)
+            future = self._stub.Delete.future(
+                req, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
             if kwargs.get("_async", False):
                 cb = kwargs.pop("_callback", None)
                 f = MutationFuture(future, cb, timeout=timeout, **kwargs)
@@ -748,7 +763,9 @@ class GrpcHandler:
             request = self._prepare_batch_upsert_request(
                 collection_name, entities, partition_name, timeout, **kwargs
             )
-            rf = self._stub.Upsert.future(request, timeout=timeout)
+            rf = self._stub.Upsert.future(
+                request, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
             if kwargs.get("_async", False) is True:
                 cb = kwargs.get("_callback")
                 f = MutationFuture(rf, cb, timeout=timeout, **kwargs)
@@ -805,14 +822,15 @@ class GrpcHandler:
         request = self._prepare_row_upsert_request(
             collection_name, entities, partition_name, timeout, **kwargs
         )
-        rf = self._stub.Upsert.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.Upsert(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         if response.status.error_code == common_pb2.SchemaMismatch:
             schema = self.update_schema(collection_name, timeout)
             request = self._prepare_row_upsert_request(
                 collection_name, entities, partition_name, schema, timeout, **kwargs
             )
-            response = self._stub.Upsert(request=request, timeout=timeout)
+            response = self._stub.Upsert(
+                request=request, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
         check_status(response.status)
         m = MutationResult(response)
         ts_utils.update_collection_ts(collection_name, m.timestamp)
@@ -823,11 +841,13 @@ class GrpcHandler:
     ):
         try:
             if kwargs.get("_async", False):
-                future = self._stub.Search.future(request, timeout=timeout)
+                future = self._stub.Search.future(
+                    request, timeout=timeout, metadata=_api_level_md(**kwargs)
+                )
                 func = kwargs.get("_callback")
                 return SearchFuture(future, func)
 
-            response = self._stub.Search(request, timeout=timeout)
+            response = self._stub.Search(request, timeout=timeout, metadata=_api_level_md(**kwargs))
             check_status(response.status)
             round_decimal = kwargs.get("round_decimal", -1)
             return SearchResult(
@@ -846,11 +866,15 @@ class GrpcHandler:
     ):
         try:
             if kwargs.get("_async", False):
-                future = self._stub.HybridSearch.future(request, timeout=timeout)
+                future = self._stub.HybridSearch.future(
+                    request, timeout=timeout, metadata=_api_level_md(**kwargs)
+                )
                 func = kwargs.get("_callback")
                 return SearchFuture(future, func)
 
-            response = self._stub.HybridSearch(request, timeout=timeout)
+            response = self._stub.HybridSearch(
+                request, timeout=timeout, metadata=_api_level_md(**kwargs)
+            )
             check_status(response.status)
             round_decimal = kwargs.get("round_decimal", -1)
             return SearchResult(response.results, round_decimal, status=response.status)
@@ -955,8 +979,9 @@ class GrpcHandler:
     @retry_on_rpc_failure()
     def get_query_segment_info(self, collection_name: str, timeout: float = 30, **kwargs):
         req = Prepare.get_query_segment_info_request(collection_name)
-        future = self._stub.GetQuerySegmentInfo.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetQuerySegmentInfo(
+            req, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return response.infos  # todo: A wrapper class of QuerySegmentInfo
@@ -967,15 +992,15 @@ class GrpcHandler:
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.create_alias_request(collection_name, alias)
-        rf = self._stub.CreateAlias.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.CreateAlias(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
     def drop_alias(self, alias: str, timeout: Optional[float] = None, **kwargs):
         request = Prepare.drop_alias_request(alias)
-        rf = self._stub.DropAlias.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DropAlias(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -984,16 +1009,16 @@ class GrpcHandler:
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.alter_alias_request(collection_name, alias)
-        rf = self._stub.AlterAlias.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.AlterAlias(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response)
 
     @retry_on_rpc_failure()
     def describe_alias(self, alias: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(alias=alias, timeout=timeout)
         request = Prepare.describe_alias_request(alias)
-        rf = self._stub.DescribeAlias.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeAlias(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         ret = {
             "alias": alias,
@@ -1010,8 +1035,9 @@ class GrpcHandler:
         if collection_name:
             check_pass_param(collection_name=collection_name)
         request = Prepare.list_aliases_request(collection_name, kwargs.get("db_name", ""))
-        rf = self._stub.ListAliases.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.ListAliases(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         ret = {
             "aliases": [],
@@ -1041,7 +1067,9 @@ class GrpcHandler:
         index_param = Prepare.create_index_request(
             collection_name, field_name, params, index_name=index_name
         )
-        future = self._stub.CreateIndex.future(index_param, timeout=timeout)
+        future = self._stub.CreateIndex.future(
+            index_param, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
 
         if _async:
 
@@ -1052,6 +1080,7 @@ class GrpcHandler:
                         index_name=index_name,
                         timeout=timeout,
                         field_name=field_name,
+                        **kwargs,
                     )
                     if not index_success:
                         raise MilvusException(message=fail_reason)
@@ -1072,6 +1101,7 @@ class GrpcHandler:
                 index_name=index_name,
                 timeout=timeout,
                 field_name=field_name,
+                **kwargs,
             )
             if not index_success:
                 raise MilvusException(message=fail_reason)
@@ -1092,9 +1122,7 @@ class GrpcHandler:
             raise ParamError(message="properties should not be None")
 
         request = Prepare.alter_index_properties_request(collection_name, index_name, properties)
-
-        rf = self._stub.AlterIndex.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.AlterIndex(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -1110,8 +1138,7 @@ class GrpcHandler:
         request = Prepare.drop_index_properties_request(
             collection_name, index_name, delete_keys=property_keys
         )
-        rf = self._stub.AlterIndex.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.AlterIndex(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -1119,8 +1146,9 @@ class GrpcHandler:
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.describe_index_request(collection_name, "")
 
-        rf = self._stub.DescribeIndex.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeIndex(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         if is_successful(status):
             return response.index_descriptions
@@ -1140,8 +1168,9 @@ class GrpcHandler:
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.describe_index_request(collection_name, index_name, timestamp=timestamp)
 
-        rf = self._stub.DescribeIndex.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeIndex(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         if status.code == ErrorCode.INDEX_NOT_FOUND or status.error_code == Status.INDEX_NOT_EXIST:
             return None
@@ -1162,11 +1191,12 @@ class GrpcHandler:
 
     @retry_on_rpc_failure()
     def get_index_build_progress(
-        self, collection_name: str, index_name: str, timeout: Optional[float] = None
+        self, collection_name: str, index_name: str, timeout: Optional[float] = None, **kwargs
     ):
         request = Prepare.describe_index_request(collection_name, index_name)
-        rf = self._stub.DescribeIndex.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeIndex(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         if len(response.index_descriptions) == 1:
@@ -1189,8 +1219,9 @@ class GrpcHandler:
         **kwargs,
     ):
         request = Prepare.describe_index_request(collection_name, index_name, timestamp)
-        rf = self._stub.DescribeIndex.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeIndex(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
 
@@ -1258,15 +1289,18 @@ class GrpcHandler:
             load_fields,
             skip_load_dynamic_field,
         )
-        rf = self._stub.LoadCollection.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.LoadCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
         _async = kwargs.get("_async", False)
         if not _async:
-            self.wait_for_loading_collection(collection_name, timeout, is_refresh=refresh)
+            self.wait_for_loading_collection(collection_name, timeout, is_refresh=refresh, **kwargs)
 
     @retry_on_rpc_failure()
-    def load_collection_progress(self, collection_name: str, timeout: Optional[float] = None):
+    def load_collection_progress(
+        self, collection_name: str, timeout: Optional[float] = None, **kwargs
+    ):
         """Return loading progress of collection"""
         progress = self.get_loading_progress(collection_name, timeout=timeout)
         return {
@@ -1275,7 +1309,11 @@ class GrpcHandler:
 
     @retry_on_rpc_failure()
     def wait_for_loading_collection(
-        self, collection_name: str, timeout: Optional[float] = None, is_refresh: bool = False
+        self,
+        collection_name: str,
+        timeout: Optional[float] = None,
+        is_refresh: bool = False,
+        **kwargs,
     ):
         start = time.time()
 
@@ -1284,7 +1322,7 @@ class GrpcHandler:
 
         while can_loop(time.time()):
             progress = self.get_loading_progress(
-                collection_name, timeout=timeout, is_refresh=is_refresh
+                collection_name, timeout=timeout, is_refresh=is_refresh, **kwargs
             )
             if progress >= 100:
                 return
@@ -1297,8 +1335,9 @@ class GrpcHandler:
     def release_collection(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.release_collection("", collection_name)
-        rf = self._stub.ReleaseCollection.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.ReleaseCollection(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
@@ -1336,14 +1375,16 @@ class GrpcHandler:
             load_fields,
             skip_load_dynamic_field,
         )
-        future = self._stub.LoadPartitions.future(request, timeout=timeout)
+        future = self._stub.LoadPartitions.future(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
 
         if kwargs.get("_async", False):
 
             def _check():
                 if kwargs.get("sync", True):
                     self.wait_for_loading_partitions(
-                        collection_name, partition_names, is_refresh=refresh
+                        collection_name, partition_names, is_refresh=refresh, **kwargs
                     )
 
             load_partitions_future = LoadPartitionsFuture(future)
@@ -1359,7 +1400,9 @@ class GrpcHandler:
         check_status(response)
         sync = kwargs.get("sync", True)
         if sync:
-            self.wait_for_loading_partitions(collection_name, partition_names, is_refresh=refresh)
+            self.wait_for_loading_partitions(
+                collection_name, partition_names, is_refresh=refresh, **kwargs
+            )
             return None
         return None
 
@@ -1370,6 +1413,7 @@ class GrpcHandler:
         partition_names: List[str],
         timeout: Optional[float] = None,
         is_refresh: bool = False,
+        **kwargs,
     ):
         start = time.time()
 
@@ -1378,7 +1422,7 @@ class GrpcHandler:
 
         while can_loop(time.time()):
             progress = self.get_loading_progress(
-                collection_name, partition_names, timeout=timeout, is_refresh=is_refresh
+                collection_name, partition_names, timeout=timeout, is_refresh=is_refresh, **kwargs
             )
             if progress >= 100:
                 return
@@ -1394,9 +1438,12 @@ class GrpcHandler:
         partition_names: Optional[List[str]] = None,
         timeout: Optional[float] = None,
         is_refresh: bool = False,
+        **kwargs,
     ):
         request = Prepare.get_loading_progress(collection_name, partition_names)
-        response = self._stub.GetLoadingProgress.future(request, timeout=timeout).result()
+        response = self._stub.GetLoadingProgress(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         if is_refresh:
             return response.refresh_progress
@@ -1412,20 +1459,24 @@ class GrpcHandler:
     ):
         check_pass_param(db_name=db_name, timeout=timeout)
         request = Prepare.create_database_req(db_name, properties=properties)
-        status = self._stub.CreateDatabase(request, timeout=timeout)
+        status = self._stub.CreateDatabase(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
-    def drop_database(self, db_name: str, timeout: Optional[float] = None):
+    def drop_database(self, db_name: str, timeout: Optional[float] = None, **kwargs):
         request = Prepare.drop_database_req(db_name)
-        status = self._stub.DropDatabase(request, timeout=timeout)
+        status = self._stub.DropDatabase(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(status)
 
     @retry_on_rpc_failure()
-    def list_database(self, timeout: Optional[float] = None):
+    def list_database(self, timeout: Optional[float] = None, **kwargs):
         check_pass_param(timeout=timeout)
         request = Prepare.list_database_req()
-        response = self._stub.ListDatabases(request, timeout=timeout)
+        response = self._stub.ListDatabases(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         return list(response.db_names)
 
@@ -1434,7 +1485,9 @@ class GrpcHandler:
         self, db_name: str, properties: dict, timeout: Optional[float] = None, **kwargs
     ):
         request = Prepare.alter_database_properties_req(db_name, properties)
-        status = self._stub.AlterDatabase(request, timeout=timeout)
+        status = self._stub.AlterDatabase(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
@@ -1442,13 +1495,17 @@ class GrpcHandler:
         self, db_name: str, property_keys: List[str], timeout: Optional[float] = None, **kwargs
     ):
         request = Prepare.drop_database_properties_req(db_name, property_keys)
-        status = self._stub.AlterDatabase(request, timeout=timeout)
+        status = self._stub.AlterDatabase(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(status)
 
     @retry_on_rpc_failure()
-    def describe_database(self, db_name: str, timeout: Optional[float] = None):
+    def describe_database(self, db_name: str, timeout: Optional[float] = None, **kwargs):
         request = Prepare.describe_database_req(db_name=db_name)
-        resp = self._stub.DescribeDatabase(request, timeout=timeout)
+        resp = self._stub.DescribeDatabase(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return DatabaseInfo(resp).to_dict()
 
@@ -1458,18 +1515,25 @@ class GrpcHandler:
         collection_name: str,
         partition_names: Optional[List[str]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ):
         request = Prepare.get_load_state(collection_name, partition_names)
-        response = self._stub.GetLoadState.future(request, timeout=timeout).result()
+        response = self._stub.GetLoadState(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         return LoadState(response.state)
 
     @retry_on_rpc_failure()
     def load_partitions_progress(
-        self, collection_name: str, partition_names: List[str], timeout: Optional[float] = None
+        self,
+        collection_name: str,
+        partition_names: List[str],
+        timeout: Optional[float] = None,
+        **kwargs,
     ):
         """Return loading progress of partitions"""
-        progress = self.get_loading_progress(collection_name, partition_names, timeout)
+        progress = self.get_loading_progress(collection_name, partition_names, timeout, **kwargs)
         return {
             "loading_progress": f"{progress:.0f}%",
         }
@@ -1486,16 +1550,18 @@ class GrpcHandler:
             collection_name=collection_name, partition_name_array=partition_names, timeout=timeout
         )
         request = Prepare.release_partitions("", collection_name, partition_names)
-        rf = self._stub.ReleasePartitions.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.ReleasePartitions(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response)
 
     @retry_on_rpc_failure()
     def get_collection_stats(self, collection_name: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         index_param = Prepare.get_collection_stats_request(collection_name)
-        future = self._stub.GetCollectionStatistics.future(index_param, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetCollectionStatistics(
+            index_param, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return response.stats
@@ -1510,20 +1576,19 @@ class GrpcHandler:
         **kwargs,
     ):
         req = Prepare.get_flush_state_request(segment_ids, collection_name, flush_ts)
-        future = self._stub.GetFlushState.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetFlushState(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         status = response.status
         check_status(status)
         return response.flushed  # todo: A wrapper class of PersistentSegmentInfo
 
-    # TODO seem not in use
     @retry_on_rpc_failure()
     def get_persistent_segment_infos(
         self, collection_name: str, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.get_persistent_segment_info_request(collection_name)
-        future = self._stub.GetPersistentSegmentInfo.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetPersistentSegmentInfo(
+            req, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
         return response.infos  # todo: A wrapper class of PersistentSegmentInfo
 
@@ -1560,7 +1625,7 @@ class GrpcHandler:
             check_pass_param(collection_name=name)
 
         request = Prepare.flush_param(collection_names)
-        future = self._stub.Flush.future(request, timeout=timeout)
+        future = self._stub.Flush.future(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         response = future.result()
         check_status(response.status)
 
@@ -1594,22 +1659,22 @@ class GrpcHandler:
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.drop_index_request(collection_name, field_name, index_name)
-        future = self._stub.DropIndex.future(request, timeout=timeout)
-        response = future.result()
+        response = self._stub.DropIndex(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response)
 
     @retry_on_rpc_failure()
     def dummy(self, request_type: Any, timeout: Optional[float] = None, **kwargs):
         request = Prepare.dummy_request(request_type)
-        future = self._stub.Dummy.future(request, timeout=timeout)
-        return future.result()
+        return self._stub.Dummy(request, timeout=timeout, metadata=_api_level_md(**kwargs))
 
     # TODO seems not in use
     @retry_on_rpc_failure()
-    def fake_register_link(self, timeout: Optional[float] = None):
+    def fake_register_link(self, timeout: Optional[float] = None, **kwargs):
         request = Prepare.register_link_request()
-        future = self._stub.RegisterLink.future(request, timeout=timeout)
-        return future.result().status
+        response = self._stub.RegisterLink(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
+        return response.status
 
     # TODO seems not in use
     @retry_on_rpc_failure()
@@ -1620,11 +1685,11 @@ class GrpcHandler:
         output_fields: Optional[List[str]] = None,
         partition_names: Optional[List[str]] = None,
         timeout: Optional[float] = None,
+        **kwargs,
     ):
         # TODO: some check
         request = Prepare.retrieve_request(collection_name, ids, output_fields, partition_names)
-        future = self._stub.Retrieve.future(request, timeout=timeout)
-        return future.result()
+        return self._stub.Retrieve(request, timeout=timeout, metadata=_api_level_md(**kwargs))
 
     @retry_on_rpc_failure()
     def query(
@@ -1642,8 +1707,7 @@ class GrpcHandler:
             collection_name, expr, output_fields, partition_names, **kwargs
         )
 
-        future = self._stub.Query.future(request, timeout=timeout)
-        response = future.result()
+        response = self._stub.Query(request, timeout=timeout, metadata=_api_level_md(**kwargs))
         if Status.EMPTY_COLLECTION in {response.status.code, response.status.error_code}:
             return []
         check_status(response.status)
@@ -1685,8 +1749,7 @@ class GrpcHandler:
         req = Prepare.load_balance_request(
             collection_name, src_node_id, dst_node_ids, sealed_segment_ids
         )
-        future = self._stub.LoadBalance.future(req, timeout=timeout)
-        status = future.result()
+        status = self._stub.LoadBalance(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(status)
 
     @retry_on_rpc_failure()
@@ -1697,15 +1760,14 @@ class GrpcHandler:
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
+        meta = _api_level_md(**kwargs)
         # should be removed, but to be compatible with old milvus server, keep it for now.
         request = Prepare.describe_collection_request(collection_name)
-        rf = self._stub.DescribeCollection.future(request, timeout=timeout)
-        response = rf.result()
+        response = self._stub.DescribeCollection(request, timeout=timeout, metadata=meta)
         check_status(response.status)
 
         req = Prepare.manual_compaction(response.collectionID, collection_name, is_clustering)
-        future = self._stub.ManualCompaction.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.ManualCompaction(req, timeout=timeout, metadata=meta)
         check_status(response.status)
 
         return response.compactionID
@@ -1715,9 +1777,9 @@ class GrpcHandler:
         self, compaction_id: int, timeout: Optional[float] = None, **kwargs
     ) -> CompactionState:
         req = Prepare.get_compaction_state(compaction_id)
-
-        future = self._stub.GetCompactionState.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetCompactionState(
+            req, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
 
         return CompactionState(
@@ -1752,8 +1814,9 @@ class GrpcHandler:
     ) -> CompactionPlans:
         req = Prepare.get_compaction_state_with_plans(compaction_id)
 
-        future = self._stub.GetCompactionStateWithPlans.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetCompactionStateWithPlans(
+            req, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(response.status)
 
         cp = CompactionPlans(compaction_id, response.state)
@@ -1771,8 +1834,7 @@ class GrpcHandler:
         ]
 
         req = Prepare.get_replicas(collection_id)
-        future = self._stub.GetReplicas.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetReplicas(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response.status)
 
         groups = []
@@ -1801,8 +1863,7 @@ class GrpcHandler:
         ]
 
         req = Prepare.get_replicas(collection_id)
-        future = self._stub.GetReplicas.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.GetReplicas(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response.status)
 
         groups = []
@@ -1832,8 +1893,7 @@ class GrpcHandler:
         **kwargs,
     ) -> int:
         req = Prepare.do_bulk_insert(collection_name, partition_name, files, **kwargs)
-        future = self._stub.Import.future(req, timeout=timeout)
-        response = future.result()
+        response = self._stub.Import(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(response.status)
         if len(response.tasks) == 0:
             raise MilvusException(
@@ -1848,8 +1908,7 @@ class GrpcHandler:
         self, task_id: int, timeout: Optional[float] = None, **kwargs
     ) -> BulkInsertState:
         req = Prepare.get_bulk_insert_state(task_id)
-        future = self._stub.GetImportState.future(req, timeout=timeout)
-        resp = future.result()
+        resp = self._stub.GetImportState(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp.status)
         return BulkInsertState(
             task_id, resp.state, resp.row_count, resp.id_list, resp.infos, resp.create_ts
@@ -1860,8 +1919,7 @@ class GrpcHandler:
         self, limit: int, collection_name: str, timeout: Optional[float] = None, **kwargs
     ) -> list:
         req = Prepare.list_bulk_insert_tasks(limit, collection_name)
-        future = self._stub.ListImportTasks.future(req, timeout=timeout)
-        resp = future.result()
+        resp = self._stub.ListImportTasks(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp.status)
 
         return [
@@ -1873,7 +1931,7 @@ class GrpcHandler:
     def create_user(self, user: str, password: str, timeout: Optional[float] = None, **kwargs):
         check_pass_param(user=user, password=password, timeout=timeout)
         req = Prepare.create_user_request(user, password)
-        resp = self._stub.CreateCredential(req, timeout=timeout)
+        resp = self._stub.CreateCredential(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -1886,26 +1944,28 @@ class GrpcHandler:
         **kwargs,
     ):
         req = Prepare.update_password_request(user, old_password, new_password)
-        resp = self._stub.UpdateCredential(req, timeout=timeout)
+        resp = self._stub.UpdateCredential(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp)
 
     @retry_on_rpc_failure()
     def delete_user(self, user: str, timeout: Optional[float] = None, **kwargs):
         req = Prepare.delete_user_request(user)
-        resp = self._stub.DeleteCredential(req, timeout=timeout)
+        resp = self._stub.DeleteCredential(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp)
 
     @retry_on_rpc_failure()
     def list_usernames(self, timeout: Optional[float] = None, **kwargs):
         req = Prepare.list_usernames_request()
-        resp = self._stub.ListCredUsers(req, timeout=timeout)
+        resp = self._stub.ListCredUsers(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp.status)
         return resp.usernames
 
     @retry_on_rpc_failure()
     def create_role(self, role_name: str, timeout: Optional[float] = None, **kwargs):
         req = Prepare.create_role_request(role_name)
-        resp = self._stub.CreateRole(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.CreateRole(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -1913,7 +1973,9 @@ class GrpcHandler:
         self, role_name: str, force_drop: bool = False, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.drop_role_request(role_name, force_drop=force_drop)
-        resp = self._stub.DropRole(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.DropRole(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -1923,7 +1985,9 @@ class GrpcHandler:
         req = Prepare.operate_user_role_request(
             username, role_name, milvus_types.OperateUserRoleType.AddUserToRole
         )
-        resp = self._stub.OperateUserRole(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperateUserRole(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -1933,7 +1997,9 @@ class GrpcHandler:
         req = Prepare.operate_user_role_request(
             username, role_name, milvus_types.OperateUserRoleType.RemoveUserFromRole
         )
-        resp = self._stub.OperateUserRole(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperateUserRole(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -1941,14 +2007,18 @@ class GrpcHandler:
         self, role_name: str, include_user_info: bool, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.select_role_request(role_name, include_user_info)
-        resp = self._stub.SelectRole(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.SelectRole(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return RoleInfo(resp.results)
 
     @retry_on_rpc_failure()
     def select_all_role(self, include_user_info: bool, timeout: Optional[float] = None, **kwargs):
         req = Prepare.select_role_request(None, include_user_info)
-        resp = self._stub.SelectRole(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.SelectRole(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return RoleInfo(resp.results)
 
@@ -1957,14 +2027,18 @@ class GrpcHandler:
         self, username: str, include_role_info: bool, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.select_user_request(username, include_role_info)
-        resp = self._stub.SelectUser(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.SelectUser(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return UserInfo(resp.results)
 
     @retry_on_rpc_failure()
     def select_all_user(self, include_role_info: bool, timeout: Optional[float] = None, **kwargs):
         req = Prepare.select_user_request(None, include_role_info)
-        resp = self._stub.SelectUser(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.SelectUser(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return UserInfo(resp.results)
 
@@ -1987,7 +2061,9 @@ class GrpcHandler:
             db_name,
             milvus_types.OperatePrivilegeType.Grant,
         )
-        resp = self._stub.OperatePrivilege(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperatePrivilege(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2009,7 +2085,9 @@ class GrpcHandler:
             db_name,
             milvus_types.OperatePrivilegeType.Revoke,
         )
-        resp = self._stub.OperatePrivilege(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperatePrivilege(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2029,7 +2107,9 @@ class GrpcHandler:
             db_name,
             collection_name,
         )
-        resp = self._stub.OperatePrivilegeV2(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperatePrivilegeV2(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2049,7 +2129,9 @@ class GrpcHandler:
             db_name,
             collection_name,
         )
-        resp = self._stub.OperatePrivilegeV2(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperatePrivilegeV2(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2057,7 +2139,9 @@ class GrpcHandler:
         self, role_name: str, db_name: str, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.select_grant_request(role_name, None, None, db_name)
-        resp = self._stub.SelectGrant(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.SelectGrant(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return GrantInfo(resp.entities)
 
@@ -2072,21 +2156,25 @@ class GrpcHandler:
         **kwargs,
     ):
         req = Prepare.select_grant_request(role_name, object, object_name, db_name)
-        resp = self._stub.SelectGrant(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.SelectGrant(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return GrantInfo(resp.entities)
 
     @retry_on_rpc_failure()
     def get_server_version(self, timeout: Optional[float] = None, **kwargs) -> str:
         req = Prepare.get_server_version()
-        resp = self._stub.GetVersion(req, timeout=timeout)
+        resp = self._stub.GetVersion(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp.status)
         return resp.version
 
     @retry_on_rpc_failure()
     def create_resource_group(self, name: str, timeout: Optional[float] = None, **kwargs):
         req = Prepare.create_resource_group(name, **kwargs)
-        resp = self._stub.CreateResourceGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.CreateResourceGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2094,19 +2182,25 @@ class GrpcHandler:
         self, configs: Mapping[str, ResourceGroupConfig], timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.update_resource_groups(configs)
-        resp = self._stub.UpdateResourceGroups(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.UpdateResourceGroups(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
     def drop_resource_group(self, name: str, timeout: Optional[float] = None, **kwargs):
         req = Prepare.drop_resource_group(name)
-        resp = self._stub.DropResourceGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.DropResourceGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
     def list_resource_groups(self, timeout: Optional[float] = None, **kwargs):
         req = Prepare.list_resource_groups()
-        resp = self._stub.ListResourceGroups(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.ListResourceGroups(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return list(resp.resource_groups)
 
@@ -2115,7 +2209,9 @@ class GrpcHandler:
         self, name: str, timeout: Optional[float] = None, **kwargs
     ) -> ResourceGroupInfo:
         req = Prepare.describe_resource_group(name)
-        resp = self._stub.DescribeResourceGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.DescribeResourceGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return ResourceGroupInfo(resp.resource_group)
 
@@ -2124,7 +2220,9 @@ class GrpcHandler:
         self, source: str, target: str, num_node: int, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.transfer_node(source, target, num_node)
-        resp = self._stub.TransferNode(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.TransferNode(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2138,13 +2236,17 @@ class GrpcHandler:
         **kwargs,
     ):
         req = Prepare.transfer_replica(source, target, collection_name, num_replica)
-        resp = self._stub.TransferReplica(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.TransferReplica(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
     def get_flush_all_state(self, flush_all_ts: int, timeout: Optional[float] = None, **kwargs):
         req = Prepare.get_flush_all_state_request(flush_all_ts, kwargs.get("db", ""))
-        response = self._stub.GetFlushAllState(req, timeout=timeout)
+        response = self._stub.GetFlushAllState(
+            req, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         status = response.status
         check_status(status)
         return response.flushed
@@ -2166,7 +2268,9 @@ class GrpcHandler:
     @retry_on_rpc_failure()
     def flush_all(self, timeout: Optional[float] = None, **kwargs):
         request = Prepare.flush_all_request(kwargs.get("db", ""))
-        future = self._stub.FlushAll.future(request, timeout=timeout)
+        future = self._stub.FlushAll.future(
+            request, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         response = future.result()
         check_status(response.status)
 
@@ -2196,9 +2300,9 @@ class GrpcHandler:
 
     @retry_on_rpc_failure()
     @ignore_unimplemented(0)
-    def alloc_timestamp(self, timeout: Optional[float] = None) -> int:
+    def alloc_timestamp(self, timeout: Optional[float] = None, **kwargs) -> int:
         request = milvus_types.AllocTimestampRequest()
-        response = self._stub.AllocTimestamp(request, timeout=timeout)
+        response = self._stub.AllocTimestamp(request, timeout=timeout, metadata=_api_level_md())
         check_status(response.status)
         return response.timestamp
 
@@ -2207,19 +2311,25 @@ class GrpcHandler:
         self, privilege_group: str, timeout: Optional[float] = None, **kwargs
     ):
         req = Prepare.create_privilege_group_req(privilege_group)
-        resp = self._stub.CreatePrivilegeGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.CreatePrivilegeGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
     def drop_privilege_group(self, privilege_group: str, timeout: Optional[float] = None, **kwargs):
         req = Prepare.drop_privilege_group_req(privilege_group)
-        resp = self._stub.DropPrivilegeGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.DropPrivilegeGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
     def list_privilege_groups(self, timeout: Optional[float] = None, **kwargs):
         req = Prepare.list_privilege_groups_req()
-        resp = self._stub.ListPrivilegeGroups(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.ListPrivilegeGroups(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp.status)
         return PrivilegeGroupInfo(resp.privilege_groups)
 
@@ -2230,7 +2340,9 @@ class GrpcHandler:
         req = Prepare.operate_privilege_group_req(
             privilege_group, privileges, milvus_types.OperatePrivilegeGroupType.AddPrivilegesToGroup
         )
-        resp = self._stub.OperatePrivilegeGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperatePrivilegeGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2242,7 +2354,9 @@ class GrpcHandler:
             privileges,
             milvus_types.OperatePrivilegeGroupType.RemovePrivilegesFromGroup,
         )
-        resp = self._stub.OperatePrivilegeGroup(req, wait_for_ready=True, timeout=timeout)
+        resp = self._stub.OperatePrivilegeGroup(
+            req, wait_for_ready=True, timeout=timeout, metadata=_api_level_md(**kwargs)
+        )
         check_status(resp)
 
     @retry_on_rpc_failure()
@@ -2259,7 +2373,7 @@ class GrpcHandler:
         req = Prepare.run_analyzer(
             texts, analyzer_params, with_hash=with_hash, with_detail=with_detail
         )
-        resp = self._stub.RunAnalyzer(req, timeout=timeout)
+        resp = self._stub.RunAnalyzer(req, timeout=timeout, metadata=_api_level_md(**kwargs))
         check_status(resp.status)
 
         if isinstance(texts, str):

--- a/pymilvus/client/interceptor.py
+++ b/pymilvus/client/interceptor.py
@@ -13,9 +13,18 @@
 # limitations under the License.
 """Base class for interceptors that operate on all RPC types."""
 
-from typing import Any, Callable, List, NamedTuple
+from typing import Any, Callable, List, NamedTuple, Optional, Tuple
 
 import grpc
+
+
+def _api_level_md(**kwargs) -> Optional[List[Tuple]]:
+    metadata = None
+    client_request_id = kwargs.get("client-request-id", kwargs.get("client_request_id"))
+    if client_request_id:
+        metadata = metadata if metadata else []
+        metadata.append(("client-request-id", client_request_id))
+    return metadata
 
 
 class _GenericClientInterceptor(

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -168,11 +168,8 @@ def tracing_request():
         @functools.wraps(func)
         def handler(self: Callable, *args, **kwargs):
             level = kwargs.get("log-level", kwargs.get("log_level"))
-            req_id = kwargs.get("client-request-id", kwargs.get("client_request_id"))
             if level:
                 self.set_onetime_loglevel(level)
-            if req_id:
-                self.set_onetime_request_id(req_id)
             return func(self, *args, **kwargs)
 
         return handler


### PR DESCRIPTION
client-request-id is used to trace each API, and unique for each API. The previous code resets the channel for every API call to set it into global channel interceptor, which has great performance down and also will rewrite each other.

This PR adds client-request-id to per API metadata, and remove some of the future calls.

See also: milvus-io#2761, milvus-io#2765, milvus-io#2766