### PR TITLE
enhance: general performance improvements across MilvusClient path

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import json
 import socket
 import time
 from pathlib import Path
@@ -8,6 +7,7 @@ from typing import Dict, List, Optional, Tuple, Union
 from urllib import parse
 
 import grpc
+import orjson
 from grpc._cython import cygrpc
 
 from pymilvus.client.call_context import CallContext, _api_level_md
@@ -1410,7 +1410,8 @@ class AsyncGrpcHandler:
         _, dynamic_fields = entity_helper.extract_dynamic_field_from_result(response)
         keys = [field_data.field_name for field_data in response.fields_data]
         filtered_keys = [k for k in keys if k != "$meta"]
-        results = [dict.fromkeys(filtered_keys) for _ in range(num_entities)]
+        template = dict.fromkeys(filtered_keys)
+        results = [template.copy() for _ in range(num_entities)]
         lazy_field_data = []
         for field_data in response.fields_data:
             lazy_extracted = entity_helper.extract_row_data_from_fields_data_v2(field_data, results)
@@ -1616,7 +1617,7 @@ class AsyncGrpcHandler:
             info_dict["field_name"] = response.index_descriptions[0].field_name
             info_dict["index_name"] = response.index_descriptions[0].index_name
             if info_dict.get("params"):
-                info_dict["params"] = json.loads(info_dict["params"])
+                info_dict["params"] = orjson.loads(info_dict["params"])
             info_dict["total_rows"] = response.index_descriptions[0].total_rows
             info_dict["indexed_rows"] = response.index_descriptions[0].indexed_rows
             info_dict["pending_index_rows"] = response.index_descriptions[0].pending_index_rows

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import logging
 import math
@@ -29,26 +30,28 @@ logger = logging.getLogger(__name__)
 CHECK_STR_ARRAY = True
 
 
+def _is_type_in_str(v: Any, t: Any):
+    if not isinstance(v, str):
+        return False
+    try:
+        t(v)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_int_type(v: Any):
+    return isinstance(v, (int, np.integer)) or _is_type_in_str(v, int)
+
+
+def _is_float_type(v: Any):
+    return isinstance(v, (float, np.floating)) or _is_type_in_str(v, float)
+
+
 def entity_is_sparse_matrix(entity: Any):
     if SciPyHelper.is_scipy_sparse(entity):
         return True
     try:
-
-        def is_type_in_str(v: Any, t: Any):
-            if not isinstance(v, str):
-                return False
-            try:
-                t(v)
-            except ValueError:
-                return False
-            return True
-
-        def is_int_type(v: Any):
-            return isinstance(v, (int, np.integer)) or is_type_in_str(v, int)
-
-        def is_float_type(v: Any):
-            return isinstance(v, (float, np.floating)) or is_type_in_str(v, float)
-
         # must be of multiple rows
         if len(entity) == 0:
             return False
@@ -60,7 +63,7 @@ def entity_is_sparse_matrix(entity: Any):
             pairs = item.items() if isinstance(item, dict) else item
             # each row must be a list of Tuple[int, float]. we allow empty sparse row
             for pair in pairs:
-                if len(pair) != 2 or not is_int_type(pair[0]) or not is_float_type(pair[1]):
+                if len(pair) != 2 or not _is_int_type(pair[0]) or not _is_float_type(pair[1]):
                     return False
     except Exception:
         return False
@@ -76,17 +79,18 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
             raise ParamError(
                 message=f"length of indices and values must be the same, got {len(indices)} and {len(values)}"
             )
-        data = b""
-        for i, v in sorted(zip(indices, values), key=lambda x: x[0]):
+        sorted_pairs = sorted(zip(indices, values), key=lambda x: x[0])
+        for i, v in sorted_pairs:
             if not (0 <= i < 2**32 - 1):
                 raise ParamError(
                     message=f"sparse vector index must be positive and less than 2^32-1: {i}"
                 )
             if math.isnan(v):
                 raise ParamError(message="sparse vector value must not be NaN")
-            data += struct.pack("I", i)
-            data += struct.pack("f", v)
-        return data
+        n = len(sorted_pairs)
+        # Pack all pairs at once: interleaved (uint32 index, float value) pairs
+        fmt = f"<{'If' * n}"
+        return struct.pack(fmt, *itertools.chain.from_iterable(sorted_pairs))
 
     if not entity_is_sparse_matrix(data):
         raise ParamError(message="input must be a sparse matrix in supported format")
@@ -102,7 +106,7 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
             )
     else:
         dim = 0
-        for _, row_data in enumerate(data):
+        for row_data in data:
             if SciPyHelper.is_scipy_sparse(row_data):
                 if row_data.shape[0] != 1:
                     raise ParamError(message="invalid input for sparse float vector: expect 1 row")
@@ -160,7 +164,7 @@ def get_max_len_of_var_char(field_info: Dict) -> int:
 
 def convert_to_str_array(orig_str_arr: Any, field_info: Dict, check: bool = True):
     arr = []
-    if Config.EncodeProtocol.lower() != "utf-8".lower():
+    if Config.EncodeProtocol.lower() != "utf-8":
         for s in orig_str_arr:
             arr.append(s.encode(Config.EncodeProtocol))
     else:
@@ -220,8 +224,7 @@ def convert_to_json(obj: object):
                 processed = {}
                 assign_to_parent(processed)
                 # Add items to stack for processing (reverse order to maintain original order)
-                items = list(current.items())
-                for k, v in reversed(items):
+                for k, v in reversed(tuple(current.items())):
                     stack.append((v, processed, k))
             elif isinstance(current, list):
                 # Process list: create new list with placeholders first
@@ -276,10 +279,11 @@ def convert_to_json(obj: object):
 
 
 def convert_to_json_arr(objs: List[object], field_info: Any):
+    field_name = field_info["name"]
     arr = []
     for obj in objs:
         if obj is None:
-            raise ParamError(message=f"field ({field_info['name']}) expects a non-None input")
+            raise ParamError(message=f"field ({field_name}) expects a non-None input")
         arr.append(convert_to_json(obj))
     return arr
 
@@ -345,6 +349,20 @@ def convert_to_array_of_vector(obj: List[Any], field_info: Any):
                 f_value = field_value.tolist()
             field_data.float_vector.data.extend(f_value)
 
+    elif element_type in (DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR):
+        all_bytes = b"".join(_convert_to_vector_bytes(fv, element_type) for fv in obj)
+        if element_type == DataType.FLOAT16_VECTOR:
+            field_data.float16_vector = all_bytes
+        else:
+            field_data.bfloat16_vector = all_bytes
+
+    elif element_type == DataType.INT8_VECTOR:
+        field_data.int8_vector = b"".join(_convert_to_vector_bytes(fv, element_type) for fv in obj)
+
+    elif element_type == DataType.BINARY_VECTOR:
+        field_data.binary_vector = b"".join(
+            fv if isinstance(fv, bytes) else bytes(fv) for fv in obj
+        )
     else:
         # todo(SpadeA): other types are now not supported. When it's supported, make sure empty
         # array is handled correctly.
@@ -356,6 +374,14 @@ def convert_to_array_of_vector(obj: List[Any], field_info: Any):
 
 def entity_to_array_arr(entity_values: List[Any], field_info: Any):
     return convert_to_array_arr(entity_values, field_info)
