### PR TITLE
fix: support explicit db_name in snapshot APIs for cross-database operations

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -2499,6 +2499,7 @@ class AsyncGrpcHandler:
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -2507,6 +2508,7 @@ class AsyncGrpcHandler:
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
         )
         status = await self._async_stub.CreateSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -2531,11 +2533,12 @@ class AsyncGrpcHandler:
     async def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[str]:
-        request = Prepare.list_snapshots_req(collection_name=collection_name)
+        request = Prepare.list_snapshots_req(collection_name=collection_name, db_name=db_name)
         response = await self._async_stub.ListSnapshots(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -2573,6 +2576,7 @@ class AsyncGrpcHandler:
         collection_name: str,
         snapshot_name: str,
         rewrite_data: bool = False,
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -2581,6 +2585,7 @@ class AsyncGrpcHandler:
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             rewrite_data=rewrite_data,
+            db_name=db_name,
         )
         response = await self._async_stub.RestoreSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -2619,11 +2624,14 @@ class AsyncGrpcHandler:
     async def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
-        request = Prepare.list_restore_snapshot_jobs_req(collection_name=collection_name)
+        request = Prepare.list_restore_snapshot_jobs_req(
+            collection_name=collection_name, db_name=db_name
+        )
         response = await self._async_stub.ListRestoreSnapshotJobs(
             request, timeout=timeout, metadata=_api_level_md(context)
         )

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -3203,6 +3203,7 @@ class GrpcHandler:
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -3211,6 +3212,7 @@ class GrpcHandler:
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
         )
         status = self._stub.CreateSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -3233,11 +3235,12 @@ class GrpcHandler:
     def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[str]:
-        request = Prepare.list_snapshots_req(collection_name=collection_name)
+        request = Prepare.list_snapshots_req(collection_name=collection_name, db_name=db_name)
         response = self._stub.ListSnapshots(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -3275,6 +3278,7 @@ class GrpcHandler:
         collection_name: str,
         snapshot_name: str,
         rewrite_data: bool = False,
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -3283,6 +3287,7 @@ class GrpcHandler:
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             rewrite_data=rewrite_data,
+            db_name=db_name,
         )
         response = self._stub.RestoreSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -3323,11 +3328,14 @@ class GrpcHandler:
     def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
-        request = Prepare.list_restore_snapshot_jobs_req(collection_name=collection_name)
+        request = Prepare.list_restore_snapshot_jobs_req(
+            collection_name=collection_name, db_name=db_name
+        )
         response = self._stub.ListRestoreSnapshotJobs(
             request, timeout=timeout, metadata=_api_level_md(context)
         )

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2596,6 +2596,7 @@ class Prepare:
         snapshot_name: str,
         collection_name: str = "",
         description: str = "",
+        db_name: str = "",
     ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
@@ -2607,6 +2608,7 @@ class Prepare:
             name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
         )
 
     @classmethod
@@ -2617,9 +2619,10 @@ class Prepare:
         return milvus_types.DropSnapshotRequest(name=snapshot_name)
 
     @classmethod
-    def list_snapshots_req(cls, collection_name: str = ""):
+    def list_snapshots_req(cls, collection_name: str = "", db_name: str = ""):
         return milvus_types.ListSnapshotsRequest(
             collection_name=collection_name,
+            db_name=db_name,
         )
 
     @classmethod
@@ -2635,6 +2638,7 @@ class Prepare:
         snapshot_name: str,
         collection_name: str = "",
         rewrite_data: bool = False,
+        db_name: str = "",
     ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
@@ -2646,6 +2650,7 @@ class Prepare:
             name=snapshot_name,
             collection_name=collection_name,
             rewrite_data=rewrite_data,
+            db_name=db_name,
         )
 
     @classmethod
@@ -2656,8 +2661,11 @@ class Prepare:
         return milvus_types.GetRestoreSnapshotStateRequest(job_id=job_id)
 
     @classmethod
-    def list_restore_snapshot_jobs_req(cls, collection_name: str = ""):
-        return milvus_types.ListRestoreSnapshotJobsRequest(collection_name=collection_name)
+    def list_restore_snapshot_jobs_req(cls, collection_name: str = "", db_name: str = ""):
+        return milvus_types.ListRestoreSnapshotJobsRequest(
+            collection_name=collection_name,
+            db_name=db_name,
+        )
 
     @classmethod
     def add_file_resource(cls, name: str, path: str):

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1909,6 +1909,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -1918,6 +1919,7 @@ class AsyncMilvusClient(BaseMilvusClient):
             collection_name (str): The name of the collection to snapshot.
             snapshot_name (str): The name of the snapshot. Must be unique.
             description (str): Optional description for the snapshot.
