### PR TITLE
fix: [cp25]avoid collision on aliases in MilvusClient (#2716)

### DIFF
--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -909,7 +909,7 @@ class MilvusClient:
     ) -> str:
         """Create the connection to the Milvus server."""
         # TODO: Implement reuse with new uri style
-        using = uuid4().hex
+        using = kwargs.pop("alias", None) or uuid4().hex
         try:
             connections.connect(using, user, password, db_name, token, uri=uri, **kwargs)
         except Exception as ex:


### PR DESCRIPTION
This PR handles the #2715

It ensures that only one alias is used when calling connections.connect within the milvus client. This will allow users to create milvus connections to multiple milvus instances in the same context without worrying about collisions on aliases.