### PR TITLE
fix: consistency_level to return human-readable string

### DIFF
--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -298,6 +298,20 @@ class CollectionSchema:
                 schema_dict["auto_id"] = field_dict["auto_id"]
                 return
 
+    def _consistency_level_to_str(self, level: int) -> str:
+        """Convert numeric consistency level to human-readable string."""
+        from pymilvus.client.constants import ConsistencyLevel
+
+        # Map integer values to their string names
+        consistency_map = {
+            ConsistencyLevel.Strong: "Strong",
+            ConsistencyLevel.Session: "Session",
+            ConsistencyLevel.Bounded: "Bounded",
+            ConsistencyLevel.Eventually: "Eventually",
+            ConsistencyLevel.Customized: "Customized",
+        }
+        return consistency_map.get(level, level)  # Return int if not found (fallback)
+
     def dict(self):
         if not self._raw:
             return {}
@@ -311,7 +325,7 @@ class CollectionSchema:
             "functions": [f.dict() for f in self.functions],
             "aliases": self.aliases,
             "collection_id": self.collection_id,
-            "consistency_level": self.consistency_level,
+            "consistency_level": self._consistency_level_to_str(self.consistency_level),
             "properties": self.properties,
             "num_partitions": self.num_partitions,
             "enable_dynamic_field": self.enable_dynamic_field,

--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -8,7 +8,12 @@ from pymilvus.exceptions import DataTypeNotMatchException, ExceptionsMessage
 from pymilvus.settings import Config
 
 from . import utils
-from .constants import DEFAULT_CONSISTENCY_LEVEL, RANKER_TYPE_RRF, RANKER_TYPE_WEIGHTED
+from .constants import (
+    DEFAULT_CONSISTENCY_LEVEL,
+    RANKER_TYPE_RRF,
+    RANKER_TYPE_WEIGHTED,
+    ConsistencyLevel,
+)
 
 # ruff: noqa: F401
 # TODO: This is a patch for older version
@@ -300,7 +305,6 @@ class CollectionSchema:
 
     def _consistency_level_to_str(self, level: int) -> str:
         """Convert numeric consistency level to human-readable string."""
-        from pymilvus.client.constants import ConsistencyLevel
 
         # Map integer values to their string names
         consistency_map = {


### PR DESCRIPTION
Fixes #2985

## Summary
When calling `describe_collection()`, the `consistency_level` field was returning a numeric value (0, 1, 2, 3, 4) instead of a human-readable string ("Strong", "Session", "Bounded", "Eventually", "Customized").

This made the output not user-friendly and required users to manually map the integer to its semantic meaning.

## Changes
- Added `_consistency_level_to_str()` helper method to `CollectionSchema` class
- Maps `ConsistencyLevel` enum integers to their string names  
- Falls back to returning the int if an unknown value is encountered
- Updated `dict()` method to use the helper when building the response

## Before
```python
{
  'collection_name': 'client_geometry_3yiyc8Bb',
  'consistency_level': 0,  # Not user-friendly!
  ...
}
```

## After
```python
{
  'collection_name': 'client_geometry_3yiyc8Bb', 
  'consistency_level': 'Strong',  # Human-readable!
  ...
}
```

## Test Plan
The fix converts all consistency level enum values correctly:
- `0` → `"Strong"`
- `1` → `"Session"`
- `2` → `"Bounded"` 
- `3` → `"Eventually"`
- `4` → `"Customized"`

Existing tests in `tests/grpc_handler/test_collection.py` verify `describe_collection()` functionality and will validate this change.