### PR TITLE
fix: enforce timeout for async operations when server is unreachable

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -220,11 +220,12 @@ class AsyncGrpcHandler:
     def get_server_type(self):
         return get_server_type(self.server_address.split(":")[0])
 
-    async def ensure_channel_ready(self):
+    async def ensure_channel_ready(self, timeout: Optional[float] = None):
         try:
             if not self._is_channel_ready:
-                # wait for channel ready
-                await self._async_channel.channel_ready()
+                # wait for channel ready, default 10s to match sync _wait_for_channel_ready
+                wait_timeout = timeout if timeout is not None else 10
+                await asyncio.wait_for(self._async_channel.channel_ready(), timeout=wait_timeout)
                 # set identifier interceptor
                 host = socket.gethostname()
                 req = Prepare.register_request(self._user, host)
@@ -237,7 +238,7 @@ class AsyncGrpcHandler:
                 self._async_stub = milvus_pb2_grpc.MilvusServiceStub(self._async_channel)
 
                 self._is_channel_ready = True
-        except grpc.FutureTimeoutError as e:
+        except (grpc.FutureTimeoutError, asyncio.TimeoutError) as e:
             raise MilvusException(
                 code=Status.CONNECT_FAILED,
                 message=f"Fail connecting to server on {self._address}, illegal connection params or server unavailable",

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -209,6 +209,11 @@ def retry_on_rpc_failure(
 
                 while True:
                     try:
+                        if retry_timeout is not None:
+                            remaining = retry_timeout - (time.time() - start_time)
+                            if remaining <= 0:
+                                raise MilvusException(message=to_msg)
+                            return await asyncio.wait_for(func(*args, **kwargs), timeout=remaining)
                         return await func(*args, **kwargs)
                     except grpc.RpcError as e:
                         # Trigger global topology refresh on connection errors
@@ -250,6 +255,8 @@ def retry_on_rpc_failure(
                             back_off = min(back_off * back_off_multiplier, max_back_off)
                         else:
                             raise e from e
+                    except asyncio.TimeoutError as e:
+                        raise MilvusException(message=to_msg) from e
                     except Exception as e:
                         raise e from e
                     finally:

--- a/tests/async_grpc_handler/test_async_partition.py
+++ b/tests/async_grpc_handler/test_async_partition.py
@@ -270,7 +270,8 @@ class TestAsyncGrpcHandlerPartitionLoad:
                 timeout=0.001,
             )
 
-        assert "wait for loading partition timeout" in str(exc_info.value)
+        msg = str(exc_info.value)
+        assert "timeout" in msg.lower()
 
     @pytest.mark.asyncio
     async def test_load_partitions_with_resource_groups(self) -> None:

--- a/tests/test_async_flush.py
+++ b/tests/test_async_flush.py
@@ -205,7 +205,7 @@ class TestAsyncFlush:
 
             # Verify timeout exception was raised
             assert (
-                "wait for flush timeout" in str(exc_info.value).lower()
+                "timeout" in str(exc_info.value).lower()
             ), "Should raise timeout exception when flush takes too long"
 
     @pytest.mark.asyncio

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from unittest.mock import MagicMock, patch
 
@@ -916,3 +917,45 @@ class MockFutureTimeoutError(grpc.FutureTimeoutError):
 
     def details(self):
         return "Future timed out"
+
+
+class TestAsyncRetryTimeout:
+    """Test that async retry_on_rpc_failure respects timeout for blocking calls."""
+
+    @pytest.mark.asyncio
+    async def test_async_timeout_enforced_on_blocking_call(self):
+        """When inner function blocks indefinitely, timeout should still be enforced."""
+        mock_self = MockSelfForTracing()
+        call_count = 0
+
+        @retry_on_rpc_failure()
+        async def blocking_func(self_arg, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            # Simulate a call that blocks much longer than timeout
+            await asyncio.sleep(60)
+
+        start = time.time()
+        with pytest.raises(MilvusException, match="Retry timeout"):
+            await blocking_func(mock_self, timeout=1)
+        elapsed = time.time() - start
+
+        assert elapsed < 5, f"Expected to finish within 5s, took {elapsed:.1f}s"
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_async_timeout_not_affected_when_no_timeout(self):
+        """Without timeout, retry_times controls retries (no asyncio.wait_for)."""
+        mock_self = MockSelfForTracing()
+        call_count = 0
+
+        @retry_on_rpc_failure(retry_times=2)
+        async def failing_func(self_arg, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            raise MockUnavailableError
+
+        with pytest.raises(MilvusException):
+            await failing_func(mock_self)
+
+        assert call_count == 3  # initial + 2 retries


### PR DESCRIPTION
AsyncMilvusClient operations hung indefinitely when the target server was down because ensure_channel_ready() called channel_ready() with no timeout, and the retry decorator could not enforce the user's timeout on blocking calls. Fix both layers:

- Wrap each async retry attempt with asyncio.wait_for(remaining) so no single attempt blocks beyond the user's timeout budget
- Add default 10s timeout to ensure_channel_ready(), matching the sync _wait_for_channel_ready() behavior

See also: #3301