+            db_name (str): The database name. If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -1935,6 +1937,7 @@ class AsyncMilvusClient(BaseMilvusClient):
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -1964,6 +1967,7 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[str]:
@@ -1971,6 +1975,7 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             collection_name (str): Optional collection name to filter snapshots.
+            db_name (str): The database name. If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -1980,6 +1985,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return await conn.list_snapshots(
             collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2013,6 +2019,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         self,
         snapshot_name: str,
         collection_name: str,
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
@@ -2021,6 +2028,8 @@ class AsyncMilvusClient(BaseMilvusClient):
         Args:
             snapshot_name (str): The name of the snapshot to restore.
             collection_name (str): The name of the target collection to create.
+            db_name (str): The target database name to restore into.
+                If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2032,6 +2041,7 @@ class AsyncMilvusClient(BaseMilvusClient):
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             rewrite_data=False,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2064,6 +2074,7 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
@@ -2071,6 +2082,7 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             collection_name (str): Optional collection name to filter jobs.
+            db_name (str): The database name. If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2080,6 +2092,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return await conn.list_restore_snapshot_jobs(
             collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2576,6 +2576,7 @@ class MilvusClient(BaseMilvusClient):
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -2585,6 +2586,7 @@ class MilvusClient(BaseMilvusClient):
             collection_name (str): The name of the collection to snapshot.
             snapshot_name (str): The name of the snapshot. Must be unique.
             description (str): Optional description for the snapshot.
+            db_name (str): The database name. If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2607,6 +2609,7 @@ class MilvusClient(BaseMilvusClient):
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2642,6 +2645,7 @@ class MilvusClient(BaseMilvusClient):
     def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[str]:
@@ -2650,6 +2654,7 @@ class MilvusClient(BaseMilvusClient):
         Args:
             collection_name (str): Optional collection name to filter snapshots.
                 If empty, lists all snapshots.
+            db_name (str): The database name. If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2668,6 +2673,7 @@ class MilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return conn.list_snapshots(
             collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2716,6 +2722,7 @@ class MilvusClient(BaseMilvusClient):
         self,
         snapshot_name: str,
         collection_name: str,
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
@@ -2727,6 +2734,8 @@ class MilvusClient(BaseMilvusClient):
         Args:
             snapshot_name (str): The name of the snapshot to restore.
             collection_name (str): The name of the target collection to create.
+            db_name (str): The target database name to restore into.
+                If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2742,24 +2751,19 @@ class MilvusClient(BaseMilvusClient):
             ...     collection_name="restored_collection"
             ... )
             >>> print(f"Restore job ID: {job_id}")
-            >>> # Monitor progress
-            >>> import time
-            >>> while True:
-            ...     state = client.get_restore_snapshot_state(job_id=job_id)
-            ...     if state.state == "RestoreSnapshotCompleted":
-            ...         print("Restore completed!")
-            ...         break
-            ...     elif state.state == "RestoreSnapshotFailed":
-            ...         print(f"Restore failed: {state.reason}")
-            ...         break
-            ...     print(f"Progress: {state.progress}%")
-            ...     time.sleep(1)
+            >>> # Restore to a different database
+            >>> job_id = client.restore_snapshot(
+            ...     snapshot_name="backup_20240101",
+            ...     collection_name="restored_collection",
+            ...     db_name="target_db"
+            ... )
         """
         conn = self._get_connection()
         return conn.restore_snapshot(
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             rewrite_data=False,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2815,6 +2819,7 @@ class MilvusClient(BaseMilvusClient):
     def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
@@ -2823,6 +2828,7 @@ class MilvusClient(BaseMilvusClient):
         Args:
             collection_name (str): Optional collection name to filter jobs.
                 If empty, lists all restore jobs.
+            db_name (str): The database name. If empty, uses the client's current database.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2842,6 +2848,7 @@ class MilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return conn.list_restore_snapshot_jobs(
             collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/tests/async_grpc_handler/test_async_snapshot.py
+++ b/tests/async_grpc_handler/test_async_snapshot.py
@@ -51,6 +51,7 @@ class TestAsyncGrpcHandlerSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="test_collection",
                 description="test description",
+                db_name="",
             )
 
     @pytest.mark.asyncio
@@ -118,7 +119,7 @@ class TestAsyncGrpcHandlerSnapshot:
             result = await handler.list_snapshots(collection_name="test_collection", timeout=30)
 
             mock_prepare.list_snapshots_req.assert_called_once_with(
-                collection_name="test_collection"
+                collection_name="test_collection", db_name=""
             )
             assert len(result) == 2
 
@@ -200,7 +201,10 @@ class TestAsyncGrpcHandlerSnapshot:
             )
 
             mock_prepare.restore_snapshot_req.assert_called_once_with(
-                snapshot_name="test_snapshot", collection_name="new_collection", rewrite_data=False
+                snapshot_name="test_snapshot",
+                collection_name="new_collection",
+                rewrite_data=False,
+                db_name="",
             )
             assert job_id == 12345
 
@@ -314,7 +318,7 @@ class TestAsyncGrpcHandlerSnapshot:
             )
 
             mock_prepare.list_restore_snapshot_jobs_req.assert_called_once_with(
-                collection_name="test_collection"
+                collection_name="test_collection", db_name=""
             )
             assert len(result) == 2
             assert result[0].job_id == 1

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1145,6 +1145,7 @@ class TestAsyncMilvusClientSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="test_collection",
                 description="Test description",
+                db_name="",
                 timeout=None,
                 context=ANY,
             )
@@ -1183,7 +1184,7 @@ class TestAsyncMilvusClientSnapshot:
 
             assert snapshots == ["snapshot1", "snapshot2"]
             mock_handler.list_snapshots.assert_called_once_with(
-                collection_name="test_collection", timeout=None, context=ANY
+                collection_name="test_collection", db_name="", timeout=None, context=ANY
             )
 
     @pytest.mark.asyncio
@@ -1235,6 +1236,7 @@ class TestAsyncMilvusClientSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="restored_collection",
                 rewrite_data=False,
+                db_name="",
                 timeout=None,
                 context=ANY,
             )
@@ -1286,5 +1288,5 @@ class TestAsyncMilvusClientSnapshot:
 
             assert len(jobs) == 0
             mock_handler.list_restore_snapshot_jobs.assert_called_once_with(
-                collection_name="test_collection", timeout=None, context=ANY
+                collection_name="test_collection", db_name="", timeout=None, context=ANY
             )

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -184,6 +184,7 @@ class TestMilvusClientSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="test_collection",
                 description="Test description",
+                db_name="",
                 timeout=None,
                 context=ANY,
             )
@@ -239,7 +240,7 @@ class TestMilvusClientSnapshot:
 
             assert snapshots == ["snapshot1", "snapshot2"]
             mock_handler.list_snapshots.assert_called_once_with(
-                collection_name="test_collection", timeout=None, context=ANY
+                collection_name="test_collection", db_name="", timeout=None, context=ANY
             )
 
     def test_list_snapshots_all(self):
@@ -311,6 +312,7 @@ class TestMilvusClientSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="restored_collection",
                 rewrite_data=False,
+                db_name="",
                 timeout=None,
                 context=ANY,
             )
@@ -392,7 +394,7 @@ class TestMilvusClientSnapshot:
             assert jobs[1].progress == 50
 
             mock_handler.list_restore_snapshot_jobs.assert_called_once_with(
-                collection_name="test_collection", timeout=None, context=ANY
+                collection_name="test_collection", db_name="", timeout=None, context=ANY
             )
 
     def test_list_restore_snapshot_jobs_all(self):
@@ -412,6 +414,97 @@ class TestMilvusClientSnapshot:
             mock_handler.list_restore_snapshot_jobs.assert_called_once()
             call_kwargs = mock_handler.list_restore_snapshot_jobs.call_args[1]
             assert call_kwargs["collection_name"] == ""
+
+    def test_create_snapshot_with_db_name(self):
+        """Test create_snapshot with explicit db_name."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler.create_snapshot.return_value = None
+
+        with patch(
+            "pymilvus.milvus_client.milvus_client.create_connection", return_value="test"
+        ), patch("pymilvus.orm.connections.Connections._fetch_handler", return_value=mock_handler):
+            client = MilvusClient()
+
+            client.create_snapshot(
+                collection_name="test_collection",
+                snapshot_name="test_snapshot",
+                db_name="target_db",
+            )
+
+            mock_handler.create_snapshot.assert_called_once_with(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                description="",
+                db_name="target_db",
+                timeout=None,
+                context=ANY,
+            )
+
+    def test_list_snapshots_with_db_name(self):
+        """Test list_snapshots with explicit db_name."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler.list_snapshots.return_value = ["snapshot1"]
+
+        with patch(
+            "pymilvus.milvus_client.milvus_client.create_connection", return_value="test"
+        ), patch("pymilvus.orm.connections.Connections._fetch_handler", return_value=mock_handler):
+            client = MilvusClient()
+
+            snapshots = client.list_snapshots(collection_name="test_collection", db_name="other_db")
+
+            assert snapshots == ["snapshot1"]
+            mock_handler.list_snapshots.assert_called_once_with(
+                collection_name="test_collection", db_name="other_db", timeout=None, context=ANY
+            )
+
+    def test_restore_snapshot_cross_db(self):
+        """Test restore_snapshot to a different database."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler.restore_snapshot.return_value = 12345
+
+        with patch(
+            "pymilvus.milvus_client.milvus_client.create_connection", return_value="test"
+        ), patch("pymilvus.orm.connections.Connections._fetch_handler", return_value=mock_handler):
+            client = MilvusClient()
+
+            job_id = client.restore_snapshot(
+                snapshot_name="test_snapshot",
+                collection_name="restored_collection",
+                db_name="target_db",
+            )
+
+            assert job_id == 12345
+            mock_handler.restore_snapshot.assert_called_once_with(
+                snapshot_name="test_snapshot",
+                collection_name="restored_collection",
+                rewrite_data=False,
+                db_name="target_db",
+                timeout=None,
+                context=ANY,
+            )
+
+    def test_list_restore_snapshot_jobs_with_db_name(self):
+        """Test list_restore_snapshot_jobs with explicit db_name."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler.list_restore_snapshot_jobs.return_value = []
+
+        with patch(
+            "pymilvus.milvus_client.milvus_client.create_connection", return_value="test"
+        ), patch("pymilvus.orm.connections.Connections._fetch_handler", return_value=mock_handler):
+            client = MilvusClient()
+
+            jobs = client.list_restore_snapshot_jobs(
+                collection_name="test_collection", db_name="other_db"
+            )
+
+            assert len(jobs) == 0
+            mock_handler.list_restore_snapshot_jobs.assert_called_once_with(
+                collection_name="test_collection", db_name="other_db", timeout=None, context=ANY
+            )
 
     def test_client_db_isolation(self):
         """


### PR DESCRIPTION
## Summary

- Add explicit `db_name` parameter to 4 snapshot APIs (`create_snapshot`, `list_snapshots`, `restore_snapshot`, `list_restore_snapshot_jobs`) across all layers (Prepare, GrpcHandler, AsyncGrpcHandler, MilvusClient, AsyncMilvusClient)
- The `db_name` is now populated in the protobuf request body, enabling cross-database snapshot operations (e.g., restore a snapshot from `db_a` into `db_b`)
- This complements #3292 which added gRPC metadata context — now `db_name` is sent via **both** proto body and metadata header

### Why both proto body and metadata?

| Path | When it works |
|------|--------------|
| Proto body `db_name` | When user passes explicit `db_name` parameter (cross-db operations) |
| Metadata header `dbname` (via `CallContext`) | When user omits `db_name`, falls back to client's `self._db_name` via `DatabaseInterceptor` |

### Affected APIs
| API | `db_name` in proto body |
|-----|------------------------|
| `create_snapshot` | added |
| `list_snapshots` | added |
| `restore_snapshot` | added |
| `list_restore_snapshot_jobs` | added |

### Example: cross-database restore
```python
client_a = MilvusClient(uri="...", db_name="db_a")
# Create snapshot in db_a
client_a.create_snapshot(collection_name="my_col", snapshot_name="snap1")

# Restore to a different database
client_a.restore_snapshot(
    snapshot_name="snap1",
    collection_name="restored_col",
    db_name="db_b",  # explicit target database
)
```

## Test plan

- [x] Unit tests: 29 snapshot tests pass (including 4 new cross-db tests)
- [x] Integration tests: 36 scenarios pass against Milvus master (`338bac3`), covering:
  - 3 databases with different collections/snapshots
  - `create_snapshot` with explicit `db_name` from default-db client
  - `list_snapshots` per database with `db_name` filter
  - Cross-db restore: `db_a` → `db_b`, `db_a` → `db_c` (empty db)
  - Same-db restore: `db_b` → `db_b`
  - Same-db restore without explicit `db_name` (uses client's db via metadata)
  - Data isolation verification across all 3 databases