### PR TITLE
[cherry-pick]fix: AsyncMilvusClient.search support EmbeddingList (#3101)

### DIFF
--- a/pymilvus/client/check.py
+++ b/pymilvus/client/check.py
@@ -205,6 +205,11 @@ def is_legal_search_data(data: Any) -> bool:
     if entity_helper.entity_is_sparse_matrix(data):
         return True
 
+    # Support EmbeddingList for array-of-vector searches
+    # Check for EmbeddingList by type name to avoid circular dependency
+    if isinstance(data, list) and len(data) > 0 and type(data[0]).__name__ == "EmbeddingList":
+        return True
+
     if not isinstance(data, (list, np.ndarray)):
         return False
 


### PR DESCRIPTION
cherry-pick #3101 
Convert EmbeddingList to flat array in search() and hybrid_search() before calling Prepare(just like the sync client). Enhance is_legal_search_data() to recognize EmbeddingList.

Add unit tests for search and hybrid_search with EmbeddingList. also see https://github.com/milvus-io/pymilvus/issues/3059



(cherry picked from commit ddff574c534c860778c11da39493812306e74d14)