+
+
+_VECTOR_ATTR_MAP = {
+    DataType.INT8_VECTOR: "int8_vector",
+    DataType.BINARY_VECTOR: "binary_vector",
+    DataType.FLOAT16_VECTOR: "float16_vector",
+    DataType.BFLOAT16_VECTOR: "bfloat16_vector",
+}
 
 
 def flush_vector_bytes(
@@ -372,14 +398,7 @@ def flush_vector_bytes(
     if not bytes_list:
         return
 
-    vector_attr_map = {
-        DataType.INT8_VECTOR: "int8_vector",
-        DataType.BINARY_VECTOR: "binary_vector",
-        DataType.FLOAT16_VECTOR: "float16_vector",
-        DataType.BFLOAT16_VECTOR: "bfloat16_vector",
-    }
-
-    attr_name = vector_attr_map.get(field_data.type)
+    attr_name = _VECTOR_ATTR_MAP.get(field_data.type)
     if attr_name:
         setattr(field_data.vectors, attr_name, b"".join(bytes_list))
 
@@ -785,8 +804,9 @@ def extract_dynamic_field_from_result(raw: Any):
 
 def extract_array_row_data_with_validity(field_data: Any, entity_rows: List[Dict], row_count: int):
     field_name = field_data.field_name
-    data = field_data.scalars.array_data.data
-    element_type = field_data.scalars.array_data.element_type
+    array_data = field_data.scalars.array_data
+    data = array_data.data
+    element_type = array_data.element_type
     if element_type == DataType.INT64:
         [
             entity_rows[i].__setitem__(
@@ -842,8 +862,9 @@ def extract_array_row_data_with_validity(field_data: Any, entity_rows: List[Dict
 
 def extract_array_row_data_no_validity(field_data: Any, entity_rows: List[Dict], row_count: int):
     field_name = field_data.field_name
-    data = field_data.scalars.array_data.data
-    element_type = field_data.scalars.array_data.element_type
+    array_data = field_data.scalars.array_data
+    data = array_data.data
+    element_type = array_data.element_type
     if element_type == DataType.INT64:
         [entity_rows[i].__setitem__(field_name, data[i].long_data.data) for i in range(row_count)]
     elif element_type == DataType.BOOL:
@@ -868,25 +889,20 @@ def extract_array_row_data_no_validity(field_data: Any, entity_rows: List[Dict],
 
 
 def extract_array_row_data(field_data: Any, index: int):
-    array = field_data.scalars.array_data.data[index]
-    if field_data.scalars.array_data.element_type == DataType.INT64:
+    array_data = field_data.scalars.array_data
+    array = array_data.data[index]
+    element_type = array_data.element_type
+    if element_type == DataType.INT64:
         return array.long_data.data
-    if field_data.scalars.array_data.element_type == DataType.BOOL:
+    if element_type == DataType.BOOL:
         return array.bool_data.data
-    if field_data.scalars.array_data.element_type in (
-        DataType.INT8,
-        DataType.INT16,
-        DataType.INT32,
-    ):
+    if element_type in (DataType.INT8, DataType.INT16, DataType.INT32):
         return array.int_data.data
-    if field_data.scalars.array_data.element_type == DataType.FLOAT:
+    if element_type == DataType.FLOAT:
         return array.float_data.data
-    if field_data.scalars.array_data.element_type == DataType.DOUBLE:
+    if element_type == DataType.DOUBLE:
         return array.double_data.data
-    if field_data.scalars.array_data.element_type in (
-        DataType.STRING,
-        DataType.VARCHAR,
-    ):
+    if element_type in (DataType.STRING, DataType.VARCHAR):
         return array.string_data.data
     return None
 
@@ -1043,174 +1059,152 @@ def extract_row_data_from_fields_data(
         if field_data.type == DataType.STRING:
             raise MilvusException(message="Not support string yet")
 
-        if field_data.type == DataType.BOOL and len(field_data.scalars.bool_data.data) >= index:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = field_data.scalars.bool_data.data[index]
-            return
+        field_name = field_data.field_name
+        valid_data = field_data.valid_data
+        has_valid = len(valid_data) > 0
+        is_null = has_valid and valid_data[index] is False
 
-        if (
-            field_data.type in (DataType.INT8, DataType.INT16, DataType.INT32)
-            and len(field_data.scalars.int_data.data) >= index
-        ):
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = field_data.scalars.int_data.data[index]
-            return
-
-        if field_data.type == DataType.INT64 and len(field_data.scalars.long_data.data) >= index:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = field_data.scalars.long_data.data[index]
-            return
-
-        if field_data.type == DataType.FLOAT and len(field_data.scalars.float_data.data) >= index:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = np.single(field_data.scalars.float_data.data[index])
-            return
-
-        if field_data.type == DataType.DOUBLE and len(field_data.scalars.double_data.data) >= index:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = field_data.scalars.double_data.data[index]
-            return
-
-        if (
-            field_data.type == DataType.VARCHAR
-            and len(field_data.scalars.string_data.data) >= index
-        ):
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = field_data.scalars.string_data.data[index]
-            return
-
-        if (
-            field_data.type == DataType.GEOMETRY
-            and len(field_data.scalars.geometry_wkt_data.data) >= index
-        ):
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                entity_row_data[field_data.field_name] = None
-                return
-            entity_row_data[field_data.field_name] = field_data.scalars.geometry_wkt_data.data[
-                index
-            ]
-            return
-
-        if field_data.type == DataType.JSON and len(field_data.scalars.json_data.data) >= index:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            try:
-                json_dict = orjson.loads(field_data.scalars.json_data.data[index])
-            except Exception as e:
-                logger.error(
-                    f"extract_row_data_from_fields_data::Failed to load JSON data: {e}, original data: {field_data.scalars.json_data.data[index]}"
-                )
-                raise
-
-            if not field_data.is_dynamic:
-                row_data[field_data.field_name] = json_dict
+        if field_data.type == DataType.BOOL:
+            scalar_data = field_data.scalars.bool_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else scalar_data[index]
                 return
 
-            if not dynamic_fields:
-                row_data.update(json_dict)
+        if field_data.type in (DataType.INT8, DataType.INT16, DataType.INT32):
+            scalar_data = field_data.scalars.int_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else scalar_data[index]
                 return
 
-            row_data.update({k: v for k, v in json_dict.items() if k in dynamic_fields})
-            return
+        if field_data.type == DataType.INT64:
+            scalar_data = field_data.scalars.long_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else scalar_data[index]
+                return
+
+        if field_data.type == DataType.FLOAT:
+            scalar_data = field_data.scalars.float_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else np.single(scalar_data[index])
+                return
+
+        if field_data.type == DataType.DOUBLE:
+            scalar_data = field_data.scalars.double_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else scalar_data[index]
+                return
+
+        if field_data.type == DataType.VARCHAR:
+            scalar_data = field_data.scalars.string_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else scalar_data[index]
+                return
+
+        if field_data.type == DataType.GEOMETRY:
+            scalar_data = field_data.scalars.geometry_wkt_data.data
+            if len(scalar_data) >= index:
+                entity_row_data[field_name] = None if is_null else scalar_data[index]
+                return
+
+        if field_data.type == DataType.JSON:
+            scalar_data = field_data.scalars.json_data.data
+            if len(scalar_data) >= index:
+                if is_null:
+                    row_data[field_name] = None
+                    return
+                try:
+                    json_dict = orjson.loads(scalar_data[index])
+                except Exception as e:
+                    logger.error(
+                        f"extract_row_data_from_fields_data::Failed to load JSON data: {e}, original data: {scalar_data[index]}"
+                    )
+                    raise
+
+                if not field_data.is_dynamic:
+                    row_data[field_name] = json_dict
+                    return
+
+                if not dynamic_fields:
+                    row_data.update(json_dict)
+                    return
+
+                row_data.update({k: v for k, v in json_dict.items() if k in dynamic_fields})
+                return
         if field_data.type == DataType.ARRAY and len(field_data.scalars.array_data.data) >= index:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
-                return
-            row_data[field_data.field_name] = extract_array_row_data(field_data, index)
+            row_data[field_name] = None if is_null else extract_array_row_data(field_data, index)
+            return
 
-        elif field_data.type == DataType.FLOAT_VECTOR:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
+        if field_data.type == DataType.FLOAT_VECTOR:
+            if is_null:
+                row_data[field_name] = None
             else:
                 dim = field_data.vectors.dim
                 phys_idx = get_physical_index(field_data, index)
-                if len(field_data.vectors.float_vector.data) >= (phys_idx + 1) * dim:
+                float_data = field_data.vectors.float_vector.data
+                if len(float_data) >= (phys_idx + 1) * dim:
                     start_pos, end_pos = phys_idx * dim, (phys_idx + 1) * dim
-                    # Here we use numpy.array to convert the float64 values to numpy.float32 values,
-                    # and return a list of numpy.float32 to users
-                    # By using numpy.array, performance improved by 60%
-                    # for topk=16384 dim=1536 case.
-                    arr = np.array(
-                        field_data.vectors.float_vector.data[start_pos:end_pos], dtype=np.float32
-                    )
-                    row_data[field_data.field_name] = list(arr)
+                    arr = np.array(float_data[start_pos:end_pos], dtype=np.float32)
+                    row_data[field_name] = list(arr)
         elif field_data.type == DataType.BINARY_VECTOR:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
+            if is_null:
+                row_data[field_name] = None
             else:
                 dim = field_data.vectors.dim
                 blen = dim // 8
                 phys_idx = get_physical_index(field_data, index)
-                if len(field_data.vectors.binary_vector) >= (phys_idx + 1) * blen:
+                binary_data = field_data.vectors.binary_vector
+                if len(binary_data) >= (phys_idx + 1) * blen:
                     start_pos, end_pos = phys_idx * blen, (phys_idx + 1) * blen
-                    row_data[field_data.field_name] = [
-                        field_data.vectors.binary_vector[start_pos:end_pos]
-                    ]
+                    row_data[field_name] = [binary_data[start_pos:end_pos]]
         elif field_data.type == DataType.BFLOAT16_VECTOR:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
+            if is_null:
+                row_data[field_name] = None
             else:
                 dim = field_data.vectors.dim
                 byte_per_row = dim * 2
                 phys_idx = get_physical_index(field_data, index)
-                if len(field_data.vectors.bfloat16_vector) >= (phys_idx + 1) * byte_per_row:
+                vec_data = field_data.vectors.bfloat16_vector
+                if len(vec_data) >= (phys_idx + 1) * byte_per_row:
                     start_pos, end_pos = phys_idx * byte_per_row, (phys_idx + 1) * byte_per_row
-                    row_data[field_data.field_name] = [
-                        field_data.vectors.bfloat16_vector[start_pos:end_pos]
-                    ]
+                    row_data[field_name] = [vec_data[start_pos:end_pos]]
         elif field_data.type == DataType.FLOAT16_VECTOR:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
+            if is_null:
+                row_data[field_name] = None
             else:
                 dim = field_data.vectors.dim
                 byte_per_row = dim * 2
                 phys_idx = get_physical_index(field_data, index)
-                if len(field_data.vectors.float16_vector) >= (phys_idx + 1) * byte_per_row:
+                vec_data = field_data.vectors.float16_vector
+                if len(vec_data) >= (phys_idx + 1) * byte_per_row:
                     start_pos, end_pos = phys_idx * byte_per_row, (phys_idx + 1) * byte_per_row
-                    row_data[field_data.field_name] = [
-                        field_data.vectors.float16_vector[start_pos:end_pos]
-                    ]
+                    row_data[field_name] = [vec_data[start_pos:end_pos]]
         elif field_data.type == DataType.SPARSE_FLOAT_VECTOR:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
+            if is_null:
+                row_data[field_name] = None
             else:
                 phys_idx = get_physical_index(field_data, index)
-                row_data[field_data.field_name] = sparse_parse_single_row(
+                row_data[field_name] = sparse_parse_single_row(
                     field_data.vectors.sparse_float_vector.contents[phys_idx]
                 )
         elif field_data.type == DataType.INT8_VECTOR:
-            if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
-                row_data[field_data.field_name] = None
+            if is_null:
+                row_data[field_name] = None
             else:
                 dim = field_data.vectors.dim
                 phys_idx = get_physical_index(field_data, index)
-                if len(field_data.vectors.int8_vector) >= (phys_idx + 1) * dim:
+                vec_data = field_data.vectors.int8_vector
+                if len(vec_data) >= (phys_idx + 1) * dim:
                     start_pos, end_pos = phys_idx * dim, (phys_idx + 1) * dim
-                    row_data[field_data.field_name] = [
-                        field_data.vectors.int8_vector[start_pos:end_pos]
-                    ]
+                    row_data[field_name] = [vec_data[start_pos:end_pos]]
         elif (
             field_data.type == DataType._ARRAY_OF_VECTOR
             and len(field_data.vectors.vector_array.data) >= index
         ):
-            row_data[field_data.field_name] = extract_vector_array_row_data(field_data, index)
+            row_data[field_name] = extract_vector_array_row_data(field_data, index)
         elif field_data.type == DataType._ARRAY_OF_STRUCT:
-            row_data[field_data.field_name] = {}
+            row_data[field_name] = {}
             for sub_field_data in field_data.struct_arrays.fields:
-                check_append(sub_field_data, row_data[field_data.field_name])
+                check_append(sub_field_data, row_data[field_name])
 
     for field_data in fields_data:
         check_append(field_data, entity_row_data)
@@ -1218,73 +1212,33 @@ def extract_row_data_from_fields_data(
     return entity_row_data
 
 
+_ARRAY_DATA_ATTRS = (
+    "string_data",
+    "int_data",
+    "long_data",
+    "float_data",
+    "double_data",
+    "bool_data",
+)
+
+
 def get_array_length(array_item: Any) -> int:
     """Get the length of an array field from its data."""
-    if hasattr(array_item, "string_data") and hasattr(array_item.string_data, "data"):
-        length = len(array_item.string_data.data)
-        if length > 0:
-            return length
-    if hasattr(array_item, "int_data") and hasattr(array_item.int_data, "data"):
-        length = len(array_item.int_data.data)
-        if length > 0:
-            return length
-    if hasattr(array_item, "long_data") and hasattr(array_item.long_data, "data"):
-        length = len(array_item.long_data.data)
-        if length > 0:
-            return length
-    if hasattr(array_item, "float_data") and hasattr(array_item.float_data, "data"):
-        length = len(array_item.float_data.data)
-        if length > 0:
-            return length
-    if hasattr(array_item, "double_data") and hasattr(array_item.double_data, "data"):
-        length = len(array_item.double_data.data)
-        if length > 0:
-            return length
-    if hasattr(array_item, "bool_data") and hasattr(array_item.bool_data, "data"):
-        length = len(array_item.bool_data.data)
-        if length > 0:
-            return length
+    for attr_name in _ARRAY_DATA_ATTRS:
+        data = getattr(array_item, attr_name, None)
+        if data is not None:
+            length = len(data.data)
+            if length > 0:
+                return length
     return 0
 
 
 def get_array_value_at_index(array_item: Any, idx: int) -> Any:
     """Get the value at a specific index from an array field."""
-    if (
-        hasattr(array_item, "string_data")
-        and hasattr(array_item.string_data, "data")
-        and len(array_item.string_data.data) > idx
-    ):
-        return array_item.string_data.data[idx]
-    if (
-        hasattr(array_item, "int_data")
-        and hasattr(array_item.int_data, "data")
-        and len(array_item.int_data.data) > idx
-    ):
-        return array_item.int_data.data[idx]
-    if (
-        hasattr(array_item, "long_data")
-        and hasattr(array_item.long_data, "data")
-        and len(array_item.long_data.data) > idx
-    ):
-        return array_item.long_data.data[idx]
-    if (
-        hasattr(array_item, "float_data")
-        and hasattr(array_item.float_data, "data")
-        and len(array_item.float_data.data) > idx
-    ):
-        return array_item.float_data.data[idx]
-    if (
-        hasattr(array_item, "double_data")
-        and hasattr(array_item.double_data, "data")
-        and len(array_item.double_data.data) > idx
-    ):
-        return array_item.double_data.data[idx]
-    if (
-        hasattr(array_item, "bool_data")
-        and hasattr(array_item.bool_data, "data")
-        and len(array_item.bool_data.data) > idx
-    ):
-        return array_item.bool_data.data[idx]
+    for attr_name in _ARRAY_DATA_ATTRS:
+        data = getattr(array_item, attr_name, None)
+        if data is not None and len(data.data) > idx:
+            return data.data[idx]
     return None
 
 

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -349,20 +349,6 @@ def convert_to_array_of_vector(obj: List[Any], field_info: Any):
                 f_value = field_value.tolist()
             field_data.float_vector.data.extend(f_value)
 
-    elif element_type in (DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR):
-        all_bytes = b"".join(_convert_to_vector_bytes(fv, element_type) for fv in obj)
-        if element_type == DataType.FLOAT16_VECTOR:
-            field_data.float16_vector = all_bytes
-        else:
-            field_data.bfloat16_vector = all_bytes
-
-    elif element_type == DataType.INT8_VECTOR:
-        field_data.int8_vector = b"".join(_convert_to_vector_bytes(fv, element_type) for fv in obj)
-
-    elif element_type == DataType.BINARY_VECTOR:
-        field_data.binary_vector = b"".join(
-            fv if isinstance(fv, bytes) else bytes(fv) for fv in obj
-        )
     else:
         # todo(SpadeA): other types are now not supported. When it's supported, make sure empty
         # array is handled correctly.

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1,5 +1,4 @@
 import base64
-import json
 import logging
 import socket
 import threading
@@ -9,6 +8,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Union
 from urllib import parse
 
 import grpc
+import orjson
 from grpc._cython import cygrpc
 
 from pymilvus.client.call_context import CallContext, _api_level_md
@@ -1163,7 +1163,6 @@ class GrpcHandler:
             raise e from e
 
     @retry_on_rpc_failure()
-    @retry_on_rpc_failure()
     def search(
         self,
         collection_name: str,
@@ -1531,7 +1530,7 @@ class GrpcHandler:
             info_dict["field_name"] = response.index_descriptions[0].field_name
             info_dict["index_name"] = response.index_descriptions[0].index_name
             if info_dict.get("params"):
-                info_dict["params"] = json.loads(info_dict["params"])
+                info_dict["params"] = orjson.loads(info_dict["params"])
             info_dict["total_rows"] = response.index_descriptions[0].total_rows
             info_dict["indexed_rows"] = response.index_descriptions[0].indexed_rows
             info_dict["pending_index_rows"] = response.index_descriptions[0].pending_index_rows
@@ -2142,7 +2141,8 @@ class GrpcHandler:
 
         keys = [field_data.field_name for field_data in response.fields_data]
         filtered_keys = [k for k in keys if k != "$meta"]
-        results = [dict.fromkeys(filtered_keys) for _ in range(num_entities)]
+        template = dict.fromkeys(filtered_keys)
+        results = [template.copy() for _ in range(num_entities)]
         lazy_field_data = []
         for field_data in response.fields_data:
             lazy_extracted = entity_helper.extract_row_data_from_fields_data_v2(field_data, results)

--- a/pymilvus/client/search_result.py
+++ b/pymilvus/client/search_result.py
@@ -9,6 +9,62 @@ from pymilvus.exceptions import MilvusException
 from pymilvus.grpc_gen import common_pb2, schema_pb2
 from pymilvus.grpc_gen.schema_pb2 import FieldData
 
+_SCALAR_TYPES = frozenset(
+    {
+        DataType.BOOL,
+        DataType.INT8,
+        DataType.INT16,
+        DataType.INT32,
+        DataType.INT64,
+        DataType.FLOAT,
+        DataType.DOUBLE,
+        DataType.VARCHAR,
+        DataType.GEOMETRY,
+        DataType.TIMESTAMPTZ,
+    }
+)
+
+_DENSE_VECTOR_TYPES = frozenset(
+    {
+        DataType.FLOAT_VECTOR,
+        DataType.BINARY_VECTOR,
+        DataType.BFLOAT16_VECTOR,
+        DataType.FLOAT16_VECTOR,
+        DataType.INT8_VECTOR,
+    }
+)
+
+_HALF_PRECISION_VECTOR_TYPES = frozenset(
+    {
+        DataType.BFLOAT16_VECTOR,
+        DataType.FLOAT16_VECTOR,
+    }
+)
+
+_SCALAR_DATA_ATTR = {
+    DataType.BOOL: "bool_data",
+    DataType.INT8: "int_data",
+    DataType.INT16: "int_data",
+    DataType.INT32: "int_data",
+    DataType.INT64: "long_data",
+    DataType.FLOAT: "float_data",
+    DataType.DOUBLE: "double_data",
+    DataType.VARCHAR: "string_data",
+    DataType.TIMESTAMPTZ: "string_data",
+    DataType.GEOMETRY: "geometry_wkt_data",
+    DataType.JSON: "json_data",
+    DataType.ARRAY: "array_data",
+}
+
+_VECTOR_DATA_ATTR = {
+    DataType.FLOAT_VECTOR: "float_vector",
+    DataType.BINARY_VECTOR: "binary_vector",
+    DataType.BFLOAT16_VECTOR: "bfloat16_vector",
+    DataType.FLOAT16_VECTOR: "float16_vector",
+    DataType.INT8_VECTOR: "int8_vector",
+    DataType.SPARSE_FLOAT_VECTOR: "sparse_float_vector",
+}
+
 from . import entity_helper
 
 logger = logging.getLogger(__name__)
@@ -41,6 +97,7 @@ class HybridHits(list):
         self.lazy_field_data = []
         self.has_materialized = False
         self.start = start
+        self._prefix_sum_cache = {}
 
         col_results = {}
 
@@ -48,18 +105,7 @@ class HybridHits(list):
             has_valid = len(field_data.valid_data) > 0
             field_name = field_data.field_name
 
-            if field_data.type in [
-                DataType.BOOL,
-                DataType.INT8,
-                DataType.INT16,
-                DataType.INT32,
-                DataType.INT64,
-                DataType.FLOAT,
-                DataType.DOUBLE,
-                DataType.VARCHAR,
-                DataType.GEOMETRY,
-                DataType.TIMESTAMPTZ,
-            ]:
+            if field_data.type in _SCALAR_TYPES:
                 data = get_field_data(field_data)
                 col_results[field_name] = apply_valid_data(
                     data[start:end],
@@ -67,8 +113,9 @@ class HybridHits(list):
                 )
 
             elif field_data.type == DataType.ARRAY:
-                element_type = field_data.scalars.array_data.element_type
-                data = field_data.scalars.array_data.data[start:end]
+                array_data = field_data.scalars.array_data
+                element_type = array_data.element_type
+                data = array_data.data[start:end]
                 col_results[field_name] = apply_valid_data(
                     extract_array_row_data(data, element_type),
                     field_data.valid_data[start:end] if has_valid else None,
@@ -140,9 +187,6 @@ class HybridHits(list):
         Uses prefix sum for O(1) lookup instead of O(n) iteration.
         Caches prefix sum in instance variable using field_data id as key.
         """
-        if not hasattr(self, "_prefix_sum_cache"):
-            self._prefix_sum_cache = {}
-
         field_id = id(field_data)
         if field_id not in self._prefix_sum_cache:
             if len(field_data.valid_data) == 0:
@@ -158,26 +202,21 @@ class HybridHits(list):
 
     def materialize(self):
         if not self.has_materialized:
+            n = len(self)
             for field_data in self.lazy_field_data:
                 field_name = field_data.field_name
                 has_valid = len(field_data.valid_data) > 0
 
-                if field_data.type in [
-                    DataType.FLOAT_VECTOR,
-                    DataType.BINARY_VECTOR,
-                    DataType.BFLOAT16_VECTOR,
-                    DataType.FLOAT16_VECTOR,
-                    DataType.INT8_VECTOR,
-                ]:
+                if field_data.type in _DENSE_VECTOR_TYPES:
                     data = get_field_data(field_data)
                     dim = field_data.vectors.dim
-                    if field_data.type in [DataType.BINARY_VECTOR]:
+                    if field_data.type == DataType.BINARY_VECTOR:
                         dim = dim // 8
-                    elif field_data.type in [DataType.BFLOAT16_VECTOR, DataType.FLOAT16_VECTOR]:
+                    elif field_data.type in _HALF_PRECISION_VECTOR_TYPES:
                         dim = dim * 2
 
                     if has_valid:
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             actual_idx = self.start + i
                             if not field_data.valid_data[actual_idx]:
@@ -189,13 +228,13 @@ class HybridHits(list):
                                 ]
                     else:
                         idx = self.start * dim
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             item["entity"][field_name] = data[idx : idx + dim]
                             idx += dim
                 elif field_data.type == DataType.SPARSE_FLOAT_VECTOR:
                     if has_valid:
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             actual_idx = self.start + i
                             if not field_data.valid_data[actual_idx]:
@@ -207,7 +246,7 @@ class HybridHits(list):
                                 )[0]
                     else:
                         idx = self.start
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             item["entity"][field_name] = entity_helper.sparse_proto_to_rows(
                                 field_data.vectors.sparse_float_vector, idx, idx + 1
@@ -215,7 +254,7 @@ class HybridHits(list):
                             idx += 1
                 elif field_data.type == DataType.JSON:
                     idx = self.start
-                    for i in range(len(self)):
+                    for i in range(n):
                         item = self.get_raw_item(i)
                         if field_data.valid_data and not field_data.valid_data[idx]:
                             item["entity"][field_name] = None
@@ -248,7 +287,7 @@ class HybridHits(list):
                     idx = self.start
                     struct_arrays = get_field_data(field_data)
                     if struct_arrays and hasattr(struct_arrays, "fields"):
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             item["entity"][field_name] = (
                                 entity_helper.extract_struct_array_from_column_data(
@@ -257,7 +296,7 @@ class HybridHits(list):
                             )
                             idx += 1
                     else:
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             item["entity"][field_name] = None
                 elif field_data.type == DataType._ARRAY_OF_VECTOR:
@@ -266,7 +305,7 @@ class HybridHits(list):
                         field_data.vectors, "vector_array"
                     ):
                         vector_array = field_data.vectors.vector_array
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             if idx < len(vector_array.data):
                                 vector_data = vector_array.data[idx]
@@ -283,7 +322,7 @@ class HybridHits(list):
                                 item["entity"][field_name] = []
                             idx += 1
                     else:
-                        for i in range(len(self)):
+                        for i in range(n):
                             item = self.get_raw_item(i)
                             item["entity"][field_name] = []
                 else:
@@ -601,41 +640,20 @@ class SearchResult(list):
 
 
 def get_field_data(field_data: FieldData):
-    if field_data.type == DataType.BOOL:
-        return field_data.scalars.bool_data.data
-    if field_data.type in {DataType.INT8, DataType.INT16, DataType.INT32}:
-        return field_data.scalars.int_data.data
-    if field_data.type == DataType.INT64:
-        return field_data.scalars.long_data.data
-    if field_data.type == DataType.FLOAT:
-        return field_data.scalars.float_data.data
-    if field_data.type == DataType.DOUBLE:
-        return field_data.scalars.double_data.data
-    if field_data.type in (DataType.VARCHAR, DataType.TIMESTAMPTZ):
-        return field_data.scalars.string_data.data
-    if field_data.type == DataType.GEOMETRY:
-        return field_data.scalars.geometry_wkt_data.data
-    if field_data.type == DataType.JSON:
-        return field_data.scalars.json_data.data
-    if field_data.type == DataType.ARRAY:
-        return field_data.scalars.array_data.data
-    if field_data.type == DataType.FLOAT_VECTOR:
-        return field_data.vectors.float_vector.data
-    if field_data.type == DataType.BINARY_VECTOR:
-        return field_data.vectors.binary_vector
-    if field_data.type == DataType.BFLOAT16_VECTOR:
-        return field_data.vectors.bfloat16_vector
-    if field_data.type == DataType.FLOAT16_VECTOR:
-        return field_data.vectors.float16_vector
-    if field_data.type == DataType.INT8_VECTOR:
-        return field_data.vectors.int8_vector
-    if field_data.type == DataType.SPARSE_FLOAT_VECTOR:
-        return field_data.vectors.sparse_float_vector
-    if field_data.type == DataType._ARRAY_OF_STRUCT:
+    field_type = field_data.type
+    scalar_attr = _SCALAR_DATA_ATTR.get(field_type)
+    if scalar_attr is not None:
+        return getattr(field_data.scalars, scalar_attr).data
+    vector_attr = _VECTOR_DATA_ATTR.get(field_type)
+    if vector_attr is not None:
+        obj = getattr(field_data.vectors, vector_attr)
+        # float_vector returns .data, others return the bytes/proto directly
+        return obj.data if field_type == DataType.FLOAT_VECTOR else obj
+    if field_type == DataType._ARRAY_OF_STRUCT:
         return field_data.struct_arrays
-    if field_data.type == DataType._ARRAY_OF_VECTOR:
+    if field_type == DataType._ARRAY_OF_VECTOR:
         return field_data.vectors.vector_array
-    msg = f"Unsupported field type: {field_data.type}"
+    msg = f"Unsupported field type: {field_type}"
     raise MilvusException(msg)
 
 

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import functools
 import logging
 import time
@@ -328,96 +327,79 @@ def retry_on_rpc_failure(
     return wrapper
 
 
+def _log_rpc_error(inner_name: str, label: str, msg: str, start_ts: float):
+    if not LOGGER.isEnabledFor(logging.ERROR):
+        return
+    elapsed_ms = (time.monotonic() - start_ts) * 1000
+    tb_str = traceback.format_exc()
+    LOGGER.error(
+        f"{label}: [{inner_name}], {msg}, <elapsed:{elapsed_ms:.1f}ms>\nTraceback:\n{tb_str}"
+    )
+
+
 def error_handler(func_name: str = ""):
     def wrapper(func: Callable):
         if asyncio.iscoroutinefunction(func):
+            inner_name = func_name or func.__name__
 
             @functools.wraps(func)
             async def async_handler(*args, **kwargs):
-                inner_name = func_name or func.__name__
-                record_dict = {}
+                start_ts = time.monotonic()
                 try:
-                    record_dict["RPC start"] = str(datetime.datetime.now())
                     return await func(*args, **kwargs)
                 except MilvusException as e:
-                    record_dict["RPC error"] = str(datetime.datetime.now())
-                    tb_str = traceback.format_exc()
-                    LOGGER.error(
-                        f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>\n"
-                        f"Traceback:\n{tb_str}"
-                    )
+                    _log_rpc_error(inner_name, "RPC error", str(e), start_ts)
                     raise e from e
                 except grpc.FutureTimeoutError as e:
-                    record_dict["gRPC timeout"] = str(datetime.datetime.now())
-                    tb_str = traceback.format_exc()
-                    LOGGER.error(
-                        f"grpc Timeout: [{inner_name}], <{e.__class__.__name__}: "
-                        f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
-                        f"Traceback:\n{tb_str}"
+                    _log_rpc_error(
+                        inner_name,
+                        "grpc Timeout",
+                        f"<{e.__class__.__name__}: {e.code()}, {e.details()}>",
+                        start_ts,
                     )
                     raise e from e
                 except grpc.RpcError as e:
-                    record_dict["gRPC error"] = str(datetime.datetime.now())
-                    tb_str = traceback.format_exc()
-                    LOGGER.error(
-                        f"grpc RpcError: [{inner_name}], <{e.__class__.__name__}: "
-                        f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
-                        f"Traceback:\n{tb_str}"
+                    _log_rpc_error(
+                        inner_name,
+                        "grpc RpcError",
+                        f"<{e.__class__.__name__}: {e.code()}, {e.details()}>",
+                        start_ts,
                     )
                     raise e from e
                 except Exception as e:
-                    record_dict["Exception"] = str(datetime.datetime.now())
-                    tb_str = traceback.format_exc()
-                    LOGGER.error(
-                        f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>\n"
-                        f"Traceback:\n{tb_str}"
-                    )
+                    _log_rpc_error(inner_name, "Unexpected error", str(e), start_ts)
                     raise MilvusException(message=f"Unexpected error, message=<{e!s}>") from e
 
             return async_handler
 
+        inner_name = func_name or func.__name__
+
         @functools.wraps(func)
         def handler(*args, **kwargs):
-            inner_name = func_name
-            if inner_name == "":
-                inner_name = func.__name__
-            record_dict = {}
+            start_ts = time.monotonic()
             try:
-                record_dict["RPC start"] = str(datetime.datetime.now())
                 return func(*args, **kwargs)
             except MilvusException as e:
-                record_dict["RPC error"] = str(datetime.datetime.now())
-                tb_str = traceback.format_exc()
-                LOGGER.error(
-                    f"RPC error: [{inner_name}], {e}, <Time:{record_dict}>\n"
-                    f"Traceback:\n{tb_str}"
-                )
+                _log_rpc_error(inner_name, "RPC error", str(e), start_ts)
                 raise e from e
             except grpc.FutureTimeoutError as e:
-                record_dict["gRPC timeout"] = str(datetime.datetime.now())
-                tb_str = traceback.format_exc()
-                LOGGER.error(
-                    f"grpc Timeout: [{inner_name}], <{e.__class__.__name__}: "
-                    f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
-                    f"Traceback:\n{tb_str}"
+                _log_rpc_error(
+                    inner_name,
+                    "grpc Timeout",
+                    f"<{e.__class__.__name__}: {e.code()}, {e.details()}>",
+                    start_ts,
                 )
                 raise e from e
             except grpc.RpcError as e:
-                record_dict["gRPC error"] = str(datetime.datetime.now())
-                tb_str = traceback.format_exc()
-                LOGGER.error(
-                    f"grpc RpcError: [{inner_name}], <{e.__class__.__name__}: "
-                    f"{e.code()}, {e.details()}>, <Time:{record_dict}>\n"
-                    f"Traceback:\n{tb_str}"
+                _log_rpc_error(
+                    inner_name,
+                    "grpc RpcError",
+                    f"<{e.__class__.__name__}: {e.code()}, {e.details()}>",
+                    start_ts,
                 )
                 raise e from e
             except Exception as e:
-                record_dict["Exception"] = str(datetime.datetime.now())
-                tb_str = traceback.format_exc()
-                LOGGER.error(
-                    f"Unexpected error: [{inner_name}], {e}, <Time: {record_dict}>\n"
-                    f"Traceback:\n{tb_str}"
-                )
+                _log_rpc_error(inner_name, "Unexpected error", str(e), start_ts)
                 raise MilvusException(message=f"Unexpected error, message=<{e!s}>") from e
 
         return handler

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -371,13 +371,13 @@ class AsyncMilvusClient(BaseMilvusClient):
         **kwargs,
     ) -> Dict:
         # If no data provided, we cannot input anything
-        if isinstance(data, Dict):
+        if isinstance(data, dict):
             data = [data]
 
         msg = "wrong type of argument 'data',"
         msg += f"expected 'Dict' or list of 'Dict', got '{type(data).__name__}'"
 
-        if not isinstance(data, List):
+        if not isinstance(data, list):
             raise TypeError(msg)
 
         if len(data) == 0:
@@ -432,13 +432,13 @@ class AsyncMilvusClient(BaseMilvusClient):
             Dict: Number of rows that were upserted.
         """
         # If no data provided, we cannot input anything
-        if isinstance(data, Dict):
+        if isinstance(data, dict):
             data = [data]
 
         msg = "wrong type of argument 'data',"
         msg += f"expected 'Dict' or list of 'Dict', got '{type(data).__name__}'"
 
-        if not isinstance(data, List):
+        if not isinstance(data, list):
             raise TypeError(msg)
 
         if len(data) == 0:

--- a/pymilvus/milvus_client/base.py
+++ b/pymilvus/milvus_client/base.py
@@ -135,7 +135,7 @@ class BaseMilvusClient:
             return {}
 
         for field_dict in fields:
-            if field_dict.get("is_primary", None) is not None:
+            if field_dict.get("is_primary"):
                 return field_dict
 
         return {}

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -219,13 +219,13 @@ class MilvusClient(BaseMilvusClient):
             Dict: Number of rows that were inserted and the inserted primary key list.
         """
         # If no data provided, we cannot input anything
-        if isinstance(data, Dict):
+        if isinstance(data, dict):
             data = [data]
 
         msg = "wrong type of argument 'data',"
         msg += f"expected 'Dict' or list of 'Dict', got '{type(data).__name__}'"
 
-        if not isinstance(data, List):
+        if not isinstance(data, list):
             raise TypeError(msg)
 
         if len(data) == 0:
@@ -283,13 +283,13 @@ class MilvusClient(BaseMilvusClient):
             Dict: Number of rows that were upserted.
         """
         # If no data provided, we cannot input anything
-        if isinstance(data, Dict):
+        if isinstance(data, dict):
             data = [data]
 
         msg = "wrong type of argument 'data',"
         msg += f"expected 'Dict' or list of 'Dict', got '{type(data).__name__}'"
 
-        if not isinstance(data, List):
+        if not isinstance(data, list):
             raise TypeError(msg)
 
         if len(data) == 0:

--- a/tests/benchmark/test_perf_improvements.py
+++ b/tests/benchmark/test_perf_improvements.py
@@ -1,0 +1,1148 @@
+"""Benchmarks for general performance improvements in pymilvus.
+
+Each benchmark compares the old (before) implementation against the new (after)
+implementation to demonstrate the performance improvement.
+
+Run with:
+    pytest tests/benchmark/test_perf_improvements.py -v --benchmark-sort=name
+"""
+
+import logging
+import struct
+import time
+import traceback
+from copy import deepcopy
+from typing import Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. sparse_float_row_to_bytes: bytes concat vs struct.pack batch
+# ---------------------------------------------------------------------------
+def _sparse_row_old(indices, values):
+    """Old: O(n^2) bytes concatenation in loop."""
+    data = b""
+    for i, v in sorted(zip(indices, values), key=lambda x: x[0]):
+        data += struct.pack("I", i)
+        data += struct.pack("f", v)
+    return data
+
+
+def _sparse_row_new(indices, values):
+    """New: single struct.pack call with batch format."""
+    sorted_pairs = sorted(zip(indices, values), key=lambda x: x[0])
+    n = len(sorted_pairs)
+    fmt = f"<{'If' * n}"
+    flat = []
+    for i, v in sorted_pairs:
+        flat.append(i)
+        flat.append(v)
+    return struct.pack(fmt, *flat)
+
+
+@pytest.mark.benchmark(group="sparse_row_to_bytes")
+class TestSparseRowToBytes:
+    SIZES: tuple = (10, 100, 1000)
+
+    @pytest.fixture(params=SIZES)
+    def sparse_data(self, request):
+        n = request.param
+        indices = list(range(n))
+        values = [float(i) * 0.1 for i in range(n)]
+        return indices, values
+
+    def test_old_bytes_concat(self, benchmark, sparse_data):
+        indices, values = sparse_data
+        benchmark(_sparse_row_old, indices, values)
+
+    def test_new_struct_pack_batch(self, benchmark, sparse_data):
+        indices, values = sparse_data
+        result = benchmark(_sparse_row_new, indices, values)
+        expected = _sparse_row_old(indices, values)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 2. convert_to_array_of_vector: bytes concat vs b"".join
+# ---------------------------------------------------------------------------
+def _bytes_concat_old(chunks):
+    """Old: O(n^2) bytes concatenation."""
+    all_bytes = b""
+    for chunk in chunks:
+        all_bytes += chunk
+    return all_bytes
+
+
+def _bytes_concat_new(chunks):
+    """New: b''.join (O(n))."""
+    return b"".join(chunks)
+
+
+@pytest.mark.benchmark(group="bytes_concat")
+class TestBytesConcat:
+    SIZES: tuple = (10, 100, 1000)
+
+    @pytest.fixture(params=SIZES)
+    def byte_chunks(self, request):
+        n = request.param
+        return [b"\x00" * 128 for _ in range(n)]
+
+    def test_old_bytes_concat(self, benchmark, byte_chunks):
+        benchmark(_bytes_concat_old, byte_chunks)
+
+    def test_new_bytes_join(self, benchmark, byte_chunks):
+        result = benchmark(_bytes_concat_new, byte_chunks)
+        expected = _bytes_concat_old(byte_chunks)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 3. get_params: deepcopy vs dict()
+# ---------------------------------------------------------------------------
+def _get_params_old(search_params):
+    params = deepcopy(search_params.get("params", {}))
+    for key, value in search_params.items():
+        if key in params:
+            pass
+        elif key != "params":
+            params[key] = value
+    return params
+
+
+def _get_params_new(search_params):
+    params = dict(search_params.get("params", {}))
+    for key, value in search_params.items():
+        if key in params:
+            pass
+        elif key != "params":
+            params[key] = value
+    return params
+
+
+@pytest.mark.benchmark(group="get_params")
+class TestGetParams:
+    @pytest.fixture
+    def search_params(self):
+        return {
+            "metric_type": "L2",
+            "params": {"nprobe": 10, "ef": 64},
+            "offset": 0,
+            "limit": 100,
+        }
+
+    def test_old_deepcopy(self, benchmark, search_params):
+        benchmark(_get_params_old, search_params)
+
+    def test_new_dict_copy(self, benchmark, search_params):
+        result = benchmark(_get_params_new, search_params)
+        expected = _get_params_old(search_params)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 4. Membership check: list vs frozenset
+# ---------------------------------------------------------------------------
+_valid_index_types_list = [
+    "GPU_IVF_FLAT",
+    "GPU_IVF_PQ",
+    "FLAT",
+    "IVF_FLAT",
+    "IVF_SQ8",
+    "IVF_PQ",
+    "HNSW",
+    "BIN_FLAT",
+    "BIN_IVF_FLAT",
+    "DISKANN",
+    "AUTOINDEX",
+    "GPU_CAGRA",
+    "GPU_BRUTE_FORCE",
+]
+_valid_index_types_frozenset = frozenset(_valid_index_types_list)
+
+
+def _membership_list(items, container):
+    count = 0
+    for item in items:
+        if item in container:
+            count += 1
+    return count
+
+
+@pytest.mark.benchmark(group="membership_check")
+class TestMembershipCheck:
+    @pytest.fixture
+    def test_items(self):
+        return [
+            "HNSW",
+            "MISSING1",
+            "FLAT",
+            "MISSING2",
+            "GPU_CAGRA",
+            "MISSING3",
+            "IVF_PQ",
+            "MISSING4",
+            "DISKANN",
+            "MISSING5",
+        ] * 100
+
+    def test_old_list_membership(self, benchmark, test_items):
+        benchmark(_membership_list, test_items, _valid_index_types_list)
+
+    def test_new_frozenset_membership(self, benchmark, test_items):
+        result = benchmark(_membership_list, test_items, _valid_index_types_frozenset)
+        expected = _membership_list(test_items, _valid_index_types_list)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 5. len_of: cascading HasField vs WhichOneof
+# ---------------------------------------------------------------------------
+class MockScalarData:
+    def __init__(self, kind, length):
+        self._kind = kind
+        self._data = MagicMock()
+        self._data.data = list(range(length))
+        self._fields = {kind: True}
+
+    def HasField(self, name):
+        return name in self._fields
+
+    def WhichOneof(self, name):
+        return self._kind
+
+    def __getattr__(self, name):
+        if name == self._kind:
+            return self._data
+        raise AttributeError(name)
+
+
+class MockFieldData:
+    def __init__(self, kind="int_data", length=100):
+        self.scalars = MockScalarData(kind, length)
+        self.valid_data = []
+        self._field = "scalars"
+
+    def HasField(self, name):
+        return name == self._field
+
+    def WhichOneof(self, name):
+        return self._field
+
+
+_SCALAR_KINDS = [
+    "bool_data",
+    "int_data",
+    "long_data",
+    "float_data",
+    "double_data",
+    "string_data",
+    "bytes_data",
+    "json_data",
+    "array_data",
+]
+
+
+def _len_of_old(field_data):
+    """Old: cascading HasField calls."""
+    if field_data.HasField("scalars"):
+        for kind in _SCALAR_KINDS:
+            if field_data.scalars.HasField(kind):
+                return len(field_data.scalars.__getattr__(kind).data)
+    return 0
+
+
+def _len_of_new(field_data):
+    """New: WhichOneof dispatch."""
+    field_kind = field_data.WhichOneof("field")
+    if field_kind == "scalars":
+        scalar_kind = field_data.scalars.WhichOneof("data")
+        if scalar_kind is None:
+            return 0
+        return len(getattr(field_data.scalars, scalar_kind).data)
+    return 0
+
+
+@pytest.mark.benchmark(group="len_of")
+class TestLenOf:
+    KINDS: tuple = ("int_data", "json_data", "array_data")
+
+    @pytest.fixture(params=KINDS)
+    def field_data(self, request):
+        return MockFieldData(kind=request.param, length=1000)
+
+    def test_old_cascading_hasfield(self, benchmark, field_data):
+        benchmark(_len_of_old, field_data)
+
+    def test_new_whichoneof(self, benchmark, field_data):
+        result = benchmark(_len_of_new, field_data)
+        expected = _len_of_old(field_data)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 6. error_handler: datetime.now + traceback on happy path vs deferred
+# ---------------------------------------------------------------------------
+import datetime
+
+
+def _error_handler_old_happy_path(func):
+    """Old: creates datetime.now() and dict on every call."""
+    record_dict = {}
+    record_dict["RPC start"] = str(datetime.datetime.now())
+    return func()
+
+
+def _error_handler_new_happy_path(func):
+    """New: only time.monotonic() on happy path."""
+    _start_ts = time.monotonic()
+    return func()
+
+
+@pytest.mark.benchmark(group="error_handler_happy_path")
+class TestErrorHandlerHappyPath:
+    def test_old_datetime_now(self, benchmark):
+        benchmark(_error_handler_old_happy_path, lambda: 42)
+
+    def test_new_monotonic(self, benchmark):
+        result = benchmark(_error_handler_new_happy_path, lambda: 42)
+        assert result == 42
+
+
+# ---------------------------------------------------------------------------
+# 7. error_handler: traceback.format_exc with vs without log level check
+# ---------------------------------------------------------------------------
+def _error_handler_old_error_path():
+    """Old: always calls traceback.format_exc()."""
+    try:
+        raise ValueError("test error")
+    except Exception:
+        tb_str = traceback.format_exc()
+        _ = f"Error: {tb_str}"
+        return tb_str
+
+
+def _error_handler_new_error_path():
+    """New: checks log level before traceback.format_exc()."""
+    logger = logging.getLogger("benchmark_test_logger")
+    logger.setLevel(logging.CRITICAL)
+    try:
+        raise ValueError("test error")
+    except Exception:
+        if logger.isEnabledFor(logging.ERROR):
+            tb_str = traceback.format_exc()
+            _ = f"Error: {tb_str}"
+            return tb_str
+        return None
+
+
+@pytest.mark.benchmark(group="error_handler_error_path")
+class TestErrorHandlerErrorPath:
+    def test_old_always_format_traceback(self, benchmark):
+        benchmark(_error_handler_old_error_path)
+
+    def test_new_skip_traceback_when_not_logging(self, benchmark):
+        benchmark(_error_handler_new_error_path)
+
+
+# ---------------------------------------------------------------------------
+# 8. isinstance: typing.Dict/List vs builtins dict/list
+# ---------------------------------------------------------------------------
+def _isinstance_typing(data):
+    """Old: isinstance with typing generics."""
+    if isinstance(data, Dict):
+        return "dict"
+    if isinstance(data, List):
+        return "list"
+    return "other"
+
+
+def _isinstance_builtin(data):
+    """New: isinstance with builtins."""
+    if isinstance(data, dict):
+        return "dict"
+    if isinstance(data, list):
+        return "list"
+    return "other"
+
+
+@pytest.mark.benchmark(group="isinstance_check")
+class TestIsinstanceCheck:
+    TEST_DATA: tuple = (
+        {"key": "value"},
+        [1, 2, 3],
+        "string",
+    )
+
+    @pytest.fixture(params=TEST_DATA)
+    def data(self, request):
+        return request.param
+
+    def test_old_typing_isinstance(self, benchmark, data):
+        benchmark(_isinstance_typing, data)
+
+    def test_new_builtin_isinstance(self, benchmark, data):
+        result = benchmark(_isinstance_builtin, data)
+        expected = _isinstance_typing(data)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 9. json_type dispatch: if/elif chain vs dict lookup
+# ---------------------------------------------------------------------------
+class _MockDataType:
+    INT8 = 1
+    INT16 = 2
+    INT32 = 3
+    INT64 = 4
+    BOOL = 5
+    VARCHAR = 6
+    STRING = 7
+
+
+def _json_type_old(json_type):
+    """Old: if/elif chain."""
+    if json_type == _MockDataType.INT8:
+        return "Int8"
+    if json_type == _MockDataType.INT16:
+        return "Int16"
+    if json_type == _MockDataType.INT32:
+        return "Int32"
+    if json_type == _MockDataType.INT64:
+        return "Int64"
+    if json_type == _MockDataType.BOOL:
+        return "Bool"
+    if json_type in (_MockDataType.VARCHAR, _MockDataType.STRING):
+        return "VarChar"
+    return None
+
+
+_JSON_TYPE_MAP = {
+    _MockDataType.INT8: "Int8",
+    _MockDataType.INT16: "Int16",
+    _MockDataType.INT32: "Int32",
+    _MockDataType.INT64: "Int64",
+    _MockDataType.BOOL: "Bool",
+    _MockDataType.VARCHAR: "VarChar",
+    _MockDataType.STRING: "VarChar",
+}
+
+
+def _json_type_new(json_type):
+    """New: dict lookup."""
+    return _JSON_TYPE_MAP.get(json_type)
+
+
+@pytest.mark.benchmark(group="json_type_dispatch")
+class TestJsonTypeDispatch:
+    TYPES: tuple = (
+        _MockDataType.INT8,
+        _MockDataType.INT64,
+        _MockDataType.VARCHAR,
+        _MockDataType.STRING,
+    )
+
+    @pytest.fixture(params=TYPES)
+    def json_type(self, request):
+        return request.param
+
+    def test_old_if_elif_chain(self, benchmark, json_type):
+        benchmark(_json_type_old, json_type)
+
+    def test_new_dict_lookup(self, benchmark, json_type):
+        result = benchmark(_json_type_new, json_type)
+        expected = _json_type_old(json_type)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 10. extend([item]) vs append(item)
+# ---------------------------------------------------------------------------
+def _extend_single_old(container, n):
+    """Old: extend with single-element list."""
+    for i in range(n):
+        container.extend([i])
+    return container
+
+
+def _append_single_new(container, n):
+    """New: append single item."""
+    for i in range(n):
+        container.append(i)
+    return container
+
+
+@pytest.mark.benchmark(group="extend_vs_append")
+class TestExtendVsAppend:
+    def test_old_extend_single(self, benchmark):
+        def run():
+            return _extend_single_old([], 1000)
+
+        benchmark(run)
+
+    def test_new_append_single(self, benchmark):
+        def run():
+            return _append_single_new([], 1000)
+
+        result = benchmark(run)
+        assert len(result) == 1000
+
+
+# ---------------------------------------------------------------------------
+# 11. _num_input_fields: len(list comprehension) vs sum(generator)
+# ---------------------------------------------------------------------------
+def _num_fields_old(fields, predicate):
+    """Old: create full list then len()."""
+    return len([f for f in fields if predicate(f)])
+
+
+def _num_fields_new(fields, predicate):
+    """New: sum with generator (no intermediate list)."""
+    return sum(1 for f in fields if predicate(f))
+
+
+@pytest.mark.benchmark(group="num_input_fields")
+class TestNumInputFields:
+    @pytest.fixture
+    def fields_data(self):
+        fields = []
+        for i in range(50):
+            fields.append({"name": f"field_{i}", "is_input": i % 3 != 0})
+        return fields
+
+    def test_old_len_list_comp(self, benchmark, fields_data):
+        benchmark(_num_fields_old, fields_data, lambda f: f["is_input"])
+
+    def test_new_sum_generator(self, benchmark, fields_data):
+        result = benchmark(_num_fields_new, fields_data, lambda f: f["is_input"])
+        expected = _num_fields_old(fields_data, lambda f: f["is_input"])
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 12. Dynamic field json_dict: always iterate vs skip when disabled
+# ---------------------------------------------------------------------------
+def _dynamic_field_old(entity, fields_data, enable_dynamic):
+    """Old: always builds dict comprehension, checks enable_dynamic inside."""
+    json_dict = {k: v for k, v in entity.items() if k not in fields_data and enable_dynamic}
+    if enable_dynamic:
+        return json_dict
+    return None
+
+
+def _dynamic_field_new(entity, fields_data, enable_dynamic):
+    """New: skip comprehension entirely when dynamic is disabled."""
+    if enable_dynamic:
+        return {k: v for k, v in entity.items() if k not in fields_data}
+    return None
+
+
+@pytest.mark.benchmark(group="dynamic_field_json")
+class TestDynamicFieldJson:
+    @pytest.fixture
+    def entity_data(self):
+        entity = {f"field_{i}": i for i in range(20)}
+        fields_data = {f"field_{i}": None for i in range(10)}
+        return entity, fields_data
+
+    def test_old_always_iterate_disabled(self, benchmark, entity_data):
+        entity, fields_data = entity_data
+        benchmark(_dynamic_field_old, entity, fields_data, False)
+
+    def test_new_skip_when_disabled(self, benchmark, entity_data):
+        entity, fields_data = entity_data
+        benchmark(_dynamic_field_new, entity, fields_data, False)
+
+    def test_old_always_iterate_enabled(self, benchmark, entity_data):
+        entity, fields_data = entity_data
+        benchmark(_dynamic_field_old, entity, fields_data, True)
+
+    def test_new_skip_when_enabled(self, benchmark, entity_data):
+        entity, fields_data = entity_data
+        result = benchmark(_dynamic_field_new, entity, fields_data, True)
+        expected = _dynamic_field_old(entity, fields_data, True)
+        assert result == expected
+
+
+# ===========================================================================
+# Iteration 2 benchmarks
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# 13. Nested function re-creation vs module-level functions
+# ---------------------------------------------------------------------------
+def _with_nested_functions(items):
+    """Old: nested function definitions recreated per call."""
+
+    def is_type_in_str(v, t):
+        if not isinstance(v, str):
+            return False
+        try:
+            t(v)
+        except ValueError:
+            return False
+        return True
+
+    def is_int_type(v):
+        return isinstance(v, (int,)) or is_type_in_str(v, int)
+
+    def is_float_type(v):
+        return isinstance(v, (float,)) or is_type_in_str(v, float)
+
+    count = 0
+    for i, f in items:
+        if is_int_type(i) and is_float_type(f):
+            count += 1
+    return count
+
+
+def _module_is_type_in_str(v, t):
+    if not isinstance(v, str):
+        return False
+    try:
+        t(v)
+    except ValueError:
+        return False
+    return True
+
+
+def _module_is_int_type(v):
+    return isinstance(v, (int,)) or _module_is_type_in_str(v, int)
+
+
+def _module_is_float_type(v):
+    return isinstance(v, (float,)) or _module_is_type_in_str(v, float)
+
+
+def _with_module_functions(items):
+    """New: module-level function references (no re-creation)."""
+    count = 0
+    for i, f in items:
+        if _module_is_int_type(i) and _module_is_float_type(f):
+            count += 1
+    return count
+
+
+@pytest.mark.benchmark(group="nested_vs_module_functions")
+class TestNestedVsModuleFunctions:
+    @pytest.fixture
+    def sparse_items(self):
+        return [(i, float(i) * 0.5) for i in range(100)]
+
+    def test_old_nested_functions(self, benchmark, sparse_items):
+        benchmark(_with_nested_functions, sparse_items)
+
+    def test_new_module_functions(self, benchmark, sparse_items):
+        result = benchmark(_with_module_functions, sparse_items)
+        expected = _with_nested_functions(sparse_items)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 14. Dict re-creation per call vs module-level constant (vector_attr_map)
+# ---------------------------------------------------------------------------
+def _dict_per_call(field_type, n):
+    """Old: recreate dict on every call."""
+    for _ in range(n):
+        vector_attr_map = {
+            1: "int8_vector",
+            2: "binary_vector",
+            3: "float16_vector",
+            4: "bfloat16_vector",
+        }
+        result = vector_attr_map.get(field_type)
+    return result
+
+
+_MODULE_VECTOR_ATTR_MAP = {
+    1: "int8_vector",
+    2: "binary_vector",
+    3: "float16_vector",
+    4: "bfloat16_vector",
+}
+
+
+def _dict_module_level(field_type, n):
+    """New: use module-level constant dict."""
+    for _ in range(n):
+        result = _MODULE_VECTOR_ATTR_MAP.get(field_type)
+    return result
+
+
+@pytest.mark.benchmark(group="dict_creation_per_call")
+class TestDictCreationPerCall:
+    def test_old_dict_per_call(self, benchmark):
+        benchmark(_dict_per_call, 2, 1000)
+
+    def test_new_module_level_dict(self, benchmark):
+        result = benchmark(_dict_module_level, 2, 1000)
+        expected = _dict_per_call(2, 1000)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 15. hasattr per call vs __init__ initialization
+# ---------------------------------------------------------------------------
+class _OldCache:
+    def lookup(self, key):
+        if not hasattr(self, "_cache"):
+            self._cache = {}
+        if key not in self._cache:
+            self._cache[key] = key * 2
+        return self._cache[key]
+
+
+class _NewCache:
+    def __init__(self):
+        self._cache = {}
+
+    def lookup(self, key):
+        if key not in self._cache:
+            self._cache[key] = key * 2
+        return self._cache[key]
+
+
+@pytest.mark.benchmark(group="hasattr_vs_init")
+class TestHasattrVsInit:
+    def test_old_hasattr_per_call(self, benchmark):
+        obj = _OldCache()
+
+        def run():
+            for i in range(100):
+                obj.lookup(i % 10)
+
+        benchmark(run)
+
+    def test_new_init_once(self, benchmark):
+        obj = _NewCache()
+
+        def run():
+            for i in range(100):
+                obj.lookup(i % 10)
+
+        benchmark(run)
+
+
+# ---------------------------------------------------------------------------
+# 16. str.lower() redundant comparison
+# ---------------------------------------------------------------------------
+def _lower_both_sides(n):
+    """Old: call .lower() on both sides every time."""
+    count = 0
+    for _ in range(n):
+        if "utf-8".lower() != "utf-8".lower():
+            count += 1
+    return count
+
+
+def _lower_one_side(n):
+    """New: only call .lower() on the variable side."""
+    protocol = "utf-8"
+    count = 0
+    for _ in range(n):
+        if protocol.lower() != "utf-8":
+            count += 1
+    return count
+
+
+@pytest.mark.benchmark(group="lower_comparison")
+class TestLowerComparison:
+    def test_old_lower_both(self, benchmark):
+        benchmark(_lower_both_sides, 1000)
+
+    def test_new_lower_one(self, benchmark):
+        result = benchmark(_lower_one_side, 1000)
+        expected = _lower_both_sides(1000)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 17. list membership vs frozenset for type checking (search results)
+# ---------------------------------------------------------------------------
+_TYPE_LIST = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+_TYPE_FROZENSET = frozenset(_TYPE_LIST)
+
+
+def _type_check_list(types, container):
+    count = 0
+    for t in types:
+        if t in container:
+            count += 1
+    return count
+
+
+@pytest.mark.benchmark(group="type_check_list_vs_frozenset")
+class TestTypeCheckListVsFrozenset:
+    @pytest.fixture
+    def types_to_check(self):
+        return [1, 5, 10, 11, 3, 15, 7, 20] * 125
+
+    def test_old_list(self, benchmark, types_to_check):
+        benchmark(_type_check_list, types_to_check, _TYPE_LIST)
+
+    def test_new_frozenset(self, benchmark, types_to_check):
+        result = benchmark(_type_check_list, types_to_check, _TYPE_FROZENSET)
+        expected = _type_check_list(types_to_check, _TYPE_LIST)
+        assert result == expected
+
+
+# ===========================================================================
+# Iteration 3 benchmarks
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# 18. Protobuf attribute chain caching
+# ---------------------------------------------------------------------------
+class _MockProtoChain:
+    """Simulates protobuf nested attribute access overhead."""
+
+    class _Scalars:
+        class _ArrayData:
+            def __init__(self):
+                self.element_type = 5
+                self.data = list(range(100))
+
+        def __init__(self):
+            self.array_data = self._ArrayData()
+
+    def __init__(self):
+        self.scalars = self._Scalars()
+
+
+def _proto_chain_uncached(proto, n):
+    """Old: access chain repeatedly."""
+    total = 0
+    for _ in range(n):
+        et = proto.scalars.array_data.element_type
+        d = proto.scalars.array_data.data
+        total += et + len(d)
+    return total
+
+
+def _proto_chain_cached(proto, n):
+    """New: cache intermediate object."""
+    array_data = proto.scalars.array_data
+    total = 0
+    for _ in range(n):
+        et = array_data.element_type
+        d = array_data.data
+        total += et + len(d)
+    return total
+
+
+@pytest.mark.benchmark(group="proto_chain_caching")
+class TestProtoChainCaching:
+    @pytest.fixture
+    def proto(self):
+        return _MockProtoChain()
+
+    def test_old_uncached_chain(self, benchmark, proto):
+        benchmark(_proto_chain_uncached, proto, 1000)
+
+    def test_new_cached_chain(self, benchmark, proto):
+        result = benchmark(_proto_chain_cached, proto, 1000)
+        expected = _proto_chain_uncached(proto, 1000)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 19. valid_data caching in check_append pattern
+# ---------------------------------------------------------------------------
+class _MockFieldDataForCheck:
+    def __init__(self, n):
+        self.valid_data = [True] * n
+        self.field_name = "test_field"
+        self.type = 5
+        self.scalars = MagicMock()
+        self.scalars.int_data.data = list(range(n))
+
+
+def _check_no_cache(field_data, index, row_data):
+    """Old: repeated len() and attribute access."""
+    if len(field_data.valid_data) > 0 and field_data.valid_data[index] is False:
+        row_data[field_data.field_name] = None
+        return
+    row_data[field_data.field_name] = field_data.scalars.int_data.data[index]
+
+
+def _check_with_cache(field_data, index, row_data):
+    """New: cached local variables."""
+    valid_data = field_data.valid_data
+    field_name = field_data.field_name
+    has_valid = len(valid_data) > 0
+    is_null = has_valid and valid_data[index] is False
+    scalar_data = field_data.scalars.int_data.data
+    row_data[field_name] = None if is_null else scalar_data[index]
+
+
+@pytest.mark.benchmark(group="check_append_caching")
+class TestCheckAppendCaching:
+    @pytest.fixture
+    def setup(self):
+        return _MockFieldDataForCheck(100)
+
+    def test_old_no_cache(self, benchmark, setup):
+        def run():
+            row = {}
+            for i in range(100):
+                _check_no_cache(setup, i, row)
+            return row
+
+        benchmark(run)
+
+    def test_new_with_cache(self, benchmark, setup):
+        def run():
+            row = {}
+            for i in range(100):
+                _check_with_cache(setup, i, row)
+            return row
+
+        benchmark(run)
+
+
+# ===========================================================================
+# Iteration 4-10 benchmarks
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# 20. json.loads vs orjson.loads
+# ---------------------------------------------------------------------------
+import json
+
+import orjson as _orjson
+
+
+def _json_stdlib_loads(data, n):
+    """Old: stdlib json.loads."""
+    for _ in range(n):
+        result = json.loads(data)
+    return result
+
+
+def _orjson_loads(data, n):
+    """New: orjson.loads (faster C implementation)."""
+    for _ in range(n):
+        result = _orjson.loads(data)
+    return result
+
+
+@pytest.mark.benchmark(group="json_loads")
+class TestJsonLoads:
+    @pytest.fixture
+    def json_data(self):
+        return b'{"nprobe": 10, "ef": 64, "metric_type": "L2"}'
+
+    def test_old_stdlib_json(self, benchmark, json_data):
+        benchmark(_json_stdlib_loads, json_data, 100)
+
+    def test_new_orjson(self, benchmark, json_data):
+        result = benchmark(_orjson_loads, json_data, 100)
+        expected = _json_stdlib_loads(json_data, 100)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 21. dict.fromkeys per iteration vs template.copy()
+# ---------------------------------------------------------------------------
+def _dict_fromkeys_per_iter(keys, n):
+    """Old: call dict.fromkeys for each entity."""
+    return [dict.fromkeys(keys) for _ in range(n)]
+
+
+def _dict_template_copy(keys, n):
+    """New: create template once, then copy."""
+    template = dict.fromkeys(keys)
+    return [template.copy() for _ in range(n)]
+
+
+@pytest.mark.benchmark(group="dict_fromkeys_vs_copy")
+class TestDictFromkeysVsCopy:
+    SIZES: tuple = (10, 100, 1000)
+
+    @pytest.fixture(params=SIZES)
+    def setup(self, request):
+        n = request.param
+        keys = [f"field_{i}" for i in range(15)]
+        return keys, n
+
+    def test_old_fromkeys_per_iter(self, benchmark, setup):
+        keys, n = setup
+        benchmark(_dict_fromkeys_per_iter, keys, n)
+
+    def test_new_template_copy(self, benchmark, setup):
+        keys, n = setup
+        result = benchmark(_dict_template_copy, keys, n)
+        expected = _dict_fromkeys_per_iter(keys, n)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 22. get_field_data: if/elif chain vs dict dispatch
+# ---------------------------------------------------------------------------
+class _MockScalars:
+    def __init__(self):
+        self.bool_data = MagicMock()
+        self.bool_data.data = [True, False]
+        self.int_data = MagicMock()
+        self.int_data.data = [1, 2, 3]
+        self.long_data = MagicMock()
+        self.long_data.data = [100, 200]
+        self.string_data = MagicMock()
+        self.string_data.data = ["a", "b"]
+
+
+_DISPATCH_MAP = {
+    1: "bool_data",
+    2: "int_data",
+    5: "long_data",
+    21: "string_data",
+}
+
+
+def _get_field_data_chain(field_type, scalars):
+    """Old: if/elif chain."""
+    if field_type == 1:
+        return scalars.bool_data.data
+    if field_type == 2:
+        return scalars.int_data.data
+    if field_type == 5:
+        return scalars.long_data.data
+    if field_type == 21:
+        return scalars.string_data.data
+    return None
+
+
+def _get_field_data_dispatch(field_type, scalars):
+    """New: dict dispatch + getattr."""
+    attr = _DISPATCH_MAP.get(field_type)
+    if attr is not None:
+        return getattr(scalars, attr).data
+    return None
+
+
+@pytest.mark.benchmark(group="get_field_data_dispatch")
+class TestGetFieldDataDispatch:
+    TYPES: tuple = (1, 5, 21)
+
+    @pytest.fixture(params=TYPES)
+    def setup(self, request):
+        return request.param, _MockScalars()
+
+    def test_old_chain(self, benchmark, setup):
+        ft, scalars = setup
+        benchmark(_get_field_data_chain, ft, scalars)
+
+    def test_new_dispatch(self, benchmark, setup):
+        ft, scalars = setup
+        result = benchmark(_get_field_data_dispatch, ft, scalars)
+        expected = _get_field_data_chain(ft, scalars)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 23. hasattr chain vs tuple iteration for array data
+# ---------------------------------------------------------------------------
+class _MockArrayItem:
+    def __init__(self):
+        self.string_data = MagicMock()
+        self.string_data.data = []
+        self.int_data = MagicMock()
+        self.int_data.data = [1, 2, 3]
+        self.long_data = MagicMock()
+        self.long_data.data = []
+        self.float_data = MagicMock()
+        self.float_data.data = []
+        self.double_data = MagicMock()
+        self.double_data.data = []
+        self.bool_data = MagicMock()
+        self.bool_data.data = []
+
+
+def _get_array_length_old(array_item):
+    """Old: hasattr chain."""
+    if hasattr(array_item, "string_data") and hasattr(array_item.string_data, "data"):
+        length = len(array_item.string_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "int_data") and hasattr(array_item.int_data, "data"):
+        length = len(array_item.int_data.data)
+        if length > 0:
+            return length
+    if hasattr(array_item, "long_data") and hasattr(array_item.long_data, "data"):
+        length = len(array_item.long_data.data)
+        if length > 0:
+            return length
+    return 0
+
+
+_ATTRS = ("string_data", "int_data", "long_data", "float_data", "double_data", "bool_data")
+
+
+def _get_array_length_new(array_item):
+    """New: tuple iteration with getattr."""
+    for attr_name in _ATTRS:
+        data = getattr(array_item, attr_name, None)
+        if data is not None:
+            length = len(data.data)
+            if length > 0:
+                return length
+    return 0
+
+
+@pytest.mark.benchmark(group="array_length_hasattr")
+class TestArrayLengthHasattr:
+    @pytest.fixture
+    def array_item(self):
+        return _MockArrayItem()
+
+    def test_old_hasattr_chain(self, benchmark, array_item):
+        benchmark(_get_array_length_old, array_item)
+
+    def test_new_tuple_iteration(self, benchmark, array_item):
+        result = benchmark(_get_array_length_new, array_item)
+        expected = _get_array_length_old(array_item)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# 24. len(self) cached vs uncached in loop
+# ---------------------------------------------------------------------------
+class _MockList(list):
+    pass
+
+
+def _loop_uncached_len(lst):
+    """Old: call len(self) in each range()."""
+    total = 0
+    for _ in range(5):
+        for i in range(len(lst)):
+            total += lst[i]
+    return total
+
+
+def _loop_cached_len(lst):
+    """New: cache len once."""
+    n = len(lst)
+    total = 0
+    for _ in range(5):
+        for i in range(n):
+            total += lst[i]
+    return total
+
+
+@pytest.mark.benchmark(group="cached_len")
+class TestCachedLen:
+    @pytest.fixture
+    def data(self):
+        return _MockList(range(200))
+
+    def test_old_uncached_len(self, benchmark, data):
+        benchmark(_loop_uncached_len, data)
+
+    def test_new_cached_len(self, benchmark, data):
+        result = benchmark(_loop_cached_len, data)
+        expected = _loop_uncached_len(data)
+        assert result == expected


### PR DESCRIPTION
Cherry-pick of #3279.

- **Fix duplicate `@retry_on_rpc_failure`** on `search()` in `grpc_handler.py` — was causing up to 75×75=5625 retry attempts instead of 75
- **24 micro-optimizations** across the MilvusClient/AsyncMilvusClient code path (no refactoring, no API changes):
- Replace O(n²) bytes concatenation with `b"".join` and `struct.pack` batch (~136x faster at n=1000)
  - Use `orjson.loads` instead of stdlib `json.loads` (~6.7x faster)
- Replace `deepcopy` with shallow `dict()` for search params (~4.2x faster)
- Use `frozenset` for O(1) membership checks instead of list O(n) (~3.6x faster)
  - Use `WhichOneof` instead of cascading `HasField` in `len_of`
- Use `time.monotonic` + lazy `traceback.format_exc` in error_handler (~13-17x faster)
- Use builtin `isinstance(x, dict/list)` instead of `typing.Dict/List` (~3.3-6.5x faster)
- Cache protobuf attribute chains to avoid repeated traversals (~1.3x faster)
  - Use dict dispatch tables instead of if/elif chains
- Move per-call dict/function creation to module-level constants (~4.5x faster)
- Use `template.copy()` instead of `dict.fromkeys` per iteration (~5.4x faster)
- Skip dynamic field json comprehension when dynamic is disabled (~16x faster)
  - Consolidate `extend([item])` to `append` (~2.8x faster)
- **80 benchmark tests** added in `tests/benchmark/test_perf_improvements.py` covering all optimization patterns
- Net **-536 / +1562 lines** across 11 files (10 production + 1 benchmark test file)
- All 2126 existing unit tests pass, all 80 benchmark tests pass

- [x] `make lint` passes (black + ruff clean)
- [x] `make unittest` — 2126 passed, 4 skipped, 1 xfailed
- [x] `pytest tests/benchmark/test_perf_improvements.py` — 80 benchmarks pass



(cherry picked from commit f69e354a51cd3e7025e845dd0c61d1f46157a646)