### PR TITLE
fix: clarify wrong-port guidance for UNIMPLEMENTED errors

### DIFF
--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -481,8 +481,11 @@ def upgrade_reminder(func: Callable):
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.UNIMPLEMENTED:
                 msg = (
-                    "Incorrect port or sdk is incompatible with server, "
-                    "please check your port or downgrade your sdk or upgrade your server"
+                    "Received UNIMPLEMENTED from server. "
+                    "Please first verify that your uri points to a Milvus gRPC port "
+                    "(default: 19530) instead of an HTTP/proxy port. "
+                    "If the port is correct, your SDK may be incompatible with the server; "
+                    "upgrade Milvus server or use a matching pymilvus version."
                 )
                 raise MilvusException(message=msg) from e
             raise e from e

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -692,7 +692,8 @@ class TestUpgradeReminderDecorator:
         with pytest.raises(MilvusException) as exc_info:
             unimplemented_func()
 
-        assert "sdk is incompatible with server" in exc_info.value.message
+        assert "default: 19530" in exc_info.value.message
+        assert "pymilvus version" in exc_info.value.message
 
     def test_upgrade_reminder_raises_other_grpc_errors(self):
         """Test that other gRPC errors are raised as-is."""


### PR DESCRIPTION
## Summary
- improve the `upgrade_reminder` message for gRPC `UNIMPLEMENTED` errors
- explicitly prioritize wrong-port diagnosis (default Milvus gRPC port: `19530`)
- keep version-mismatch guidance as a secondary step
- update decorator unit test assertions accordingly

## Why
When users connect to a wrong port, the old message could look like an SDK/server version issue first. This patch makes the troubleshooting order explicit and actionable.

## Validation
- `uv run --extra dev python -m pytest -q tests/test_decorators.py -k upgrade_reminder`

Fixes #2231
