### PR TITLE
fix: [cp25]MilvusClient misusage of disconnect

### DIFF
--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -571,7 +571,7 @@ class AsyncMilvusClient:
         return index_params
 
     async def close(self):
-        await connections.async_disconnect(self._using)
+        await connections.async_remove_connection(self._using)
 
     def _get_connection(self):
         return connections._fetch_handler(self._using)

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -893,7 +893,7 @@ class MilvusClient:
             self.load_collection(collection_name, timeout=timeout)
 
     def close(self):
-        connections.disconnect(self._using)
+        connections.remove_connection(self._using)
 
     def _get_connection(self):
         return connections._fetch_handler(self._using)

--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -292,6 +292,10 @@ class Connections(metaclass=SingleInstanceMetaClass):
         if alias in self._connected_alias:
             await self._connected_alias.pop(alias).close()
 
+    async def async_remove_connection(self, alias: str):
+        self.async_disconnect(alias)
+        self._alias.pop(alias, None)
+
     def remove_connection(self, alias: str):
         """Removes connection from the registry.
 


### PR DESCRIPTION
To remove a one-time connection, we need to call
remove_connection instead of disconnect