### PR TITLE
fix: remove validation for collection_id in manual_compaction method

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1466,9 +1466,6 @@ class Prepare:
 
     @classmethod
     def manual_compaction(cls, collection_id: int, collection_name: str, is_clustering: bool):
-        if collection_id is None or not isinstance(collection_id, int):
-            raise ParamError(message=f"collection_id value {collection_id} is illegal")
-
         if is_clustering is None or not isinstance(is_clustering, bool):
             raise ParamError(message=f"is_clustering value {is_clustering} is illegal")
 


### PR DESCRIPTION
fix: remove validation for collection_id in manual_compaction method
issue: https://github.com/milvus-io/pymilvus/issues/2839