### PR TITLE
fix: AsyncMilvusClient.search support EmbeddingList

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -35,6 +35,7 @@ from .check import (
     is_legal_port,
 )
 from .constants import ITERATOR_SESSION_TS_FIELD
+from .embedding_list import EmbeddingList
 from .interceptor import _api_level_md
 from .prepare import Prepare
 from .search_result import SearchResult
@@ -842,6 +843,12 @@ class AsyncGrpcHandler:
             guarantee_timestamp=kwargs.get("guarantee_timestamp"),
             timeout=timeout,
         )
+
+        # Convert EmbeddingList to flat array if present
+        if isinstance(data, list) and len(data) > 0 and isinstance(data[0], EmbeddingList):
+            data = [emb_list.to_flat_array() for emb_list in data]
+            kwargs["is_embedding_list"] = True
+
         request = Prepare.search_requests_with_expr(
             collection_name,
             data,
@@ -882,9 +889,16 @@ class AsyncGrpcHandler:
 
         requests = []
         for req in reqs:
+            data = req.data
+            req_kwargs = dict(kwargs)
+            # Convert EmbeddingList to flat array if present
+            if isinstance(data, list) and len(data) > 0 and isinstance(data[0], EmbeddingList):
+                data = [emb_list.to_flat_array() for emb_list in data]
+                req_kwargs["is_embedding_list"] = True
+
             search_request = Prepare.search_requests_with_expr(
                 collection_name,
-                req.data,
+                data,
                 req.anns_field,
                 req.param,
                 req.limit,
@@ -892,7 +906,7 @@ class AsyncGrpcHandler:
                 partition_names=partition_names,
                 round_decimal=round_decimal,
                 expr_params=req.expr_params,
-                **kwargs,
+                **req_kwargs,
             )
             requests.append(search_request)
 

--- a/pymilvus/client/check.py
+++ b/pymilvus/client/check.py
@@ -205,6 +205,11 @@ def is_legal_search_data(data: Any) -> bool:
     if entity_helper.entity_is_sparse_matrix(data):
         return True
 
+    # Support EmbeddingList for array-of-vector searches
+    # Check for EmbeddingList by type name to avoid circular dependency
+    if isinstance(data, list) and len(data) > 0 and type(data[0]).__name__ == "EmbeddingList":
+        return True
+
     if not isinstance(data, (list, np.ndarray)):
         return False
 


### PR DESCRIPTION
Convert EmbeddingList to flat array in search() and hybrid_search() before calling Prepare(just like the sync client). Enhance is_legal_search_data() to recognize EmbeddingList.

Add unit tests for search and hybrid_search with EmbeddingList.
also see https://github.com/milvus-io/pymilvus/issues/3059