### PR TITLE
fix:  Keep boolean serialization as uppercase for e2e compatibility

### DIFF
--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -316,10 +316,9 @@ def get_server_type(host: str):
 
 
 def dumps(v: Union[dict, str]) -> str:
-    # Use JSON serialization for dicts and booleans to ensure consistent formatting
-    # (e.g., booleans are serialized as 'true'/'false' not 'True'/'False')
-    # For other types (strings, numbers), use str() to maintain compatibility
-    if isinstance(v, (dict, bool)):
+    # Use JSON serialization for dicts to ensure proper formatting
+    # For other types (strings, numbers, booleans), use str() to maintain compatibility
+    if isinstance(v, dict):
         return orjson.dumps(v).decode(Config.EncodeProtocol)
     return str(v)
 

--- a/tests/test_prepare.py
+++ b/tests/test_prepare.py
@@ -553,7 +553,8 @@ class TestCreateIndexRequest:
         param_values = {p.key: p.value for p in req.extra_params}
         
         assert "with_raw_data" in param_keys, "with_raw_data parameter should be included"
-        assert param_values["with_raw_data"] == "false", "with_raw_data should be serialized as 'false'"
+        # Short-term fix: booleans are serialized as uppercase "False"/"True" for e2e compatibility
+        assert param_values["with_raw_data"] == "False", "with_raw_data should be serialized as 'False'"
         assert "index_type" in param_keys
         # String values are serialized as plain strings (without quotes) for compatibility
         assert param_values["index_type"] == "SCANN", "index_type should be serialized as plain string"
@@ -575,7 +576,8 @@ class TestCreateIndexRequest:
         param_values = {p.key: p.value for p in req.extra_params}
         
         assert "with_raw_data" in param_keys, "with_raw_data parameter should be included"
-        assert param_values["with_raw_data"] == "true", "with_raw_data should be serialized as 'true'"
+        # Short-term fix: booleans are serialized as uppercase "False"/"True" for e2e compatibility
+        assert param_values["with_raw_data"] == "True", "with_raw_data should be serialized as 'True'"
         assert param_values["index_type"] == "SCANN", "index_type should be serialized as plain string"
         assert param_values["metric_type"] == "L2", "metric_type should be serialized as plain string"
 


### PR DESCRIPTION
- Keep boolean serialization as uppercase for e2e compatibility
- Updated unit tests to expect uppercase boolean values