### PR TITLE
[Backport 2.6] Feat/support python 3.14 (#3306)

### DIFF
--- a/.github/workflows/code_checker.yml
+++ b/.github/workflows/code_checker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [3.8, 3.13]
+        python-version: [3.8, 3.14]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     name: Run Python Tests
     strategy:
       matrix:
-        python-version: [3.8, 3.13]
+        python-version: [3.8, 3.14]
         os: [ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
 

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import inspect
 import logging
 import time
 import traceback
@@ -84,7 +85,7 @@ def retry_on_schema_mismatch():
     """
 
     def wrapper(func: Callable):
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
             async def async_handler(self: Any, collection_name: str, *args, **kwargs):
@@ -171,7 +172,7 @@ def retry_on_rpc_failure(
     back_off_multiplier: int = 3,
 ):
     def wrapper(func: Any):
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
             @error_handler(func_name=func.__name__)
@@ -361,7 +362,7 @@ def _log_rpc_error(inner_name: str, label: str, msg: str, start_ts: float):
 
 def error_handler(func_name: str = ""):
     def wrapper(func: Callable):
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             inner_name = func_name or func.__name__
 
             @functools.wraps(func)
@@ -431,7 +432,7 @@ def error_handler(func_name: str = ""):
 
 def tracing_request():
     def wrapper(func: Callable):
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
             async def async_handler(self: Callable, *args, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
 ]
 
@@ -66,9 +67,11 @@ milvus_lite = [
 ]
 
 dev = [
-    # Python3.13 supports starts from 1.66.2
-    "grpcio==1.66.2",
-    "grpcio-tools==1.66.2",
+    # Pin grpcio-tools to 1.66.2: generated code in grpc_gen/ embeds GRPC_GENERATED_VERSION,
+    # so regenerating with a newer version would break older Python (e.g. 3.8) at import time.
+    # Python 3.14 cannot be used as a dev environment for codegen.
+    "grpcio==1.66.2; python_version < '3.14'",
+    "grpcio-tools==1.66.2; python_version < '3.14'",
     "pytest>=5.3.4",
     "pytest-cov>=5.0.0",
     "pytest-timeout>=1.3.4",

--- a/tests/test_grpc_error_diagnostics.py
+++ b/tests/test_grpc_error_diagnostics.py
@@ -231,7 +231,14 @@ class TestGrpcErrorDiagnosticsIntegration:
         assert error.code() == grpc.StatusCode.UNAVAILABLE
         assert "debug=" in error_info
         assert "channel_state=" in error_info
-        assert "DNS" in error_info or "name" in error_info.lower()
+        # Different grpcio versions and OS DNS resolvers produce different messages:
+        # - "DNS resolution failed" / "Name resolution failure" on Linux
+        # - "failed to connect to all addresses" on macOS (resolves .invalid to sinkhole IP)
+        error_lower = error_info.lower()
+        assert any(
+            kw in error_lower
+            for kw in ("dns", "name", "resolve", "failed to connect", "socket closed")
+        )
 
     def test_connection_refused_includes_debug_and_channel_state(self):
         """Test connection refused includes diagnostic info."""


### PR DESCRIPTION
- **pyproject.toml**: Add `Python :: 3.14` classifier; split runtime
`grpcio` dependency with environment markers (`<3.14` keeps existing
constraints, `>=3.14` requires `grpcio>=1.76.0`); same split for dev
`grpcio`/`grpcio-tools` pins.
- **pymilvus/decorators.py**: Replace `asyncio.iscoroutinefunction()`
with `inspect.iscoroutinefunction()` to fix `DeprecationWarning` on
Python 3.14 (fixes #3293).
- **CI workflows**: Update `pull_request.yml` and `code_checker.yml`
test matrices to `[3.8, 3.14]`.
- **tests/test_grpc_error_diagnostics.py**: Broaden DNS failure
assertion to handle varying error messages across grpcio versions and OS
platforms.

See also: #3306

Co-authored-by: jac <jacllovey@qq.com>
Signed-off-by: xuan.yang <xuan.yang@zilliz.com>