### PR TITLE
[Backport 2.6] feat: add global cluster client support (#3251) (#3260)

### DIFF
--- a/docs/plans/global-client-design.md
+++ b/docs/plans/global-client-design.md
@@ -1,0 +1,282 @@
+# Global Client Design for PyMilvus
+
+- **Created:** 2026-01-28
+- **Author(s):** @bigsheeper
+
+## Overview
+
+This feature adds transparent support for Milvus global clusters (similar to Amazon Aurora Global Database). When a user connects to a global endpoint, PyMilvus automatically discovers the cluster topology and routes all operations to the primary cluster.
+
+**Key Principles:**
+- Completely transparent to users - no API changes required
+- Automatic detection based on URL pattern
+- All operations route to primary cluster
+- Background topology refresh for resilience
+
+## User Experience
+
+```python
+# Regular connection - works as before
+client = MilvusClient(uri="https://in01-xxx.zilliz.com", token="...")
+
+# Global connection - same API, automatic global handling
+client = MilvusClient(uri="https://glo-xxx.global-cluster.vectordb.zilliz.com", token="...")
+```
+
+No new parameters, no new methods, no code changes required.
+
+## Detection Logic
+
+```python
+def is_global_endpoint(uri: str) -> bool:
+    return "global-cluster" in uri.lower()
+```
+
+## Data Structures
+
+### Topology Response Model
+
+```python
+from dataclasses import dataclass
+from typing import List
+
+class ClusterCapability:
+    READABLE = 0b01  # bit 0
+    WRITABLE = 0b10  # bit 1
+    PRIMARY = 0b11   # read + write
+
+@dataclass
+class ClusterInfo:
+    cluster_id: str
+    endpoint: str
+    capability: int
+
+    @property
+    def is_primary(self) -> bool:
+        return (self.capability & ClusterCapability.WRITABLE) != 0
+
+@dataclass
+class GlobalTopology:
+    version: int  # parsed from string
+    clusters: List[ClusterInfo]
+
+    @property
+    def primary(self) -> ClusterInfo:
+        for cluster in self.clusters:
+            if cluster.is_primary:
+                return cluster
+        raise ValueError("No primary cluster found in topology")
+```
+
+### Topology REST API
+
+- **Endpoint:** `GET https://<global-endpoint>/global-cluster/topology`
+- **Auth:** `Authorization: Bearer <token>` (reuse existing token)
+- **Response:**
+```json
+{
+    "code": 0,
+    "data": {
+        "version": "1",
+        "clusters": [
+            {
+                "clusterId": "in01-xxxx",
+                "endpoint": "https://in01-xxx.zilliz.com",
+                "capability": 3
+            }
+        ]
+    }
+}
+```
+
+Capability values:
+- `3` (0b11) = primary (read + write)
+- `1` (0b01) = secondary (read only)
+
+## Initialization Flow
+
+```
+1. User calls MilvusClient(uri="glo-xxx.global-cluster...", token="...")
+2. Detect "global-cluster" in URI → use GlobalStub
+3. Fetch topology from REST API (with retry + backoff)
+4. Parse response, find primary cluster (capability & 0b10)
+5. Connect to primary cluster's endpoint using standard gRPC stub
+6. Start background topology refresh thread
+7. Return initialized client
+```
+
+### Retry Strategy
+
+```python
+max_retries = 3
+base_delay = 1.0  # seconds
+max_delay = 10.0  # seconds
+
+for attempt in range(max_retries):
+    try:
+        topology = fetch_topology(global_endpoint, token)
+        break
+    except Exception as e:
+        if attempt == max_retries - 1:
+            raise ConnectionError(f"Failed to fetch global topology: {e}")
+        delay = min(base_delay * (2 ** attempt), max_delay)
+        delay += random.uniform(0, delay * 0.1)  # 10% jitter
+        time.sleep(delay)
+```
+
+### Error Handling
+
+All global cluster errors use `MilvusException`:
+
+- Topology fetch fails after retries → raise `MilvusException`
+- No primary cluster in topology → raise `MilvusException`
+- Primary endpoint connection fails → raise standard connection error
+
+## GlobalStub Structure
+
+```python
+@dataclass
+class GlobalStub:
+    global_endpoint: str
+    token: str
+    topology: GlobalTopology
+    primary_connection: GrpcHandler
+```
+
+## Background Topology Refresh
+
+### Refresh Triggers
+
+1. **Fixed interval:** Every 5 minutes
+2. **Event-driven:** On connection errors (e.g., gRPC unavailable, timeout)
+
+### Background Thread Logic
+
+```python
+class TopologyRefresher:
+    def __init__(self, global_stub: GlobalStub):
+        self.global_stub = global_stub
+        self.refresh_interval = 300  # 5 minutes
+        self.stop_event = threading.Event()
+        self.thread = threading.Thread(target=self._refresh_loop, daemon=True)
+
+    def _refresh_loop(self):
+        while not self.stop_event.wait(self.refresh_interval):
+            self._try_refresh()
+
+    def _try_refresh(self):
+        try:
+            new_topology = fetch_topology(...)
+            if new_topology.version > self.global_stub.topology.version:
+                self._apply_topology(new_topology)
+        except Exception as e:
+            logger.warning(f"Topology refresh failed: {e}")
+            # Keep using cached topology, will retry next interval
+
+    def trigger_refresh(self):
+        """Called on connection errors - immediate refresh"""
+        threading.Thread(target=self._try_refresh, daemon=True).start()
+```
+
+### Thread Safety
+
+- Use `threading.Lock` when updating topology and primary connection
+- Swap connection atomically: create new → update reference → close old
+
+### On Topology Refresh (version changed)
+
+- Reconnect to new primary if primary endpoint changed
+- Close old connection after new one is established
+
+## Operation Routing
+
+All operations (read and write) go through the primary connection. The GlobalStub acts as a transparent wrapper.
+
+### Integration Point
+
+Note: `GrpcHandler` receives `uri` as a parameter (the URI is parsed into an address
+internally for non-global connections). For global endpoints, the URI is passed directly
+to `GlobalStub` which handles topology discovery.
+
+```python
+class GrpcHandler:
+    def __init__(self, uri, ...):
+        self._global_stub = None
+
+        if is_global_endpoint(uri):
+            self._init_global_connection(uri, **kwargs)
+            return
+
+        # existing logic - parse address from uri, set up gRPC channel
+        self._address = self.__get_address(uri, host, port)
+        self._setup_grpc_channel()
+
+    def _init_global_connection(self, uri, **kwargs):
+        token = kwargs.pop("token", "")
+        self._global_conn_lock = threading.Lock()
+        self._global_stub = GlobalStub(
+            global_endpoint=uri, token=token,
+            on_primary_change=self._update_primary_connection, **kwargs,
+        )
+        self._update_primary_connection(self._global_stub.get_primary_handler())
+
+    def _update_primary_connection(self, primary_handler):
+        """Thread-safe update of connection attributes from the primary handler."""
+        with self._global_conn_lock:
+            self._stub = primary_handler._stub
+            self._channel = primary_handler._channel
+            # ... copy other connection attributes
+```
+
+### Error Handling with Refresh Trigger
+
+Connection errors are intercepted via the existing `retry_on_rpc_failure` decorator. When
+a `grpc.RpcError` is caught, the decorator calls `_handle_global_connection_error` on the
+handler, which triggers a topology refresh for `UNAVAILABLE` errors.
+
+```python
+def _handle_global_connection_error(self, error: grpc.RpcError):
+    if self._global_stub is None:
+        return
+    if error.code() == grpc.StatusCode.UNAVAILABLE:
+        self._global_stub.trigger_refresh()
+```
+
+### Connection Errors that Trigger Refresh
+
+- `UNAVAILABLE` - server unreachable
+
+## Implementation Plan
+
+### Files to Modify/Create
+
+| File | Change |
+|------|--------|
+| `pymilvus/client/grpc_handler.py` | Add global endpoint detection, integrate GlobalStub |
+| `pymilvus/client/global_stub.py` | **New file** - GlobalStub, TopologyRefresher, data models |
+| `pymilvus/decorators.py` | Integrate global connection error handling into `retry_on_rpc_failure` |
+
+### Dependencies
+
+- `requests` for REST API calls (added to main dependencies)
+- Standard library: `threading`, `dataclasses`, `time`, `random`
+
+### Test Coverage (>90%)
+
+- Unit tests for `is_global_endpoint()` detection
+- Unit tests for topology parsing
+- Unit tests for retry logic with mocked failures
+- Unit tests for background refresh thread
+- Integration tests with mocked global endpoint
+
+### No Changes Required
+
+- User-facing API (`MilvusClient`)
+- Existing gRPC operations
+- Authentication flow
+
+## Scope Limitations (v1)
+
+- **No failover support** - If primary is unavailable, operations fail
+- **No read routing to secondaries** - All operations go to primary
+- **No user-configurable refresh interval** - Fixed at 5 minutes

--- a/pymilvus/client/global_stub.py
+++ b/pymilvus/client/global_stub.py
@@ -1,0 +1,324 @@
+import logging
+import random
+import threading
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+import requests
+
+from pymilvus.exceptions import MilvusException
+
+if TYPE_CHECKING:
+    from pymilvus.client.grpc_handler import GrpcHandler
+
+logger = logging.getLogger(__name__)
+
+GLOBAL_CLUSTER_IDENTIFIER = "global-cluster"
+
+
+def is_global_endpoint(uri: str) -> bool:
+    """Check if the URI points to a global cluster endpoint."""
+    if not uri:
+        return False
+    return GLOBAL_CLUSTER_IDENTIFIER in uri.lower()
+
+
+class ClusterCapability:
+    """Bitset flags for cluster capabilities."""
+
+    READABLE = 0b01  # bit 0
+    WRITABLE = 0b10  # bit 1
+    PRIMARY = 0b11  # read + write
+
+
+@dataclass
+class ClusterInfo:
+    """Information about a cluster in the global topology."""
+
+    cluster_id: str
+    endpoint: str
+    capability: int
+
+    @property
+    def is_primary(self) -> bool:
+        """Check if this cluster is the primary (writable) cluster."""
+        return (self.capability & ClusterCapability.WRITABLE) != 0
+
+
+@dataclass
+class GlobalTopology:
+    """Global cluster topology containing all clusters."""
+
+    version: int
+    clusters: List[ClusterInfo]
+
+    @property
+    def primary(self) -> ClusterInfo:
+        """Get the primary cluster from the topology."""
+        for cluster in self.clusters:
+            if cluster.is_primary:
+                return cluster
+        msg = "No primary cluster found in topology"
+        raise ValueError(msg)
+
+
+# Constants for retry logic
+MAX_RETRIES = 3
+BASE_DELAY = 1.0  # seconds
+MAX_DELAY = 10.0  # seconds
+REQUEST_TIMEOUT = 10  # seconds
+
+
+def _parse_topology_response(data: dict) -> GlobalTopology:
+    """Parse the topology response from the REST API."""
+    clusters = [
+        ClusterInfo(
+            cluster_id=c["clusterId"],
+            endpoint=c["endpoint"],
+            capability=c["capability"],
+        )
+        for c in data["clusters"]
+    ]
+    return GlobalTopology(version=int(data["version"]), clusters=clusters)
+
+
+def fetch_topology(global_endpoint: str, token: str) -> GlobalTopology:
+    """Fetch the global cluster topology from the REST API.
+
+    Args:
+        global_endpoint: The global cluster endpoint URL
+        token: Authentication token
+
+    Returns:
+        GlobalTopology object containing cluster information
+
+    Raises:
+        MilvusException: If topology cannot be fetched after retries
+    """
+    # Build the topology URL
+    endpoint = global_endpoint.rstrip("/")
+    if not endpoint.startswith(("http://", "https://")):
+        endpoint = f"https://{endpoint}"
+    url = f"{endpoint}/{GLOBAL_CLUSTER_IDENTIFIER}/topology"
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    last_error = None
+    for attempt in range(MAX_RETRIES):
+        try:
+            response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+
+            if response.status_code != 200:
+                msg = f"Topology request failed with status {response.status_code}: {response.text}"
+                raise RuntimeError(msg)  # Retryable HTTP error
+
+            result = response.json()
+            if result.get("code", 0) != 0:
+                raise MilvusException(message=result.get("message", "Unknown API error"))
+
+            return _parse_topology_response(result["data"])
+
+        except MilvusException:
+            raise
+        except (requests.exceptions.RequestException, RuntimeError) as e:
+            last_error = e
+            if attempt < MAX_RETRIES - 1:
+                delay = min(BASE_DELAY * (2**attempt), MAX_DELAY)
+                delay += random.uniform(0, delay * 0.1)  # noqa: S311
+                logger.warning(
+                    f"Topology fetch attempt {attempt + 1} failed: {e}. Retrying in {delay:.1f}s"
+                )
+                time.sleep(delay)
+
+    raise MilvusException(
+        message=f"Failed to fetch global topology after {MAX_RETRIES} attempts: {last_error}"
+    )
+
+
+# Default refresh interval
+DEFAULT_REFRESH_INTERVAL = 300  # 5 minutes
+
+
+class TopologyRefresher:
+    """Background thread that periodically refreshes the global cluster topology."""
+
+    def __init__(
+        self,
+        global_endpoint: str,
+        token: str,
+        topology: GlobalTopology,
+        refresh_interval: float = DEFAULT_REFRESH_INTERVAL,
+        on_topology_change: Optional[Callable] = None,
+    ):
+        self._global_endpoint = global_endpoint
+        self._token = token
+        self._topology = topology
+        self._refresh_interval = refresh_interval
+        self._on_topology_change = on_topology_change
+
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        """Start the background refresh thread."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._refresh_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the background refresh thread."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def is_running(self) -> bool:
+        """Check if the refresh thread is running."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def get_topology(self) -> GlobalTopology:
+        """Get the current topology (thread-safe)."""
+        with self._lock:
+            return self._topology
+
+    def trigger_refresh(self) -> None:
+        """Trigger an immediate topology refresh (async)."""
+        threading.Thread(target=self._try_refresh, daemon=True).start()
+
+    def _refresh_loop(self) -> None:
+        """Main refresh loop running in background thread."""
+        while not self._stop_event.wait(self._refresh_interval):
+            self._try_refresh()
+
+    def _try_refresh(self) -> None:
+        """Attempt to refresh the topology."""
+        try:
+            new_topology = fetch_topology(self._global_endpoint, self._token)
+
+            with self._lock:
+                if new_topology.version > self._topology.version:
+                    old_topology = self._topology
+                    self._topology = new_topology
+                    logger.info(
+                        f"Topology updated: version {old_topology.version} -> {new_topology.version}"
+                    )
+
+                    if self._on_topology_change:
+                        try:
+                            self._on_topology_change(new_topology)
+                        except Exception:
+                            logger.warning("Topology change callback failed", exc_info=True)
+
+        except Exception:
+            logger.warning("Topology refresh failed", exc_info=True)
+            # Keep using cached topology, will retry next interval
+
+
+class GlobalStub:
+    """Global cluster stub that manages topology discovery and primary connection."""
+
+    def __init__(
+        self,
+        global_endpoint: str,
+        token: str,
+        *,
+        start_refresher: bool = True,
+        on_primary_change: Optional[Callable] = None,
+        **handler_kwargs,
+    ):
+        """Initialize the global stub.
+
+        Args:
+            global_endpoint: The global cluster endpoint URL
+            token: Authentication token
+            start_refresher: Whether to start the background topology refresher
+            on_primary_change: Callback when primary cluster changes, receives new GrpcHandler
+            **handler_kwargs: Additional kwargs to pass to GrpcHandler
+        """
+        self._global_endpoint = global_endpoint
+        self._token = token
+        self._handler_kwargs = handler_kwargs
+        self._on_primary_change = on_primary_change
+        self._lock = threading.Lock()
+
+        # Fetch initial topology
+        self._topology = fetch_topology(global_endpoint, token)
+
+        # Connect to primary cluster
+        self._primary_handler = self._create_primary_handler()
+
+        # Start background refresher
+        self._refresher = TopologyRefresher(
+            global_endpoint=global_endpoint,
+            token=token,
+            topology=self._topology,
+            on_topology_change=self._on_topology_change,
+        )
+        if start_refresher:
+            self._refresher.start()
+
+    def _create_primary_handler(self) -> "GrpcHandler":
+        """Create a GrpcHandler for the primary cluster."""
+        from pymilvus.client.grpc_handler import GrpcHandler  # noqa: PLC0415
+
+        primary = self._topology.primary
+        return GrpcHandler(uri=primary.endpoint, token=self._token, **self._handler_kwargs)
+
+    def _on_topology_change(self, new_topology: GlobalTopology) -> None:
+        """Handle topology change - reconnect to new primary if needed."""
+        with self._lock:
+            old_primary = self._topology.primary
+            new_primary = new_topology.primary
+
+            self._topology = new_topology
+
+            if old_primary.endpoint != new_primary.endpoint:
+                logger.info(f"Primary changed: {old_primary.endpoint} -> {new_primary.endpoint}")
+                old_handler = self._primary_handler
+                self._primary_handler = self._create_primary_handler()
+
+                # Notify caller about primary change
+                if self._on_primary_change:
+                    try:
+                        self._on_primary_change(self._primary_handler)
+                    except Exception:
+                        logger.warning("Primary change callback failed", exc_info=True)
+
+                # Close old handler after new one is established
+                try:
+                    old_handler.close()
+                except Exception:
+                    logger.warning("Failed to close old handler", exc_info=True)
+
+    def get_topology(self) -> GlobalTopology:
+        """Get the current topology."""
+        return self._refresher.get_topology()
+
+    def get_primary_endpoint(self) -> str:
+        """Get the primary cluster endpoint."""
+        with self._lock:
+            return self._topology.primary.endpoint
+
+    def get_primary_handler(self) -> "GrpcHandler":
+        """Get the GrpcHandler for the primary cluster."""
+        with self._lock:
+            return self._primary_handler
+
+    def trigger_refresh(self) -> None:
+        """Trigger an immediate topology refresh."""
+        self._refresher.trigger_refresh()
+
+    def close(self) -> None:
+        """Close the global stub and release resources."""
+        self._refresher.stop()
+        with self._lock:
+            if self._primary_handler:
+                try:
+                    self._primary_handler.close()
+                except Exception:
+                    logger.warning("Failed to close primary handler", exc_info=True)

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -211,6 +211,9 @@ def retry_on_rpc_failure(
                     try:
                         return await func(*args, **kwargs)
                     except grpc.RpcError as e:
+                        # Trigger global topology refresh on connection errors
+                        if args and hasattr(args[0], "_handle_global_connection_error"):
+                            args[0]._handle_global_connection_error(e)
                         if e.code() in IGNORE_RETRY_CODES:
                             raise e from e
                         if is_timeout(start_time):
@@ -288,6 +291,9 @@ def retry_on_rpc_failure(
                 try:
                     return func(*args, **kwargs)
                 except grpc.RpcError as e:
+                    # Trigger global topology refresh on connection errors
+                    if args and hasattr(args[0], "_handle_global_connection_error"):
+                        args[0]._handle_global_connection_error(e)
                     # Do not retry on these codes
                     if e.code() in IGNORE_RETRY_CODES:
                         raise e from e

--- a/pymilvus/orm/connections.py
+++ b/pymilvus/orm/connections.py
@@ -20,6 +20,7 @@ from urllib import parse
 from pymilvus.client.async_grpc_handler import AsyncGrpcHandler
 from pymilvus.client.call_context import CallContext
 from pymilvus.client.check import is_legal_address, is_legal_host, is_legal_port
+from pymilvus.client.global_stub import is_global_endpoint
 from pymilvus.client.grpc_handler import GrpcHandler, ReconnectHandler
 from pymilvus.exceptions import (
     ConnectionConfigException,
@@ -410,6 +411,10 @@ class Connections(metaclass=SingleInstanceMetaClass):
         if with_config(config):
             addr, parsed_uri = self.__get_full_address(*config)
             kwargs["address"] = addr
+
+            # Preserve original URI for global client detection
+            if is_global_endpoint(config[1]):
+                kwargs["uri"] = config[1]
 
             if self.has_connection(alias) and self._alias_config[alias].get("address") != addr:
                 raise ConnectionConfigException(message=ExceptionsMessage.ConnDiffConf % alias)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies=[
     "pandas>=1.2.4",
     "numpy<1.25.0;python_version<='3.8'",
     "cachetools>=5.0.0",
+    "requests>=2.20.0",
 ]
 
 classifiers=[

--- a/tests/test_global_stub.py
+++ b/tests/test_global_stub.py
@@ -1,0 +1,798 @@
+import threading
+from unittest.mock import MagicMock, patch
+
+import grpc
+import pytest
+from pymilvus.client.global_stub import (
+    GLOBAL_CLUSTER_IDENTIFIER,
+    ClusterCapability,
+    ClusterInfo,
+    GlobalStub,
+    GlobalTopology,
+    TopologyRefresher,
+    fetch_topology,
+    is_global_endpoint,
+)
+from pymilvus.client.grpc_handler import GrpcHandler
+from pymilvus.exceptions import MilvusException
+
+
+class TestIsGlobalEndpoint:
+    def test_detects_global_cluster_in_url(self):
+        assert is_global_endpoint("https://glo-xxx.global-cluster.vectordb.zilliz.com") is True
+
+    def test_detects_global_cluster_case_insensitive(self):
+        assert is_global_endpoint("https://glo-xxx.GLOBAL-CLUSTER.vectordb.zilliz.com") is True
+
+    def test_rejects_regular_endpoint(self):
+        assert is_global_endpoint("https://in01-xxx.zilliz.com") is False
+
+    def test_rejects_empty_string(self):
+        assert is_global_endpoint("") is False
+
+
+class TestClusterCapability:
+    def test_primary_capability(self):
+        assert ClusterCapability.PRIMARY == 0b11
+        assert ClusterCapability.READABLE == 0b01
+        assert ClusterCapability.WRITABLE == 0b10
+
+
+class TestClusterInfo:
+    def test_primary_cluster(self):
+        cluster = ClusterInfo(
+            cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+        )
+        assert cluster.is_primary is True
+
+    def test_secondary_cluster(self):
+        cluster = ClusterInfo(
+            cluster_id="in02-xxx", endpoint="https://in02-xxx.zilliz.com", capability=1
+        )
+        assert cluster.is_primary is False
+
+
+class TestGlobalTopology:
+    def test_finds_primary_cluster(self):
+        topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+                ClusterInfo(
+                    cluster_id="in02-xxx", endpoint="https://in02-xxx.zilliz.com", capability=1
+                ),
+            ],
+        )
+        primary = topology.primary
+        assert primary.cluster_id == "in01-xxx"
+        assert primary.is_primary is True
+
+    def test_raises_when_no_primary(self):
+        topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in02-xxx", endpoint="https://in02-xxx.zilliz.com", capability=1
+                ),
+            ],
+        )
+        with pytest.raises(ValueError, match="No primary cluster"):
+            _ = topology.primary
+
+
+class TestFetchTopology:
+    def test_fetches_topology_successfully(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "code": 0,
+            "data": {
+                "version": "123",
+                "clusters": [
+                    {
+                        "clusterId": "in01-xxx",
+                        "endpoint": "https://in01-xxx.zilliz.com",
+                        "capability": 3,
+                    },
+                ],
+            },
+        }
+
+        with patch(
+            "pymilvus.client.global_stub.requests.get", return_value=mock_response
+        ) as mock_get:
+            topology = fetch_topology(
+                "https://glo-xxx.global-cluster.vectordb.zilliz.com", "test-token"
+            )
+
+            mock_get.assert_called_once()
+            call_args = mock_get.call_args
+            assert "global-cluster/topology" in call_args[0][0]
+            assert call_args[1]["headers"]["Authorization"] == "Bearer test-token"
+
+            assert topology.version == 123
+            assert len(topology.clusters) == 1
+            assert topology.primary.cluster_id == "in01-xxx"
+
+    def test_retries_on_failure(self):
+        mock_response_fail = MagicMock()
+        mock_response_fail.status_code = 500
+
+        mock_response_success = MagicMock()
+        mock_response_success.status_code = 200
+        mock_response_success.json.return_value = {
+            "code": 0,
+            "data": {
+                "version": "1",
+                "clusters": [
+                    {
+                        "clusterId": "in01-xxx",
+                        "endpoint": "https://in01-xxx.zilliz.com",
+                        "capability": 3,
+                    },
+                ],
+            },
+        }
+
+        with patch(
+            "pymilvus.client.global_stub.requests.get",
+            side_effect=[mock_response_fail, mock_response_success],
+        ):
+            with patch("pymilvus.client.global_stub.time.sleep"):  # Skip delays in tests
+                topology = fetch_topology(
+                    "https://glo-xxx.global-cluster.vectordb.zilliz.com", "test-token"
+                )
+                assert topology.version == 1
+
+    def test_raises_after_max_retries(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        with patch("pymilvus.client.global_stub.requests.get", return_value=mock_response):
+            with patch("pymilvus.client.global_stub.time.sleep"):
+                with pytest.raises(MilvusException, match="Failed to fetch global topology"):
+                    fetch_topology(
+                        "https://glo-xxx.global-cluster.vectordb.zilliz.com", "test-token"
+                    )
+
+    def test_raises_on_api_error_code(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"code": 1, "message": "Invalid token"}
+
+        with patch("pymilvus.client.global_stub.requests.get", return_value=mock_response):
+            with patch("pymilvus.client.global_stub.time.sleep"):
+                with pytest.raises(MilvusException, match="Invalid token"):
+                    fetch_topology(
+                        "https://glo-xxx.global-cluster.vectordb.zilliz.com", "test-token"
+                    )
+
+    def test_adds_https_prefix_when_missing(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "code": 0,
+            "data": {
+                "version": "1",
+                "clusters": [
+                    {
+                        "clusterId": "in01-xxx",
+                        "endpoint": "https://in01-xxx.zilliz.com",
+                        "capability": 3,
+                    },
+                ],
+            },
+        }
+
+        with patch(
+            "pymilvus.client.global_stub.requests.get", return_value=mock_response
+        ) as mock_get:
+            fetch_topology("glo-xxx.global-cluster.vectordb.zilliz.com", "test-token")
+
+            call_args = mock_get.call_args
+            # Verify https:// was added
+            assert (
+                call_args[0][0]
+                == "https://glo-xxx.global-cluster.vectordb.zilliz.com/global-cluster/topology"
+            )
+
+
+class TestTopologyRefresher:
+    def test_starts_and_stops(self):
+        topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(cluster_id="in01", endpoint="https://in01.zilliz.com", capability=3)
+            ],
+        )
+
+        refresher = TopologyRefresher(
+            global_endpoint="https://glo.global-cluster.zilliz.com",
+            token="test-token",
+            topology=topology,
+            refresh_interval=0.1,
+        )
+        refresher.start()
+        assert refresher.is_running()
+
+        refresher.stop()
+        assert not refresher.is_running()
+
+    def test_updates_topology_on_version_change(self):
+        initial_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(cluster_id="in01", endpoint="https://in01.zilliz.com", capability=3)
+            ],
+        )
+
+        new_topology = GlobalTopology(
+            version=2,
+            clusters=[
+                ClusterInfo(cluster_id="in02", endpoint="https://in02.zilliz.com", capability=3)
+            ],
+        )
+
+        callback_called = threading.Event()
+        received_topology = []
+
+        def on_topology_change(topo):
+            received_topology.append(topo)
+            callback_called.set()
+
+        refresher = TopologyRefresher(
+            global_endpoint="https://glo.global-cluster.zilliz.com",
+            token="test-token",
+            topology=initial_topology,
+            refresh_interval=0.05,
+            on_topology_change=on_topology_change,
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=new_topology):
+            refresher.start()
+            callback_called.wait(timeout=1.0)
+            refresher.stop()
+
+        assert len(received_topology) == 1
+        assert received_topology[0].version == 2
+
+    def test_does_not_update_on_same_version(self):
+        topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(cluster_id="in01", endpoint="https://in01.zilliz.com", capability=3)
+            ],
+        )
+
+        callback_called = []
+        refresh_count = threading.Event()
+        call_count = 0
+
+        def counting_fetch(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                refresh_count.set()
+            return topology
+
+        def on_topology_change(topo):
+            callback_called.append(topo)
+
+        refresher = TopologyRefresher(
+            global_endpoint="https://glo.global-cluster.zilliz.com",
+            token="test-token",
+            topology=topology,
+            refresh_interval=0.05,
+            on_topology_change=on_topology_change,
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", side_effect=counting_fetch):
+            refresher.start()
+            refresh_count.wait(timeout=2.0)
+            refresher.stop()
+
+        assert len(callback_called) == 0
+
+    def test_trigger_refresh_immediate(self):
+        initial_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(cluster_id="in01", endpoint="https://in01.zilliz.com", capability=3)
+            ],
+        )
+
+        new_topology = GlobalTopology(
+            version=2,
+            clusters=[
+                ClusterInfo(cluster_id="in02", endpoint="https://in02.zilliz.com", capability=3)
+            ],
+        )
+
+        callback_called = threading.Event()
+
+        def on_topology_change(topo):
+            callback_called.set()
+
+        refresher = TopologyRefresher(
+            global_endpoint="https://glo.global-cluster.zilliz.com",
+            token="test-token",
+            topology=initial_topology,
+            refresh_interval=300,  # Long interval - shouldn't trigger automatically
+            on_topology_change=on_topology_change,
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=new_topology):
+            refresher.start()
+            refresher.trigger_refresh()
+            callback_called.wait(timeout=1.0)
+            refresher.stop()
+
+        assert callback_called.is_set()
+
+    def test_continues_on_fetch_failure(self):
+        topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(cluster_id="in01", endpoint="https://in01.zilliz.com", capability=3)
+            ],
+        )
+
+        fetch_attempted = threading.Event()
+
+        def failing_fetch(*args, **kwargs):
+            fetch_attempted.set()
+            raise Exception("Network error")
+
+        refresher = TopologyRefresher(
+            global_endpoint="https://glo.global-cluster.zilliz.com",
+            token="test-token",
+            topology=topology,
+            refresh_interval=0.05,
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", side_effect=failing_fetch):
+            refresher.start()
+            fetch_attempted.wait(timeout=2.0)
+            assert refresher.is_running()
+            refresher.stop()
+
+        assert refresher.get_topology().version == 1  # Still has original topology
+
+
+class TestGlobalStub:
+    def test_initializes_with_topology(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler = MagicMock()
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                assert stub.get_topology().version == 1
+                assert stub.get_primary_endpoint() == "https://in01-xxx.zilliz.com"
+
+    def test_provides_primary_handler(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler = MagicMock()
+        mock_handler._stub = MagicMock()
+        mock_handler._channel = MagicMock()
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                assert stub.get_primary_handler() is mock_handler
+
+    def test_reconnects_on_topology_change(self):
+        initial_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        new_topology = GlobalTopology(
+            version=2,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in02-xxx", endpoint="https://in02-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler_1 = MagicMock()
+        mock_handler_2 = MagicMock()
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=initial_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler_1):
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                    start_refresher=False,  # Don't start background refresh for this test
+                )
+
+        # Simulate topology change
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler_2):
+            stub._on_topology_change(new_topology)
+
+        assert stub.get_primary_handler() is mock_handler_2
+        assert stub.get_primary_endpoint() == "https://in02-xxx.zilliz.com"
+        mock_handler_1.close.assert_called_once()
+
+    def test_closes_cleanly(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler = MagicMock()
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                stub.close()
+
+                mock_handler.close.assert_called_once()
+                assert not stub._refresher.is_running()
+
+    def test_trigger_refresh_on_connection_error(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler = MagicMock()
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                    start_refresher=False,
+                )
+
+                with patch.object(stub._refresher, "trigger_refresh") as mock_trigger:
+                    stub.trigger_refresh()
+                    mock_trigger.assert_called_once()
+
+
+class TestGrpcHandlerGlobalIntegration:
+    def test_uses_global_stub_for_global_endpoint(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+                handler = GrpcHandler(
+                    uri="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                assert handler._global_stub is not None
+                assert handler._global_stub.get_primary_endpoint() == "https://in01-xxx.zilliz.com"
+
+    def test_uses_regular_connection_for_non_global_endpoint(self):
+        with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+            handler = GrpcHandler(uri="https://in01-xxx.zilliz.com", token="test-token")
+
+            assert handler._global_stub is None
+
+    def test_triggers_refresh_on_unavailable_error(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+                handler = GrpcHandler(
+                    uri="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                with patch.object(handler._global_stub, "trigger_refresh") as mock_trigger:
+                    # Simulate UNAVAILABLE error
+                    mock_error = MagicMock()
+                    mock_error.code.return_value = grpc.StatusCode.UNAVAILABLE
+
+                    handler._handle_global_connection_error(mock_error)
+
+                    mock_trigger.assert_called_once()
+
+    def test_does_not_trigger_refresh_on_other_errors(self):
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+                handler = GrpcHandler(
+                    uri="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                with patch.object(handler._global_stub, "trigger_refresh") as mock_trigger:
+                    # Simulate INVALID_ARGUMENT error (should not trigger refresh)
+                    mock_error = MagicMock()
+                    mock_error.code.return_value = grpc.StatusCode.INVALID_ARGUMENT
+
+                    handler._handle_global_connection_error(mock_error)
+
+                    mock_trigger.assert_not_called()
+
+
+class _FakeRpcError(grpc.RpcError):
+    """A fake gRPC error for testing that properly inherits from grpc.RpcError."""
+
+    def __init__(self, status_code, details_msg=""):
+        self._code = status_code
+        self._details = details_msg
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+
+class TestGlobalErrorHandling:
+    def test_retry_decorator_triggers_refresh_on_unavailable(self):
+        """Test that retry_on_rpc_failure decorator calls _handle_global_connection_error."""
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+                handler = GrpcHandler(
+                    uri="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                assert hasattr(handler, "_handle_global_connection_error")
+                assert handler._global_stub is not None
+
+                # Verify the decorator integration: simulate a gRPC call that raises UNAVAILABLE
+                rpc_error = _FakeRpcError(grpc.StatusCode.UNAVAILABLE, "Connection refused")
+
+                handler._stub = MagicMock()
+                handler._stub.DescribeCollection.side_effect = rpc_error
+
+                with patch.object(handler._global_stub, "trigger_refresh") as mock_trigger:
+                    with pytest.raises(MilvusException):
+                        handler.has_collection("test_collection", timeout=0.1, retry_times=1)
+
+                    mock_trigger.assert_called()
+
+    def test_retry_decorator_does_not_trigger_refresh_on_deadline_exceeded(self):
+        """Test that DEADLINE_EXCEEDED does not trigger topology refresh."""
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+                handler = GrpcHandler(
+                    uri="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                rpc_error = _FakeRpcError(grpc.StatusCode.DEADLINE_EXCEEDED, "Deadline exceeded")
+
+                handler._stub = MagicMock()
+                handler._stub.DescribeCollection.side_effect = rpc_error
+
+                with patch.object(handler._global_stub, "trigger_refresh") as mock_trigger:
+                    with pytest.raises((MilvusException, _FakeRpcError)):
+                        handler.has_collection("test_collection", timeout=0.1)
+
+                    mock_trigger.assert_not_called()
+
+
+class TestGlobalClusterConstant:
+    def test_global_cluster_identifier_constant(self):
+        assert GLOBAL_CLUSTER_IDENTIFIER == "global-cluster"
+
+
+class TestGlobalClientEndToEnd:
+    def test_full_initialization_flow(self):
+        """Test the complete flow from GlobalStub initialization to handler access."""
+        mock_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+                ClusterInfo(
+                    cluster_id="in02-xxx", endpoint="https://in02-xxx.zilliz.com", capability=1
+                ),
+            ],
+        )
+
+        mock_grpc_handler = MagicMock()
+        mock_grpc_handler._stub = MagicMock()
+        mock_grpc_handler._channel = MagicMock()
+        mock_grpc_handler._final_channel = MagicMock()
+        mock_grpc_handler._address = "in01-xxx.zilliz.com:443"
+        mock_grpc_handler.get_server_type.return_value = "zilliz"
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=mock_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_grpc_handler):
+                # Test GlobalStub initialization and handler access
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                    start_refresher=False,
+                )
+
+                # Verify the topology was fetched
+                assert stub.get_topology().version == 1
+                assert len(stub.get_topology().clusters) == 2
+
+                # Verify the primary endpoint is correct
+                assert stub.get_primary_endpoint() == "https://in01-xxx.zilliz.com"
+
+                # Verify handler is accessible
+                handler = stub.get_primary_handler()
+                assert handler is mock_grpc_handler
+
+                # Clean up
+                stub.close()
+
+    def test_topology_refresh_updates_connection(self):
+        """Test that topology refresh properly updates the primary connection."""
+        initial_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        new_topology = GlobalTopology(
+            version=2,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in02-xxx", endpoint="https://in02-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler_1 = MagicMock()
+        mock_handler_1._stub = MagicMock()
+        mock_handler_2 = MagicMock()
+        mock_handler_2._stub = MagicMock()
+
+        handler_calls = [mock_handler_1, mock_handler_2]
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=initial_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler", side_effect=handler_calls):
+                stub = GlobalStub(
+                    global_endpoint="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                    start_refresher=False,
+                )
+
+                initial_handler = stub.get_primary_handler()
+                assert initial_handler is mock_handler_1
+
+                # Trigger topology change
+                stub._on_topology_change(new_topology)
+
+                new_handler = stub.get_primary_handler()
+                assert new_handler is mock_handler_2
+                assert stub.get_primary_endpoint() == "https://in02-xxx.zilliz.com"
+
+    def test_grpc_handler_connection_updated_on_topology_change(self):
+        """Test that GrpcHandler's connection attributes are updated when topology changes."""
+        initial_topology = GlobalTopology(
+            version=1,
+            clusters=[
+                ClusterInfo(
+                    cluster_id="in01-xxx", endpoint="https://in01-xxx.zilliz.com", capability=3
+                ),
+            ],
+        )
+
+        mock_handler_1 = MagicMock()
+        mock_handler_1._stub = MagicMock(name="stub1")
+        mock_handler_1._channel = MagicMock(name="channel1")
+        mock_handler_1._address = "in01-xxx.zilliz.com:443"
+
+        mock_handler_2 = MagicMock()
+        mock_handler_2._stub = MagicMock(name="stub2")
+        mock_handler_2._channel = MagicMock(name="channel2")
+        mock_handler_2._address = "in02-xxx.zilliz.com:443"
+
+        handler_calls = [mock_handler_1, mock_handler_2]
+
+        with patch("pymilvus.client.global_stub.fetch_topology", return_value=initial_topology):
+            with patch("pymilvus.client.grpc_handler.GrpcHandler._setup_grpc_channel"):
+                grpc_handler = GrpcHandler(
+                    uri="https://glo-xxx.global-cluster.vectordb.zilliz.com",
+                    token="test-token",
+                )
+
+                # Mock the internal GrpcHandler creation in GlobalStub
+                with patch("pymilvus.client.grpc_handler.GrpcHandler", side_effect=handler_calls):
+                    # Re-initialize with mocked handlers
+                    grpc_handler._global_stub._primary_handler = mock_handler_1
+                    grpc_handler._update_primary_connection(mock_handler_1)
+
+                    # Verify initial connection
+                    assert grpc_handler._stub is mock_handler_1._stub
+                    assert grpc_handler._channel is mock_handler_1._channel
+                    assert grpc_handler._address == "in01-xxx.zilliz.com:443"
+
+                    # Simulate topology change triggering the callback
+                    grpc_handler._update_primary_connection(mock_handler_2)
+
+                    # Verify connection was updated
+                    assert grpc_handler._stub is mock_handler_2._stub
+                    assert grpc_handler._channel is mock_handler_2._channel
+                    assert grpc_handler._address == "in02-xxx.zilliz.com:443"


### PR DESCRIPTION
## Summary
- Backport of #3251 and #3260 to the 2.6 branch
- Add transparent support for Milvus global clusters (auto-detect global endpoints, fetch cluster topology via REST API, background topology refresh, route operations to primary cluster)
- Fix leaked `address` kwarg in global client connection init

## Cherry-picked PRs
- #3251 feat: add global cluster client support
- #3260 fix: pop leaked address kwarg in global client connection init

## Test plan
- [x] Cherry-picks applied cleanly with no conflicts
- [x] Unit tests included in original PRs