### PR TITLE
ci: require 90% patch coverage and auto-remove ci-passed on re-run

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -12,9 +12,26 @@ pull_request_rules:
       - "status-success~=Run Check Proto \\(\\d+\\.\\d+\\)"
       # Require that code lint checks pass for any Python version
       - "status-success~=Code lint check \\(\\d+\\.\\d+\\)"
+      # Require that patch coverage meets the threshold
+      - status-success=codecov/patch
     actions:
       label:
         add:
+          - ci-passed
+  - name: Remove ci-passed label when CI is not passing
+    conditions:
+      - or:
+        - base=master
+        - base~=2\.\d
+      - or:
+        - "-status-success~=Run Python Tests \\(\\d+\\.\\d+, windows-\\S+\\)"
+        - "-status-success~=Run Python Tests \\(\\d+\\.\\d+, ubuntu-\\S+\\)"
+        - "-status-success~=Run Check Proto \\(\\d+\\.\\d+\\)"
+        - "-status-success~=Code lint check \\(\\d+\\.\\d+\\)"
+        - -status-success=codecov/patch
+    actions:
+      label:
+        remove:
           - ci-passed
   - name: Add needs-dco label when DCO check failed
     conditions:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,13 +4,9 @@ coverage:
   round: down
   range: "70...100"
 
-  # status:
-  #   project:
-  #     default:
-  #       target: 77%
-  #       threshold: 0% #Allow the coverage to drop by threshold%, and posting a success status.
-  #   patch:
-  #     default:
-  #       target: 80%   #target of patch diff
-  #       threshold: 0%
-  #       if_ci_failed: error #success, failure, error, ignore
+  status:
+    patch:
+      default:
+        target: 90%
+        threshold: 0%
+        if_ci_failed: error


### PR DESCRIPTION
Enable codecov/patch status check with a 90% target on changed lines.
Add it as a condition for the ci-passed label in Mergify. Also add a
complementary Mergify rule that removes ci-passed when any required
check is not passing, so the label is cleared when authors push new
commits and CI re-triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)