### PR TITLE
fix: avoid calling len() on scipy sparse matrix in entity_to_field_data

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -770,7 +770,12 @@ def entity_to_field_data(entity: Dict, field_info: Any, num_rows: int) -> schema
                 field_data.vectors.dim = field_info.get("params", {}).get("dim", 0)
             field_data.vectors.bfloat16_vector = b"".join(entity_values)
         elif entity_type == DataType.SPARSE_FLOAT_VECTOR:
-            if len(entity_values) > 0:
+            entity_len = (
+                entity_values.shape[0]
+                if SciPyHelper.is_scipy_sparse(entity_values)
+                else len(entity_values)
+            )
+            if entity_len > 0:
                 field_data.vectors.sparse_float_vector.CopyFrom(sparse_rows_to_proto(entity_values))
         elif entity_type == DataType.INT8_VECTOR:
             if len(entity_values) > 0:


### PR DESCRIPTION
## Problem
`entity_to_field_data()` calls `len(entity_values)` on `scipy.sparse.csr_matrix`, which raises `TypeError: sparse array length is ambiguous; use getnnz() or shape[0]`.

This was introduced in PR #3141 (commit 67b50168) which added `if len(entity_values) > 0:` guard for all vector types, but `scipy.sparse` matrices do not support `len()`.

## Fix
Use `entity_values.shape[0]` for scipy sparse types and `len()` for others to get the entity count, then check if greater than 0. This keeps the empty-value guard consistent for both scipy sparse and non-scipy inputs.

Fixes #3288

Signed-off-by: wangting0128 <ting.wang@zilliz.com>