### PR TITLE
Fixes hasattr checks against Hit for missing attributes

### DIFF
--- a/pymilvus/client/search_result.py
+++ b/pymilvus/client/search_result.py
@@ -392,7 +392,10 @@ class Hit(UserDict):
         if item == "entity":
             return self
 
-        return self.__getitem__(item)
+        try:
+            return self.__getitem__(item)
+        except KeyError as exc:
+            raise AttributeError from exc
 
     def to_dict(self) -> Dict[str, Any]:
         """Patch for orm, will be deprecated soon"""

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -21,6 +21,9 @@ class TestHit:
         assert h.score == h.distance == h["distance"] == h.get("distance") == pk_dist["distance"]
         assert h.entity == h
         assert h["entity"] == h.get("entity") == {}
+        assert hasattr(h, "id") is True
+        assert hasattr(h, "distance") is True
+        assert hasattr(h, "a_random_attribute") is False
 
     @pytest.mark.parametrize("pk_dist_fields", [
         {"id": 1, "distance": 0.1, "entity": {"vector": [1., 2., 3., 4.],  "description": "This is a test", 'd_a': "dynamic a"}},
@@ -38,10 +41,16 @@ class TestHit:
         assert h.distance == h.get("distance") == h["distance"]
         assert h.entity == pk_dist_fields
         assert pk_dist_fields["entity"] == h.get("entity")==h["entity"]
+        assert hasattr(h, "id") is True
+        assert hasattr(h, "distance") is True
 
         # dynamic attributes
         assert h.description == pk_dist_fields["entity"].get("description")
         assert h.vector == pk_dist_fields["entity"].get("vector")
+        assert hasattr(h, "description") is True
+        assert hasattr(h, "vector") is True
+
+        assert hasattr(h, "a_random_attribute") is False
 
         with pytest.raises(Exception):
             h.field_not_exits


### PR DESCRIPTION
## The problem
`hasattr` calls against `Hit` instances fail with `KeyError`.

### How to replicate
```python
>>> res = {
...   "my_id": 1,
...   "distance": 0.3
... }
>>> h = Hit(res, pk_name="my_id")

>>> hasattr(h, 'my_id')
True

>>> hasattr(h, '__pydantic_decorators__')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.12/site-packages/pymilvus/client/search_result.py", line 389, in __getattr__
    return self.__getitem__(item)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pymilvus/client/search_result.py", line 425, in __getitem__
    return self.data["entity"][key]
           ~~~~~~~~~^^^^^^^^^^
KeyError: 'entity'
```

## Root cause

The current implementation of `Hit.__getattr__` raises `KeyError` when a requested key does not exist. But the only exception that is expected is `AttributeError` (see [`hasattr` docs](https://docs.python.org/3/library/functions.html#getattr)).

This is especially crucial because `pydantic` library uses `hasattr(instance, '__pydantic_decorators__')` call for its needs. And I was “lucky” to get there when I tried to use `llama-index` instrumentation with data originating from Milvus.