### PR TITLE
fix: remove default replica_number in load_collection

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -819,7 +819,7 @@ class AsyncGrpcHandler:
     async def load_partitions(
         self,
         collection_name: str,
-        partition_names: Union[str, List[str]],
+        partition_names: List[str],
         replica_number: Optional[int] = None,
         timeout: Optional[float] = None,
         **kwargs,

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1239,23 +1239,39 @@ class Prepare:
     @classmethod
     def load_collection(
         cls,
-        db_name: str,
         collection_name: str,
-        replica_number: int,
-        refresh: bool,
-        resource_groups: List[str],
-        load_fields: List[str],
-        skip_load_dynamic_field: bool,
+        replica_number: Optional[int] = None,
+        **kwargs,
     ):
-        return milvus_types.LoadCollectionRequest(
-            db_name=db_name,
+        check_pass_param(collection_name=collection_name)
+        req = milvus_types.LoadCollectionRequest(
             collection_name=collection_name,
-            replica_number=replica_number,
-            refresh=refresh,
-            resource_groups=resource_groups,
-            load_fields=load_fields,
-            skip_load_dynamic_field=skip_load_dynamic_field,
         )
+
+        if replica_number:
+            check_pass_param(replica_number=replica_number)
+            req.replica_number = replica_number
+
+        # Keep underscore key for backward compatibility
+        if "refresh" in kwargs or "_refresh" in kwargs:
+            refresh = kwargs.get("refresh", kwargs.get("_refresh", False))
+            req.refresh = refresh
+
+        if "resource_groups" in kwargs or "_resource_groups" in kwargs:
+            resource_groups = kwargs.get("resource_groups", kwargs.get("_resource_groups"))
+            req.resource_groups = resource_groups
+
+        if "load_fields" in kwargs or "_load_fields" in kwargs:
+            load_fields = kwargs.get("load_fields", kwargs.get("_load_fields"))
+            req.load_fields = load_fields
+
+        if "skip_load_dynamic_field" in kwargs or "_skip_load_dynamic_field" in kwargs:
+            skip_load_dynamic_field = kwargs.get(
+                "skip_load_dynamic_field", kwargs.get("_skip_load_dynamic_field", False)
+            )
+            req.skip_load_dynamic_field = skip_load_dynamic_field
+
+        return req
 
     @classmethod
     def release_collection(cls, db_name: str, collection_name: str):
@@ -1266,25 +1282,43 @@ class Prepare:
     @classmethod
     def load_partitions(
         cls,
-        db_name: str,
         collection_name: str,
         partition_names: List[str],
-        replica_number: int,
-        refresh: bool,
-        resource_groups: List[str],
-        load_fields: List[str],
-        skip_load_dynamic_field: bool,
+        replica_number: Optional[int] = None,
+        **kwargs,
     ):
-        return milvus_types.LoadPartitionsRequest(
-            db_name=db_name,
+        check_pass_param(collection_name=collection_name)
+        req = milvus_types.LoadPartitionsRequest(
             collection_name=collection_name,
-            partition_names=partition_names,
-            replica_number=replica_number,
-            refresh=refresh,
-            resource_groups=resource_groups,
-            load_fields=load_fields,
-            skip_load_dynamic_field=skip_load_dynamic_field,
         )
+
+        if partition_names:
+            check_pass_param(partition_name_array=partition_names)
+            req.partition_names.extend(partition_names)
+
+        if replica_number:
+            check_pass_param(replica_number=replica_number)
+            req.replica_number = replica_number
+
+        # Keep underscore key for backward compatibility
+        if "refresh" in kwargs or "_refresh" in kwargs:
+            refresh = kwargs.get("refresh", kwargs.get("_refresh", False))
+            req.refresh = refresh
+
+        if "resource_groups" in kwargs or "_resource_groups" in kwargs:
+            resource_groups = kwargs.get("resource_groups", kwargs.get("_resource_groups"))
+            req.resource_groups = resource_groups
+
+        if "load_fields" in kwargs or "_load_fields" in kwargs:
+            load_fields = kwargs.get("load_fields", kwargs.get("_load_fields"))
+            req.load_fields = load_fields
+
+        if "skip_load_dynamic_field" in kwargs or "_skip_load_dynamic_field" in kwargs:
+            skip_load_dynamic_field = kwargs.get(
+                "skip_load_dynamic_field", kwargs.get("_skip_load_dynamic_field", False)
+            )
+            req.skip_load_dynamic_field = skip_load_dynamic_field
+        return req
 
     @classmethod
     def release_partitions(cls, db_name: str, collection_name: str, partition_names: List[str]):

--- a/pymilvus/orm/collection.py
+++ b/pymilvus/orm/collection.py
@@ -374,7 +374,7 @@ class Collection:
     def load(
         self,
         partition_names: Optional[list] = None,
-        replica_number: int = 0,
+        replica_number: Optional[int] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -382,7 +382,7 @@ class Collection:
 
         Args:
             partition_names (``List[str]``): The specified partitions to load.
-            replica_number (``int``, optional): The replica number to load, defaults to 1.
+            replica_number (``int``, optional): The replica number to load, defaults to None.
             timeout (float, optional): an optional duration of time in seconds to allow
                 for the RPCs. If timeout is not set, the client keeps waiting until the
                 server responds or an error occurs.

--- a/pymilvus/orm/partition.py
+++ b/pymilvus/orm/partition.py
@@ -173,11 +173,11 @@ class Partition:
         conn = self._get_connection()
         return conn.drop_partition(self._collection.name, self.name, timeout=timeout, **kwargs)
 
-    def load(self, replica_number: int = 0, timeout: Optional[float] = None, **kwargs):
+    def load(self, replica_number: Optional[int] = None, timeout: Optional[float] = None, **kwargs):
         """Load the partition data into memory.
 
         Args:
-            replica_number (``int``, optional): The replica number to load, defaults to 1.
+            replica_number (``int``, optional): The replica number to load, defaults to None.
             timeout (``float``, optional): an optional duration of time in seconds to allow
                 for the RPCs. If timeout is not set, the client keeps waiting until the
                 server responds or an error occurs.


### PR DESCRIPTION
The default value should be decided in the server side

See also: #2781, milvus-io/milvus#41673