### PR TITLE
fix: [2.5]add retry in compact for compatibility with old Milvus server in order to reduce describecollection

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1725,15 +1725,18 @@ class GrpcHandler:
         **kwargs,
     ) -> int:
         meta = _api_level_md(**kwargs)
-        # should be removed, but to be compatible with old milvus server, keep it for now.
-        request = Prepare.describe_collection_request(collection_name)
-        response = self._stub.DescribeCollection(request, timeout=timeout, metadata=meta)
-        check_status(response.status)
-
-        req = Prepare.manual_compaction(response.collectionID, collection_name, is_clustering)
+        # try with only collection_name
+        req = Prepare.manual_compaction(None, collection_name, is_clustering)
         response = self._stub.ManualCompaction(req, timeout=timeout, metadata=meta)
-        check_status(response.status)
+        if response.status.error_code == common_pb2.CollectionNameNotFound:
+            # should be removed, but to be compatible with old milvus server, keep it for now.
+            request = Prepare.describe_collection_request(collection_name)
+            response = self._stub.DescribeCollection(request, timeout=timeout, metadata=meta)
+            check_status(response.status)
 
+            req = Prepare.manual_compaction(response.collectionID, collection_name, is_clustering)
+            response = self._stub.ManualCompaction(req, timeout=timeout, metadata=meta)
+        check_status(response.status)
         return response.compactionID
 
     @retry_on_rpc_failure()


### PR DESCRIPTION
add retry compact for for compatibility with old Milvus server in order to reduce describecollection
issue: https://github.com/milvus-io/pymilvus/issues/2839
master:https://github.com/milvus-io/pymilvus/pull/2840