### PR TITLE
[Backport 2.6] fix: pass address to GrpcHandler in ConnectionManager strategies (#3321)

### DIFF
--- a/pymilvus/client/connection_manager.py
+++ b/pymilvus/client/connection_manager.py
@@ -274,6 +274,7 @@ class RegularStrategy(ConnectionStrategy):
 
         return GrpcHandler(
             uri=config.uri,
+            address=config.address,
             token=config.token,
             db_name=config.db_name,
             **config.get_handler_kwargs(),
@@ -758,6 +759,7 @@ class AsyncRegularStrategy(ConnectionStrategy):
 
         return AsyncGrpcHandler(
             uri=config.uri,
+            address=config.address,
             token=config.token,
             db_name=config.db_name,
             **config.get_handler_kwargs(),

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -326,6 +326,7 @@ class TestConnectionConfig:
             strategy.create_handler(config)
             mock_handler_cls.assert_called_once_with(
                 uri=config.uri,
+                address=config.address,
                 token=config.token,
                 db_name=config.db_name,
                 secure=True,
@@ -341,6 +342,7 @@ class TestConnectionConfig:
             strategy.create_handler(config)
             mock_handler_cls.assert_called_once_with(
                 uri=config.uri,
+                address=config.address,
                 token=config.token,
                 db_name=config.db_name,
                 secure=True,
@@ -370,7 +372,11 @@ class TestRegularStrategy:
             handler = strategy.create_handler(config)
 
             mock_handler_cls.assert_called_once_with(
-                uri="https://host:19530/mydb", token="mytoken", db_name="mydb", secure=True
+                uri="https://host:19530/mydb",
+                address="host:19530",
+                token="mytoken",
+                db_name="mydb",
+                secure=True,
             )
             assert handler is mock_handler_cls.return_value
 

--- a/tests/test_milvus_lite.py
+++ b/tests/test_milvus_lite.py
@@ -1,35 +1,45 @@
-import pathlib
 import sys
-from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
 from pymilvus.exceptions import ConnectionConfigException
 from pymilvus.milvus_client import MilvusClient
 
+milvus_lite = pytest.importorskip("milvus_lite", reason="milvus-lite not installed")
+
 
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Milvus Lite is not supported on Windows"
 )
 class TestMilvusLite:
-    @pytest.mark.skip("Milvus Lite is now an optional dependency. This test will be fixed later.")
-    def test_milvus_lite(self):
-        with TemporaryDirectory(dir="./") as root:
-            db_file = pathlib.Path(root).joinpath("test.db")
-            client = MilvusClient(db_file.as_posix())
+    def test_milvus_client_with_local_db_path(self, tmp_path):
+        """MilvusClient("./test.db") should connect via Milvus Lite.
+
+        Regression test for https://github.com/milvus-io/pymilvus/issues/3314
+        and https://github.com/milvus-io/pymilvus/issues/3317.
+
+        On pymilvus 2.6.10 this hangs with 'dns:///' gRPC error because the
+        ConnectionManager constructs an empty gRPC target URI for local .db paths.
+        """
+        db_file = tmp_path / "test.db"
+        client = MilvusClient(db_file.as_posix(), timeout=10)
+        try:
+            collections = client.list_collections()
+            assert isinstance(collections, list)
+        finally:
+            client.close()
+
+    def test_milvus_lite_insert_search(self, tmp_path):
+        """End-to-end test: create collection, insert, search, query, delete via Milvus Lite."""
+        db_file = tmp_path / "test.db"
+        client = MilvusClient(db_file.as_posix(), timeout=10)
+        try:
             client.create_collection(collection_name="demo_collection", dimension=3)
 
-            # Text strings to search from.
-            docs = [
-                "Artificial intelligence was founded as an academic discipline in 1956.",
-                "Alan Turing was the first person to conduct substantial research in AI.",
-                "Born in Maida Vale, London, Turing was raised in southern England.",
-            ]
-
             rng = np.random.default_rng(seed=19530)
-            vectors = [[rng.uniform(-1, 1) for _ in range(3)] for _ in range(len(docs))]
+            vectors = [[rng.uniform(-1, 1) for _ in range(3)] for _ in range(3)]
             data = [
-                {"id": i, "vector": vectors[i], "text": docs[i], "subject": "history"}
+                {"id": i, "vector": vectors[i], "text": f"doc_{i}", "subject": "history"}
                 for i in range(len(vectors))
             ]
             res = client.insert(collection_name="demo_collection", data=data)
@@ -44,7 +54,6 @@ class TestMilvusLite:
             )
             assert len(res[0]) == 2
 
-            # a query that retrieves all entities matching filter expressions.
             res = client.query(
                 collection_name="demo_collection",
                 filter="subject == 'history'",
@@ -52,17 +61,33 @@ class TestMilvusLite:
             )
             assert len(res) == 3
 
-            # delete
             res = client.delete(
                 collection_name="demo_collection",
                 filter="subject == 'history'",
             )
             assert len(res) == 3
+        finally:
+            client.close()
+
+    def test_milvus_lite_multiple_clients_same_db(self, tmp_path):
+        """Two MilvusClient instances sharing the same .db file should work."""
+        db_file = tmp_path / "shared.db"
+        client1 = MilvusClient(db_file.as_posix(), timeout=10)
+        try:
+            client1.create_collection(collection_name="col1", dimension=3)
+            assert "col1" in client1.list_collections()
+
+            client2 = MilvusClient(db_file.as_posix(), timeout=10)
+            try:
+                assert "col1" in client2.list_collections()
+            finally:
+                client2.close()
+        finally:
+            client1.close()
 
     def test_illegal_name(self):
         with pytest.raises(ConnectionConfigException) as e:
             MilvusClient("localhost")
-        # check the raised exception contained
         assert (
             e.value.message
             == "uri: localhost is illegal, needs start with [unix, http, https, tcp] or a local file endswith [.db]"


### PR DESCRIPTION
fix: pass address to GrpcHandler in ConnectionManager strategies

RegularStrategy and AsyncRegularStrategy did not pass
config.address to GrpcHandler/AsyncGrpcHandler, causing
GrpcHandler.__get_address to parse unix-socket URIs returned
by milvus-lite and produce an empty netloc → empty gRPC target
(dns:///) → connection hang.

See also: #3314, #3317, #3321

Signed-off-by: xuan.yang <xuan.yang@zilliz.com>