### PR TITLE
feat: add detailed traceback to error_handler decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ uv.lock
 
 # AI rules
 WARP.md
+CLAUDE.md

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -3,6 +3,7 @@ import datetime
 import functools
 import logging
 import time
+import traceback
 from typing import Any, Callable, Optional
 
 import grpc
@@ -216,25 +217,37 @@ def error_handler(func_name: str = ""):
                     return await func(*args, **kwargs)
                 except MilvusException as e:
                     record_dict["RPC error"] = str(datetime.datetime.now())
-                    LOGGER.error(f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>")
+                    tb_str = traceback.format_exc()
+                    LOGGER.error(
+                        f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>\n"
+                        f"Traceback:\n{tb_str}"
+                    )
                     raise e from e
                 except grpc.FutureTimeoutError as e:
                     record_dict["gRPC timeout"] = str(datetime.datetime.now())
+                    tb_str = traceback.format_exc()
                     LOGGER.error(
                         f"grpc Timeout: [{inner_name}], <{e.__class__.__name__}: "
-                        f"{e.code()}, {e.details()}>, <Time:{record_dict}>"
+                        f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
+                        f"Traceback:\n{tb_str}"
                     )
                     raise e from e
                 except grpc.RpcError as e:
                     record_dict["gRPC error"] = str(datetime.datetime.now())
+                    tb_str = traceback.format_exc()
                     LOGGER.error(
                         f"grpc RpcError: [{inner_name}], <{e.__class__.__name__}: "
-                        f"{e.code()}, {e.details()}>, <Time:{record_dict}>"
+                        f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
+                        f"Traceback:\n{tb_str}"
                     )
                     raise e from e
                 except Exception as e:
                     record_dict["Exception"] = str(datetime.datetime.now())
-                    LOGGER.error(f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>")
+                    tb_str = traceback.format_exc()
+                    LOGGER.error(
+                        f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>\n"
+                        f"Traceback:\n{tb_str}"
+                    )
                     raise MilvusException(message=f"Unexpected error, message=<{e!s}>") from e
 
             return async_handler
@@ -250,25 +263,37 @@ def error_handler(func_name: str = ""):
                 return func(*args, **kwargs)
             except MilvusException as e:
                 record_dict["RPC error"] = str(datetime.datetime.now())
-                LOGGER.error(f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>")
+                tb_str = traceback.format_exc()
+                LOGGER.error(
+                    f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>\n"
+                    f"Traceback:\n{tb_str}"
+                )
                 raise e from e
             except grpc.FutureTimeoutError as e:
                 record_dict["gRPC timeout"] = str(datetime.datetime.now())
+                tb_str = traceback.format_exc()
                 LOGGER.error(
                     f"grpc Timeout: [{inner_name}], <{e.__class__.__name__}: "
-                    f"{e.code()}, {e.details()}>, <Time:{record_dict}>"
+                    f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
+                    f"Traceback:\n{tb_str}"
                 )
                 raise e from e
             except grpc.RpcError as e:
                 record_dict["gRPC error"] = str(datetime.datetime.now())
+                tb_str = traceback.format_exc()
                 LOGGER.error(
                     f"grpc RpcError: [{inner_name}], <{e.__class__.__name__}: "
-                    f"{e.code()}, {e.details()}>, <Time:{record_dict}>"
+                    f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
+                    f"Traceback:\n{tb_str}"
                 )
                 raise e from e
             except Exception as e:
                 record_dict["Exception"] = str(datetime.datetime.now())
-                LOGGER.error(f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>")
+                tb_str = traceback.format_exc()
+                LOGGER.error(
+                    f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>\n"
+                    f"Traceback:\n{tb_str}"
+                )
                 raise MilvusException(message=f"Unexpected error, message=<{e!s}>") from e
 
         return handler


### PR DESCRIPTION

Enhanced the error_handler decorator to capture and log complete stack traces for all exception types (MilvusException, grpc errors, and general exceptions). This improves debugging by showing the exact location where errors originate, rather than just the decorator wrapper location.

Also added CLAUDE.md to .gitignore to keep AI-specific documentation local.