### PR TITLE
fix: Fix the existing version fmt

### DIFF
--- a/_version_helper.py
+++ b/_version_helper.py
@@ -44,7 +44,7 @@ def parse(root: str, config: Configuration) -> ScmVersion | None:
             if parsed is not None:
                 return parsed
 
-fmt = "{guessed}.rc{distance}"
+fmt = "{guessed}rc{distance}" # align with PEP440 public version that has no dot before rc
 
 def custom_version(version: ScmVersion) -> str:
     if version.exact:


### PR DESCRIPTION
This won't influence any output dev package name
As no dot is the standard and every time this's fixed by python build system