### PR TITLE
fix: fix return empty array with STRUCT field

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -1033,18 +1033,30 @@ def extract_row_data_from_fields_data(
 
 def get_array_length(array_item: Any) -> int:
     """Get the length of an array field from its data."""
-    if hasattr(array_item, "string_data") and array_item.string_data:
-        return len(array_item.string_data.data)
-    if hasattr(array_item, "int_data") and array_item.int_data:
-        return len(array_item.int_data.data)
-    if hasattr(array_item, "long_data") and array_item.long_data:
-        return len(array_item.long_data.data)
-    if hasattr(array_item, "float_data") and array_item.float_data:
-        return len(array_item.float_data.data)
-    if hasattr(array_item, "double_data") and array_item.double_data:
-        return len(array_item.double_data.data)
-    if hasattr(array_item, "bool_data") and array_item.bool_data:
-        return len(array_item.bool_data.data)
+    if hasattr(array_item, "string_data") and hasattr(array_item.string_data, "data"):
+        length = len(array_item.string_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "int_data") and hasattr(array_item.int_data, "data"):
+        length = len(array_item.int_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "long_data") and hasattr(array_item.long_data, "data"):
+        length = len(array_item.long_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "float_data") and hasattr(array_item.float_data, "data"):
+        length = len(array_item.float_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "double_data") and hasattr(array_item.double_data, "data"):
+        length = len(array_item.double_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "bool_data") and hasattr(array_item.bool_data, "data"):
+        length = len(array_item.bool_data.data)
+        if length > 0:
+            return length
     return 0
 
 
@@ -1052,38 +1064,38 @@ def get_array_value_at_index(array_item: Any, idx: int) -> Any:
     """Get the value at a specific index from an array field."""
     if (
         hasattr(array_item, "string_data")
-        and array_item.string_data
-        and idx < len(array_item.string_data.data)
+        and hasattr(array_item.string_data, "data")
+        and len(array_item.string_data.data) > idx
     ):
         return array_item.string_data.data[idx]
     if (
         hasattr(array_item, "int_data")
-        and array_item.int_data
-        and idx < len(array_item.int_data.data)
+        and hasattr(array_item.int_data, "data")
+        and len(array_item.int_data.data) > idx
     ):
         return array_item.int_data.data[idx]
     if (
         hasattr(array_item, "long_data")
-        and array_item.long_data
-        and idx < len(array_item.long_data.data)
+        and hasattr(array_item.long_data, "data")
+        and len(array_item.long_data.data) > idx
     ):
         return array_item.long_data.data[idx]
     if (
         hasattr(array_item, "float_data")
-        and array_item.float_data
-        and idx < len(array_item.float_data.data)
+        and hasattr(array_item.float_data, "data")
+        and len(array_item.float_data.data) > idx
     ):
         return array_item.float_data.data[idx]
     if (
         hasattr(array_item, "double_data")
-        and array_item.double_data
-        and idx < len(array_item.double_data.data)
+        and hasattr(array_item.double_data, "data")
+        and len(array_item.double_data.data) > idx
     ):
         return array_item.double_data.data[idx]
     if (
         hasattr(array_item, "bool_data")
-        and array_item.bool_data
-        and idx < len(array_item.bool_data.data)
+        and hasattr(array_item.bool_data, "data")
+        and len(array_item.bool_data.data) > idx
     ):
         return array_item.bool_data.data[idx]
     return None


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/42148

If output_field is non-string element type, the empty array is returned such as :

```
============== Search with element filter 3 (EmbeddingList with 2 embeddings of 
dimension 32 (float32)) - Total hits: 3
    {'id': 462182756501698654, 'distance': -0.10249601304531097, 'entity': {'struct_field': []}}
    {'id': 462182756501698627, 'distance': -0.10412182658910751, 'entity': {'struct_field': []}}
    {'id': 462182756501698675, 'distance': -0.11959204822778702, 'entity': {'struct_field': []}}
```

This PR fixes this.