### PR TITLE
feat: Support nullable vectors in Python SDK

### DIFF
--- a/examples/nullable_vector.py
+++ b/examples/nullable_vector.py
@@ -1,0 +1,314 @@
+import numpy as np
+import ml_dtypes
+
+from pymilvus import (
+    connections,
+    Collection,
+    FieldSchema,
+    CollectionSchema,
+    DataType,
+    utility,
+    MilvusClient,
+)
+
+DIM = 4
+
+def gen_float_vector(dim):
+    return np.random.rand(dim).astype(np.float32)
+
+
+def gen_binary_vector(dim):
+    return np.packbits(np.random.randint(0, 2, dim), axis=-1).tobytes()
+
+
+def gen_fp16_vector(dim):
+    return np.random.rand(dim).astype(np.float16)
+
+
+def gen_bf16_vector(dim):
+    return np.random.rand(dim).astype(ml_dtypes.bfloat16)
+
+
+def gen_sparse_vector():
+    dim = np.random.randint(2, 20)
+    return {i: float(np.random.rand()) for i in range(dim)}
+
+
+def gen_int8_vector(dim):
+    return np.random.randint(-128, 127, dim, dtype=np.int8)
+
+
+def vectors_equal(v1, v2, vtype_name):
+    if v1 is None and v2 is None:
+        return True
+    if v1 is None or v2 is None:
+        return False
+
+    if vtype_name == "sparse_float_vector":
+        if set(v1.keys()) != set(v2.keys()):
+            return False
+        return all(abs(v1[k] - v2[k]) < 1e-5 for k in v1.keys())
+    elif vtype_name == "binary_vector":
+        b1 = v1[0] if isinstance(v1, list) else v1
+        b2 = v2[0] if isinstance(v2, list) else v2
+        return b1 == b2
+    elif vtype_name in ("float16_vector", "bfloat16_vector"):
+        dtype = np.float16 if vtype_name == "float16_vector" else ml_dtypes.bfloat16
+        def to_array(v):
+            if isinstance(v, list) and len(v) == 1:
+                v = v[0]
+            if isinstance(v, bytes):
+                return np.frombuffer(v, dtype=dtype)
+            return np.asarray(v, dtype=dtype)
+        return np.allclose(to_array(v1).astype(np.float32), to_array(v2).astype(np.float32), rtol=1e-2)
+    elif vtype_name == "int8_vector":
+        def to_array(v):
+            if isinstance(v, list) and len(v) == 1:
+                v = v[0]
+            if isinstance(v, bytes):
+                return np.frombuffer(v, dtype=np.int8)
+            return np.asarray(v, dtype=np.int8)
+        return np.array_equal(to_array(v1), to_array(v2))
+    else:
+        return np.allclose(np.asarray(v1), np.asarray(v2), rtol=1e-3)
+
+
+connections.connect("default", host="localhost", port="19530")
+
+VECTOR_TYPES = [
+    {
+        "name": "float_vector",
+        "dtype": DataType.FLOAT_VECTOR,
+        "dim": DIM,
+        "gen_vector": lambda: gen_float_vector(DIM),
+        "index_params": {"metric_type": "L2", "index_type": "FLAT", "params": {}},
+    },
+    {
+        "name": "binary_vector",
+        "dtype": DataType.BINARY_VECTOR,
+        "dim": DIM * 8,
+        "gen_vector": lambda: gen_binary_vector(DIM * 8),
+        "index_params": {"metric_type": "HAMMING", "index_type": "BIN_FLAT", "params": {}},
+    },
+    {
+        "name": "float16_vector",
+        "dtype": DataType.FLOAT16_VECTOR,
+        "dim": DIM,
+        "gen_vector": lambda: gen_fp16_vector(DIM),
+        "index_params": {"metric_type": "L2", "index_type": "FLAT", "params": {}},
+    },
+    {
+        "name": "bfloat16_vector",
+        "dtype": DataType.BFLOAT16_VECTOR,
+        "dim": DIM,
+        "gen_vector": lambda: gen_bf16_vector(DIM),
+        "index_params": {"metric_type": "L2", "index_type": "FLAT", "params": {}},
+    },
+    {
+        "name": "sparse_float_vector",
+        "dtype": DataType.SPARSE_FLOAT_VECTOR,
+        "dim": None,
+        "gen_vector": gen_sparse_vector,
+        "index_params": {"metric_type": "IP", "index_type": "SPARSE_INVERTED_INDEX", "params": {"drop_ratio_build": 0.2}},
+    },
+    {
+        "name": "int8_vector",
+        "dtype": DataType.INT8_VECTOR,
+        "dim": DIM,
+        "gen_vector": lambda: gen_int8_vector(DIM),
+        "index_params": {"metric_type": "L2", "index_type": "HNSW", "params": {"M": 8, "efConstruction": 200}},
+    },
+]
+
+
+def test_nullable_vector(vector_config, batch_size=1000, num_batches=10, null_percent=10):
+    vtype_name = vector_config["name"]
+    dtype = vector_config["dtype"]
+    dim = vector_config["dim"]
+    gen_vector = vector_config["gen_vector"]
+    index_params = vector_config["index_params"]
+    collection_name = f"test_nullable_{vtype_name}"
+
+    print(f"\n[Test] {vtype_name} ({batch_size}x{num_batches} rows, {null_percent}% null)")
+
+    if utility.has_collection(collection_name):
+        utility.drop_collection(collection_name)
+
+    fields = [
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=False),
+        FieldSchema(name="name", dtype=DataType.VARCHAR, max_length=100),
+    ]
+    if dim is not None:
+        fields.append(FieldSchema(name="embedding", dtype=dtype, dim=dim, nullable=True))
+    else:
+        fields.append(FieldSchema(name="embedding", dtype=dtype, nullable=True))
+
+    collection = Collection(collection_name, CollectionSchema(fields))
+    collection.create_index("embedding", index_params)
+
+    expected = {}
+    current_id = 0
+
+    for batch_idx in range(num_batches):
+        data = []
+        for i in range(batch_size):
+            row_id = current_id + i
+            is_null = (row_id % 100) < null_percent
+            embedding = None if is_null else gen_vector()
+            expected[row_id] = embedding
+            data.append({"id": row_id, "name": f"row_{row_id}", "embedding": embedding})
+
+        current_id += batch_size
+        collection.insert(data)
+        collection.flush()
+        collection.load()
+
+        results = collection.query(expr="id >= 0", output_fields=["id", "embedding"], limit=current_id + 1000)
+        result_map = {row['id']: row.get('embedding') for row in results}
+
+        assert len(results) == current_id
+        for row_id, exp in expected.items():
+            actual = result_map[row_id]
+            if exp is None:
+                assert actual is None, f"id={row_id}: expected None"
+            else:
+                assert actual is not None and vectors_equal(actual, exp, vtype_name), f"id={row_id}: mismatch"
+
+        search_results = collection.search(
+            data=[gen_vector()], anns_field="embedding",
+            param={"metric_type": index_params["metric_type"]},
+            limit=min(100, current_id), output_fields=["id", "embedding"]
+        )
+        for hit in search_results[0]:
+            assert hit.entity.get('embedding') is not None
+            assert expected[hit.id] is not None
+
+        collection.release()
+        null_count = sum(1 for v in expected.values() if v is None)
+        print(f"  Batch {batch_idx+1}/{num_batches}: {len(expected)-null_count} valid, {null_count} null - OK")
+
+    utility.drop_collection(collection_name)
+    null_count = sum(1 for v in expected.values() if v is None)
+    print(f"  PASSED ({len(expected)-null_count} valid, {null_count} null)")
+    return True
+
+
+def test_add_nullable_vector_column(vector_config, initial_rows=10, new_rows=10, null_percent=50):
+    vtype_name = vector_config["name"]
+    dtype = vector_config["dtype"]
+    dim = vector_config["dim"]
+    gen_vector = vector_config["gen_vector"]
+    index_params = vector_config["index_params"]
+    collection_name = f"test_add_col_{vtype_name}"
+
+    print(f"\n[Test Add Column] {vtype_name} ({initial_rows} initial + {new_rows} new, {null_percent}% null)")
+
+    if utility.has_collection(collection_name):
+        utility.drop_collection(collection_name)
+
+    fields = [
+        FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=False),
+        FieldSchema(name="name", dtype=DataType.VARCHAR, max_length=100),
+        FieldSchema(name="base_vec", dtype=DataType.FLOAT_VECTOR, dim=4),
+    ]
+    collection = Collection(collection_name, CollectionSchema(fields))
+
+    initial_data = [
+        {"id": i, "name": f"initial_{i}", "base_vec": [float(i), float(i+1), float(i+2), float(i+3)]}
+        for i in range(initial_rows)
+    ]
+    collection.insert(initial_data)
+    collection.flush()
+
+    client = MilvusClient(uri="http://localhost:19530")
+    if dim is not None:
+        client.add_collection_field(collection_name, "embedding", dtype, dim=dim, nullable=True)
+    else:
+        client.add_collection_field(collection_name, "embedding", dtype, nullable=True)
+    collection = Collection(collection_name)
+
+    collection.create_index("base_vec", {"metric_type": "L2", "index_type": "FLAT", "params": {}})
+    collection.create_index("embedding", index_params)
+
+    expected = {i: None for i in range(initial_rows)}
+
+    data = []
+    for i in range(new_rows):
+        row_id = initial_rows + i
+        is_null = ((i * 100) // new_rows) < null_percent
+        embedding = None if is_null else gen_vector()
+        expected[row_id] = embedding
+        data.append({
+            "id": row_id, "name": f"new_{row_id}",
+            "base_vec": [float(row_id), float(row_id+1), float(row_id+2), float(row_id+3)],
+            "embedding": embedding
+        })
+
+    collection.insert(data)
+    collection.flush()
+    collection.load()
+
+    results = collection.query(expr="id >= 0", output_fields=["id", "embedding"], limit=initial_rows + new_rows + 100)
+    result_map = {row['id']: row.get('embedding') for row in results}
+
+    assert len(results) == initial_rows + new_rows
+    for row_id, exp in expected.items():
+        actual = result_map[row_id]
+        if exp is None:
+            assert actual is None, f"id={row_id}: expected None"
+        else:
+            assert actual is not None and vectors_equal(actual, exp, vtype_name), f"id={row_id}: mismatch"
+
+    valid_count = sum(1 for v in expected.values() if v is not None)
+    if valid_count > 0:
+        search_results = collection.search(
+            data=[gen_vector()], anns_field="embedding",
+            param={"metric_type": index_params["metric_type"]},
+            limit=min(100, valid_count), output_fields=["id", "embedding"]
+        )
+        for hit in search_results[0]:
+            assert hit.entity.get('embedding') is not None
+            assert expected[hit.id] is not None
+            assert hit.id >= initial_rows
+
+    collection.release()
+    utility.drop_collection(collection_name)
+    null_count = sum(1 for v in expected.values() if v is None)
+    print(f"  PASSED ({valid_count} valid, {null_count} null)")
+    return True
+
+
+def main():
+    print("Nullable Vector Test")
+
+    passed, failed = [], []
+    for config in VECTOR_TYPES:
+        try:
+            if test_nullable_vector(config):
+                passed.append(config["name"])
+            else:
+                failed.append(config["name"])
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            failed.append(config["name"])
+
+    for config in VECTOR_TYPES:
+        try:
+            if test_add_nullable_vector_column(config):
+                passed.append(f"add_col_{config['name']}")
+            else:
+                failed.append(f"add_col_{config['name']}")
+        except Exception as e:
+            print(f"  FAILED: {e}")
+            failed.append(f"add_col_{config['name']}")
+
+    print(f"\nSummary: {len(passed)} passed, {len(failed)} failed")
+    if failed:
+        print(f"Failed: {', '.join(failed)}")
+
+    connections.disconnect("default")
+    return len(failed) == 0
+
+
+if __name__ == "__main__":
+    exit(0 if main() else 1)

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -390,16 +390,20 @@ def pack_field_value_to_field_data(
             ) from e
     elif field_type == DataType.FLOAT_VECTOR:
         try:
-            f_value = field_value
-            if isinstance(field_value, np.ndarray):
-                if field_value.dtype not in ("float32", "float64"):
-                    raise ParamError(
-                        message="invalid input for float32 vector. Expected an np.ndarray with dtype=float32"
-                    )
-                f_value = field_value.tolist()
+            if field_value is None:
+                if field_data.vectors.dim == 0:
+                    field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
+            else:
+                f_value = field_value
+                if isinstance(field_value, np.ndarray):
+                    if field_value.dtype not in ("float32", "float64"):
+                        raise ParamError(
+                            message="invalid input for float32 vector. Expected an np.ndarray with dtype=float32"
+                        )
+                    f_value = field_value.tolist()
 
-            field_data.vectors.dim = len(f_value)
-            field_data.vectors.float_vector.data.extend(f_value)
+                field_data.vectors.dim = len(f_value)
+                field_data.vectors.float_vector.data.extend(f_value)
         except (TypeError, ValueError) as e:
             raise DataNotMatchException(
                 message=ExceptionsMessage.FieldDataInconsistent
@@ -408,8 +412,12 @@ def pack_field_value_to_field_data(
             ) from e
     elif field_type == DataType.BINARY_VECTOR:
         try:
-            field_data.vectors.dim = len(field_value) * 8
-            field_data.vectors.binary_vector += bytes(field_value)
+            if field_value is None:
+                if field_data.vectors.dim == 0:
+                    field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
+            else:
+                field_data.vectors.dim = len(field_value) * 8
+                field_data.vectors.binary_vector += bytes(field_value)
         except (TypeError, ValueError) as e:
             raise DataNotMatchException(
                 message=ExceptionsMessage.FieldDataInconsistent
@@ -418,21 +426,25 @@ def pack_field_value_to_field_data(
             ) from e
     elif field_type == DataType.FLOAT16_VECTOR:
         try:
-            if isinstance(field_value, bytes):
-                v_bytes = field_value
-            elif isinstance(field_value, np.ndarray):
-                if field_value.dtype != "float16":
-                    raise ParamError(
-                        message="invalid input for float16 vector. Expected an np.ndarray with dtype=float16"
-                    )
-                v_bytes = field_value.view(np.uint8).tobytes()
+            if field_value is None:
+                if field_data.vectors.dim == 0:
+                    field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             else:
-                raise ParamError(
-                    message="invalid input type for float16 vector. Expected an np.ndarray with dtype=float16"
-                )
+                if isinstance(field_value, bytes):
+                    v_bytes = field_value
+                elif isinstance(field_value, np.ndarray):
+                    if field_value.dtype != "float16":
+                        raise ParamError(
+                            message="invalid input for float16 vector. Expected an np.ndarray with dtype=float16"
+                        )
+                    v_bytes = field_value.view(np.uint8).tobytes()
+                else:
+                    raise ParamError(
+                        message="invalid input type for float16 vector. Expected an np.ndarray with dtype=float16"
+                    )
 
-            field_data.vectors.dim = len(v_bytes) // 2
-            field_data.vectors.float16_vector += v_bytes
+                field_data.vectors.dim = len(v_bytes) // 2
+                field_data.vectors.float16_vector += v_bytes
         except (TypeError, ValueError) as e:
             raise DataNotMatchException(
                 message=ExceptionsMessage.FieldDataInconsistent
@@ -441,21 +453,25 @@ def pack_field_value_to_field_data(
             ) from e
     elif field_type == DataType.BFLOAT16_VECTOR:
         try:
-            if isinstance(field_value, bytes):
-                v_bytes = field_value
-            elif isinstance(field_value, np.ndarray):
-                if field_value.dtype != "bfloat16":
-                    raise ParamError(
-                        message="invalid input for bfloat16 vector. Expected an np.ndarray with dtype=bfloat16"
-                    )
-                v_bytes = field_value.view(np.uint8).tobytes()
+            if field_value is None:
+                if field_data.vectors.dim == 0:
+                    field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             else:
-                raise ParamError(
-                    message="invalid input type for bfloat16 vector. Expected an np.ndarray with dtype=bfloat16"
-                )
+                if isinstance(field_value, bytes):
+                    v_bytes = field_value
+                elif isinstance(field_value, np.ndarray):
+                    if field_value.dtype != "bfloat16":
+                        raise ParamError(
+                            message="invalid input for bfloat16 vector. Expected an np.ndarray with dtype=bfloat16"
+                        )
+                    v_bytes = field_value.view(np.uint8).tobytes()
+                else:
+                    raise ParamError(
+                        message="invalid input type for bfloat16 vector. Expected an np.ndarray with dtype=bfloat16"
+                    )
 
-            field_data.vectors.dim = len(v_bytes) // 2
-            field_data.vectors.bfloat16_vector += v_bytes
+                field_data.vectors.dim = len(v_bytes) // 2
+                field_data.vectors.bfloat16_vector += v_bytes
         except (TypeError, ValueError) as e:
             raise DataNotMatchException(
                 message=ExceptionsMessage.FieldDataInconsistent
@@ -464,15 +480,19 @@ def pack_field_value_to_field_data(
             ) from e
     elif field_type == DataType.SPARSE_FLOAT_VECTOR:
         try:
-            if not SciPyHelper.is_scipy_sparse(field_value):
-                field_value = [field_value]
-            elif field_value.shape[0] != 1:
-                raise ParamError(message="invalid input for sparse float vector: expect 1 row")
-            if not entity_is_sparse_matrix(field_value):
-                raise ParamError(message="invalid input for sparse float vector")
-            field_data.vectors.sparse_float_vector.contents.append(
-                sparse_rows_to_proto(field_value).contents[0]
-            )
+            if field_value is None:
+                if field_data.vectors.dim == 0:
+                    field_data.vectors.dim = 0
+            else:
+                if not SciPyHelper.is_scipy_sparse(field_value):
+                    field_value = [field_value]
+                elif field_value.shape[0] != 1:
+                    raise ParamError(message="invalid input for sparse float vector: expect 1 row")
+                if not entity_is_sparse_matrix(field_value):
+                    raise ParamError(message="invalid input for sparse float vector")
+                field_data.vectors.sparse_float_vector.contents.append(
+                    sparse_rows_to_proto(field_value).contents[0]
+                )
         except (TypeError, ValueError) as e:
             raise DataNotMatchException(
                 message=ExceptionsMessage.FieldDataInconsistent
@@ -481,19 +501,23 @@ def pack_field_value_to_field_data(
             ) from e
     elif field_type == DataType.INT8_VECTOR:
         try:
-            if isinstance(field_value, np.ndarray):
-                if field_value.dtype != "int8":
+            if field_value is None:
+                if field_data.vectors.dim == 0:
+                    field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
+            else:
+                if isinstance(field_value, np.ndarray):
+                    if field_value.dtype != "int8":
+                        raise ParamError(
+                            message="invalid input for int8 vector. Expected an np.ndarray with dtype=int8"
+                        )
+                    i_bytes = field_value.view(np.int8).tobytes()
+                else:
                     raise ParamError(
                         message="invalid input for int8 vector. Expected an np.ndarray with dtype=int8"
                     )
-                i_bytes = field_value.view(np.int8).tobytes()
-            else:
-                raise ParamError(
-                    message="invalid input for int8 vector. Expected an np.ndarray with dtype=int8"
-                )
 
-            field_data.vectors.dim = len(i_bytes)
-            field_data.vectors.int8_vector += i_bytes
+                field_data.vectors.dim = len(i_bytes)
+                field_data.vectors.int8_vector += i_bytes
         except (TypeError, ValueError) as e:
             raise DataNotMatchException(
                 message=ExceptionsMessage.FieldDataInconsistent
@@ -588,23 +612,38 @@ def entity_to_field_data(entity: Dict, field_info: Any, num_rows: int) -> schema
             field_data.scalars.double_data.data.extend(entity_values)
 
         elif entity_type == DataType.FLOAT_VECTOR:
-            # TODO: get dimension from field_info
-            field_data.vectors.dim = len(entity_values[0])
+            if len(entity_values) > 0:
+                field_data.vectors.dim = len(entity_values[0])
+            else:
+                field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             all_floats = [f for vector in entity_values for f in vector]
             field_data.vectors.float_vector.data.extend(all_floats)
         elif entity_type == DataType.BINARY_VECTOR:
-            field_data.vectors.dim = len(entity_values[0]) * 8
+            if len(entity_values) > 0:
+                field_data.vectors.dim = len(entity_values[0]) * 8
+            else:
+                field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             field_data.vectors.binary_vector = b"".join(entity_values)
         elif entity_type == DataType.FLOAT16_VECTOR:
-            field_data.vectors.dim = len(entity_values[0]) // 2
+            if len(entity_values) > 0:
+                field_data.vectors.dim = len(entity_values[0]) // 2
+            else:
+                field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             field_data.vectors.float16_vector = b"".join(entity_values)
         elif entity_type == DataType.BFLOAT16_VECTOR:
-            field_data.vectors.dim = len(entity_values[0]) // 2
+            if len(entity_values) > 0:
+                field_data.vectors.dim = len(entity_values[0]) // 2
+            else:
+                field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             field_data.vectors.bfloat16_vector = b"".join(entity_values)
         elif entity_type == DataType.SPARSE_FLOAT_VECTOR:
-            field_data.vectors.sparse_float_vector.CopyFrom(sparse_rows_to_proto(entity_values))
+            if len(entity_values) > 0:
+                field_data.vectors.sparse_float_vector.CopyFrom(sparse_rows_to_proto(entity_values))
         elif entity_type == DataType.INT8_VECTOR:
-            field_data.vectors.dim = len(entity_values[0])
+            if len(entity_values) > 0:
+                field_data.vectors.dim = len(entity_values[0])
+            else:
+                field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             field_data.vectors.int8_vector = b"".join(entity_values)
 
         elif entity_type == DataType.VARCHAR:
@@ -884,6 +923,29 @@ def extract_row_data_from_fields_data(
     entity_row_data = {}
     dynamic_fields = dynamic_output_fields or set()
 
+    # Cache prefix sums by field_data id for O(1) lookup (avoids O(n) per row)
+    prefix_sum_cache: Dict[int, Any] = {}
+
+    def get_physical_index(field_data: Any, logical_index: int) -> int:
+        """Calculate physical index for nullable vectors with sparse storage.
+
+        For nullable vectors, valid_data indicates which logical positions have valid data,
+        and the actual data only contains valid values (sparse storage).
+        Uses prefix sum for O(1) lookup instead of O(n) iteration.
+        """
+        field_id = id(field_data)
+        if field_id not in prefix_sum_cache:
+            if len(field_data.valid_data) == 0:
+                prefix_sum_cache[field_id] = None
+            else:
+                prefix_sum_cache[field_id] = np.cumsum(
+                    [0] + [1 if v else 0 for v in field_data.valid_data]
+                )
+        prefix_sum = prefix_sum_cache[field_id]
+        if prefix_sum is None:
+            return logical_index
+        return int(prefix_sum[logical_index])
+
     def check_append(field_data: Any, row_data: Dict):
         if field_data.type == DataType.STRING:
             raise MilvusException(message="Not support string yet")
@@ -977,48 +1039,76 @@ def extract_row_data_from_fields_data(
             row_data[field_data.field_name] = extract_array_row_data(field_data, index)
 
         elif field_data.type == DataType.FLOAT_VECTOR:
-            dim = field_data.vectors.dim
-            if len(field_data.vectors.float_vector.data) >= index * dim:
-                start_pos, end_pos = index * dim, (index + 1) * dim
-                # Here we use numpy.array to convert the float64 values to numpy.float32 values,
-                # and return a list of numpy.float32 to users
-                # By using numpy.array, performance improved by 60% for topk=16384 dim=1536 case.
-                arr = np.array(
-                    field_data.vectors.float_vector.data[start_pos:end_pos], dtype=np.float32
-                )
-                row_data[field_data.field_name] = list(arr)
+            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+                row_data[field_data.field_name] = None
+            else:
+                dim = field_data.vectors.dim
+                phys_idx = get_physical_index(field_data, index)
+                if len(field_data.vectors.float_vector.data) >= (phys_idx + 1) * dim:
+                    start_pos, end_pos = phys_idx * dim, (phys_idx + 1) * dim
+                    # Here we use numpy.array to convert the float64 values to numpy.float32 values,
+                    # and return a list of numpy.float32 to users
+                    # By using numpy.array, performance improved by 60%
+                    # for topk=16384 dim=1536 case.
+                    arr = np.array(
+                        field_data.vectors.float_vector.data[start_pos:end_pos], dtype=np.float32
+                    )
+                    row_data[field_data.field_name] = list(arr)
         elif field_data.type == DataType.BINARY_VECTOR:
-            dim = field_data.vectors.dim
-            if len(field_data.vectors.binary_vector) >= index * (dim // 8):
-                start_pos, end_pos = index * (dim // 8), (index + 1) * (dim // 8)
-                row_data[field_data.field_name] = [
-                    field_data.vectors.binary_vector[start_pos:end_pos]
-                ]
+            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+                row_data[field_data.field_name] = None
+            else:
+                dim = field_data.vectors.dim
+                blen = dim // 8
+                phys_idx = get_physical_index(field_data, index)
+                if len(field_data.vectors.binary_vector) >= (phys_idx + 1) * blen:
+                    start_pos, end_pos = phys_idx * blen, (phys_idx + 1) * blen
+                    row_data[field_data.field_name] = [
+                        field_data.vectors.binary_vector[start_pos:end_pos]
+                    ]
         elif field_data.type == DataType.BFLOAT16_VECTOR:
-            dim = field_data.vectors.dim
-            if len(field_data.vectors.bfloat16_vector) >= index * (dim * 2):
-                start_pos, end_pos = index * (dim * 2), (index + 1) * (dim * 2)
-                row_data[field_data.field_name] = [
-                    field_data.vectors.bfloat16_vector[start_pos:end_pos]
-                ]
+            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+                row_data[field_data.field_name] = None
+            else:
+                dim = field_data.vectors.dim
+                byte_per_row = dim * 2
+                phys_idx = get_physical_index(field_data, index)
+                if len(field_data.vectors.bfloat16_vector) >= (phys_idx + 1) * byte_per_row:
+                    start_pos, end_pos = phys_idx * byte_per_row, (phys_idx + 1) * byte_per_row
+                    row_data[field_data.field_name] = [
+                        field_data.vectors.bfloat16_vector[start_pos:end_pos]
+                    ]
         elif field_data.type == DataType.FLOAT16_VECTOR:
-            dim = field_data.vectors.dim
-            if len(field_data.vectors.float16_vector) >= index * (dim * 2):
-                start_pos, end_pos = index * (dim * 2), (index + 1) * (dim * 2)
-                row_data[field_data.field_name] = [
-                    field_data.vectors.float16_vector[start_pos:end_pos]
-                ]
+            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+                row_data[field_data.field_name] = None
+            else:
+                dim = field_data.vectors.dim
+                byte_per_row = dim * 2
+                phys_idx = get_physical_index(field_data, index)
+                if len(field_data.vectors.float16_vector) >= (phys_idx + 1) * byte_per_row:
+                    start_pos, end_pos = phys_idx * byte_per_row, (phys_idx + 1) * byte_per_row
+                    row_data[field_data.field_name] = [
+                        field_data.vectors.float16_vector[start_pos:end_pos]
+                    ]
         elif field_data.type == DataType.SPARSE_FLOAT_VECTOR:
-            row_data[field_data.field_name] = sparse_parse_single_row(
-                field_data.vectors.sparse_float_vector.contents[index]
-            )
+            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+                row_data[field_data.field_name] = None
+            else:
+                phys_idx = get_physical_index(field_data, index)
+                row_data[field_data.field_name] = sparse_parse_single_row(
+                    field_data.vectors.sparse_float_vector.contents[phys_idx]
+                )
         elif field_data.type == DataType.INT8_VECTOR:
-            dim = field_data.vectors.dim
-            if len(field_data.vectors.int8_vector) >= index * dim:
-                start_pos, end_pos = index * dim, (index + 1) * dim
-                row_data[field_data.field_name] = [
-                    field_data.vectors.int8_vector[start_pos:end_pos]
-                ]
+            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+                row_data[field_data.field_name] = None
+            else:
+                dim = field_data.vectors.dim
+                phys_idx = get_physical_index(field_data, index)
+                if len(field_data.vectors.int8_vector) >= (phys_idx + 1) * dim:
+                    start_pos, end_pos = phys_idx * dim, (phys_idx + 1) * dim
+                    row_data[field_data.field_name] = [
+                        field_data.vectors.int8_vector[start_pos:end_pos]
+                    ]
         elif (
             field_data.type == DataType._ARRAY_OF_VECTOR
             and len(field_data.vectors.vector_array.data) >= index

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -186,6 +186,9 @@ def len_of(field_data: Any) -> int:
         raise MilvusException(message="Unsupported scalar type")
 
     if field_data.HasField("vectors"):
+        if len(field_data.valid_data) > 0:
+            return len(field_data.valid_data)
+
         dim = field_data.vectors.dim
         if field_data.vectors.HasField("float_vector"):
             total_len = len(field_data.vectors.float_vector.data)

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -10,7 +10,7 @@ from pymilvus.client.types import (
     RoleInfo,
     UserInfo,
 )
-from pymilvus.client.utils import convert_struct_fields_to_user_format
+from pymilvus.client.utils import convert_struct_fields_to_user_format, is_vector_type
 from pymilvus.exceptions import (
     DataTypeNotMatchException,
     ParamError,
@@ -701,6 +701,10 @@ class AsyncMilvusClient(BaseMilvusClient):
         timeout: Optional[float] = None,
         **kwargs,
     ):
+        if is_vector_type(data_type) and not kwargs.get("nullable", False):
+            raise ParamError(
+                message="Adding vector field to existing collection requires nullable=True"
+            )
         field_schema = self.create_field_schema(field_name, data_type, desc, **kwargs)
         conn = self._get_connection()
         await conn.add_collection_field(

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -1021,6 +1021,10 @@ class MilvusClient(BaseMilvusClient):
         Raises:
             MilvusException: If anything goes wrong
         """
+        if is_vector_type(data_type) and not kwargs.get("nullable", False):
+            raise ParamError(
+                message="Adding vector field to existing collection requires nullable=True"
+            )
         field_schema = self.create_field_schema(field_name, data_type, desc, **kwargs)
         conn = self._get_connection()
         conn.add_collection_field(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dev = [
     "py-spy",
     "memray;sys_platform!='win32'",
     "pytest-benchmark[histogram]",
+    "ml_dtypes",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
related: #3154 

- Add None value handling in pack_field_value_to_field_data() for all vector types
- Add get_physical_index() helper for logical-to-physical index mapping
- Update extract_row_data_from_fields_data() with valid_data check and physical index mapping
- Update HybridHits.materialize() and HybridExtraList._extract_lazy_fields() for nullable vectors
- Update len_of() to use valid_data length as logical row count
- Remove nullable restriction for vector fields in insert method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for nullable vectors across all vector types; vector fields may be added to existing collections when nullable=True.
  * Automatic inference of missing vector dimensions from metadata.

* **Bug Fixes / Improvements**
  * More robust handling of nullable/sparse data, safer slicing and explicit type/validation checks.
  * Added caching to speed index mapping for nullable vectors.

* **Tests**
  * New unit tests covering nullable vector packing, extraction, and client-side validation.

* **Examples**
  * Added an example script demonstrating nullable-vector workflows and dynamic column addition.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->