### PR TITLE
fix: prevent "Cannot invoke RPC on closed channel" after connection recovery

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -125,6 +125,26 @@ class AsyncGrpcHandler:
         await self._async_channel.close()
         self._async_channel = None
 
+    async def reconnect(self, address: Optional[str] = None, timeout: float = 10):
+        """Reset the async gRPC channel, reconnecting to the same or a new address.
+
+        Preserves the handler object identity so that all existing references
+        (AsyncMilvusClient._handler, in-flight retry loops) continue to work.
+
+        Args:
+            address: Optional new address to connect to.
+            timeout: Connection timeout in seconds (default 10).
+        """
+        try:
+            await self.close()
+        except Exception:
+            self._async_channel = None
+        if address:
+            self._address = address
+        self._setup_grpc_channel()
+        self._is_channel_ready = False
+        await self.ensure_channel_ready(timeout=timeout)
+
     def _setup_authorization_interceptor(self, user: str, password: str, token: str):
         keys = []
         values = []

--- a/pymilvus/client/connection_manager.py
+++ b/pymilvus/client/connection_manager.py
@@ -189,6 +189,7 @@ class ManagedConnection:
     created_at: float = field(default_factory=time.time)
     last_used_at: float = field(default_factory=time.time)
     clients: weakref.WeakSet = field(default_factory=weakref.WeakSet)
+    recovery_gen: int = 0
 
     def touch(self) -> None:
         """Update last_used_at to current time."""
@@ -248,6 +249,20 @@ class ConnectionStrategy(ABC):
         Args:
             managed: The managed connection to close
         """
+
+    def get_recovery_address(self, managed: ManagedConnection) -> Optional[str]:
+        """Get address for in-place reconnection during recovery.
+
+        Returns None to keep the current address (default for regular connections).
+        Global strategies override this to return the new primary's address.
+
+        Args:
+            managed: The managed connection being recovered
+
+        Returns:
+            New address string, or None to keep current address
+        """
+        return None
 
     async def close_async(self, managed: ManagedConnection) -> None:
         """Close resources for a managed connection (async).
@@ -359,6 +374,17 @@ class _GlobalStrategyMixin:
         """Get current topology (thread-safe)."""
         with self._lock:
             return self._topology
+
+    def get_recovery_address(self, managed: ManagedConnection) -> Optional[str]:
+        """Return the current primary's address for in-place reconnection."""
+        topology = self.get_topology()
+        if topology and topology.primary:
+            parsed = urlparse(topology.primary.endpoint)
+            host = parsed.hostname or "localhost"
+            port = parsed.port or DEFAULT_PORT
+            return f"{host}:{port}"
+        logger.warning("Global strategy has no topology; reconnecting to current address")
+        return None
 
     def _stop_refresher(self) -> None:
         """Stop the background topology refresher."""
@@ -627,35 +653,20 @@ class ConnectionManager:
             return True
 
     def _recover(self, managed: ManagedConnection) -> None:
-        """Recover a connection by creating new handler.
+        """Recover a connection by resetting the channel in-place.
 
-        Uses strategy.close() instead of handler.close() so that strategy-owned
-        resources (e.g. GlobalStrategy's TopologyRefresher) are also cleaned up.
+        Reuses the existing handler object (closing and recreating its gRPC
+        channel) so that all existing references — MilvusClient._handler and
+        in-flight retry loops — continue to work with the new channel.
 
         Args:
             managed: Connection to recover
         """
         try:
-            old_handler_id = id(managed.handler)
-
-            # Close old handler and strategy resources (e.g. TopologyRefresher)
-            with contextlib.suppress(Exception):
-                managed.strategy.close(managed)
-
-            # Create new handler via strategy
-            new_handler = managed.strategy.create_handler(managed.config)
-            self._register_error_callback(new_handler)
-            new_handler._wait_for_channel_ready()
-
-            # Update managed connection
-            managed.handler = new_handler
+            new_address = managed.strategy.get_recovery_address(managed)
+            managed.handler.reconnect(address=new_address)
+            managed.recovery_gen += 1
             managed.touch()
-
-            # Update dedicated registry key if this is a dedicated connection
-            if old_handler_id in self._dedicated:
-                self._dedicated.pop(old_handler_id)
-                self._dedicated[id(new_handler)] = managed
-
         except Exception:
             logger.warning("Connection recovery failed", exc_info=True)
             raise
@@ -696,15 +707,16 @@ class ConnectionManager:
             managed = self._get_managed(handler)
             if managed is None:
                 return False
+            saved_gen = managed.recovery_gen
 
         # Run strategy decision outside lock (may do network I/O)
         should_recover = managed.strategy.on_unavailable(managed)
 
         if should_recover:
             with self._lock:
-                # Re-verify the handler is still the current one; another
-                # thread may have already recovered this connection.
-                if managed.handler is not handler:
+                # Re-verify no other thread has already recovered this
+                # connection while we were outside the lock.
+                if managed.recovery_gen != saved_gen:
                     return True
                 self._recover(managed)
 
@@ -923,11 +935,11 @@ class AsyncConnectionManager:
         AsyncConnectionManager.handle_error() which returns True if the error
         was handled and the caller should retry.
 
-        The closure captures ``handler`` by reference. After recovery, the old
-        handler's closure still points to the old handler object, so
-        ``_get_managed(old_handler)`` returns None (the registry now holds the
-        new handler). This intentionally prevents double recovery when multiple
-        in-flight RPCs fail on the same old handler.
+        The closure captures ``handler`` by reference. Recovery reconnects the
+        handler in-place (same object, new channel), so the closure remains
+        valid and ``_get_managed(handler)`` continues to find the connection.
+        Double recovery is prevented by the ``recovery_gen`` counter checked
+        in ``handle_error()``.
         """
 
         async def _on_rpc_error(error: Exception) -> bool:
@@ -1085,6 +1097,8 @@ class AsyncConnectionManager:
 
             # Run sync on_unavailable in executor to avoid blocking the
             # event loop (GlobalStrategy.on_unavailable does network I/O).
+            # Unlike the sync path, the lock is held throughout, so no
+            # concurrent recovery can happen — no recovery_gen guard needed.
             loop = asyncio.get_running_loop()
             should_recover = await loop.run_in_executor(
                 None, managed.strategy.on_unavailable, managed
@@ -1095,36 +1109,20 @@ class AsyncConnectionManager:
         return should_recover
 
     async def _recover(self, managed: ManagedConnection) -> None:
-        """Recover an async connection by creating new handler.
+        """Recover an async connection by resetting the channel in-place.
 
-        Uses strategy.close_async() to properly clean up old handler and strategy
-        resources (e.g. TopologyRefresher). Awaits ensure_channel_ready() on the
-        new handler so it's fully ready before being stored.
+        Reuses the existing handler object (closing and recreating its gRPC
+        channel) so that all existing references — AsyncMilvusClient._handler
+        and in-flight retry loops — continue to work with the new channel.
 
         Args:
             managed: Connection to recover
         """
         try:
-            old_handler_id = id(managed.handler)
-
-            # Close old handler and strategy resources (e.g. TopologyRefresher)
-            with contextlib.suppress(Exception):
-                await managed.strategy.close_async(managed)
-
-            # Create new handler via strategy (sync - creates handler object)
-            new_handler = managed.strategy.create_handler(managed.config)
-            self._register_error_callback(new_handler)
-            await new_handler.ensure_channel_ready()
-
-            # Update managed connection
-            managed.handler = new_handler
+            new_address = managed.strategy.get_recovery_address(managed)
+            await managed.handler.reconnect(address=new_address)
+            managed.recovery_gen += 1
             managed.touch()
-
-            # Update dedicated registry key if this is a dedicated connection
-            if old_handler_id in self._dedicated:
-                self._dedicated.pop(old_handler_id)
-                self._dedicated[id(new_handler)] = managed
-
         except Exception:
             logger.warning("Async connection recovery failed", exc_info=True)
             raise

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -243,6 +243,26 @@ class GrpcHandler:
             self._channel.close()
         self._channel = None
 
+    def reconnect(self, address: Optional[str] = None, timeout: float = 10):
+        """Reset the gRPC channel, reconnecting to the same or a new address.
+
+        Preserves the handler object identity so that all existing references
+        (MilvusClient._handler, in-flight retry loops) continue to work.
+
+        Args:
+            address: Optional new address to connect to.
+            timeout: Connection timeout in seconds.
+        """
+        try:
+            self.close()
+        except Exception:
+            # Ensure channel is cleared even if close() fails
+            self._channel = None
+        if address:
+            self._address = address
+        self._setup_grpc_channel()
+        self._wait_for_channel_ready(timeout=timeout)
+
     def reset_db_name(self, db_name: str):
         """Deprecated: db_name is now passed per-request via kwargs.
 

--- a/tests/grpc_handler/test_data.py
+++ b/tests/grpc_handler/test_data.py
@@ -4,8 +4,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from pymilvus import AnnSearchRequest, RRFRanker
+from pymilvus.client.call_context import CallContext
 from pymilvus.client.types import DataType
-from pymilvus.exceptions import MilvusException, ParamError
+from pymilvus.exceptions import (
+    DataNotMatchException,
+    MilvusException,
+    ParamError,
+    SchemaMismatchRetryableException,
+)
+from pymilvus.grpc_gen import common_pb2
 
 from .conftest import make_mutation_response
 
@@ -226,3 +233,374 @@ class TestGrpcHandlerBatchInsert:
         """Test _prepare_batch_insert_request with invalid insert_param."""
         with pytest.raises(ParamError):
             handler._prepare_batch_insert_request("coll", [[1]], insert_param="invalid")
+
+
+class TestSchemaMismatchRetry:
+    """Tests for the schema mismatch retry flow during insert/upsert.
+
+    Exercises the full path: insert_rows → server returns SchemaMismatch →
+    retry_on_schema_mismatch catches it → schema cache invalidated → retry
+    with fresh schema.
+
+    This simulates the scenario from milvus-io/milvus#48522 where concurrent
+    add_field changes the collection schema mid-insert.
+    """
+
+    @pytest.fixture
+    def old_schema(self):
+        """Schema before add_field (2 fields)."""
+        return {
+            "fields": [
+                {"name": "id", "type": DataType.INT64, "is_primary": True, "auto_id": False},
+                {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
+            ],
+            "enable_dynamic_field": False,
+            "update_timestamp": 100,
+        }
+
+    @pytest.fixture
+    def new_schema(self):
+        """Schema after add_field (3 fields — new nullable field added)."""
+        return {
+            "fields": [
+                {"name": "id", "type": DataType.INT64, "is_primary": True, "auto_id": False},
+                {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
+                {"name": "extra", "type": DataType.INT64, "nullable": True},
+            ],
+            "enable_dynamic_field": False,
+            "update_timestamp": 200,
+        }
+
+    @staticmethod
+    def _make_schema_mismatch_response():
+        """Create a response with SchemaMismatch error status."""
+        resp = MagicMock()
+        resp.status.code = common_pb2.SchemaMismatch
+        resp.status.error_code = common_pb2.SchemaMismatch
+        resp.status.reason = "collection schema mismatch"
+        return resp
+
+    @staticmethod
+    def _make_ok_response(ids=None):
+        return make_mutation_response(insert_cnt=len(ids or [1]), ids=ids or [1])
+
+    def test_insert_retries_on_server_schema_mismatch(self, handler, old_schema, new_schema):
+        """insert_rows: server returns SchemaMismatch → cache invalidated → retry succeeds.
+
+        Simulates: add_field changes the schema between the first insert attempt
+        and the retry. The retry re-fetches the schema and succeeds.
+        """
+        context = CallContext(db_name="test_db")
+        call_count = 0
+
+        def stub_insert_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return self._make_schema_mismatch_response()
+            return self._make_ok_response()
+
+        handler._stub.Insert.side_effect = stub_insert_side_effect
+
+        # First call returns old schema; after invalidation, returns new schema
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        with patch.object(handler, "_get_schema", side_effect=lambda *a, **kw: next(schema_iter)):
+            result = handler.insert_rows(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        assert call_count == 2
+        assert result.insert_count == 1
+
+    def test_upsert_retries_on_server_schema_mismatch(self, handler, old_schema, new_schema):
+        """upsert_rows: server returns SchemaMismatch → cache invalidated → retry succeeds."""
+        context = CallContext(db_name="test_db")
+        call_count = 0
+
+        def stub_upsert_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return self._make_schema_mismatch_response()
+            return make_mutation_response(upsert_cnt=1, ids=[1])
+
+        handler._stub.Upsert.side_effect = stub_upsert_side_effect
+
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        with patch.object(handler, "_get_schema", side_effect=lambda *a, **kw: next(schema_iter)):
+            result = handler.upsert_rows(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        assert call_count == 2
+        assert result.upsert_count == 1
+
+    def test_insert_schema_mismatch_invalidates_cache(self, handler, old_schema, new_schema):
+        """Verify _invalidate_schema is called with correct collection and db_name."""
+        context = CallContext(db_name="mydb")
+        call_count = 0
+
+        def stub_insert(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return self._make_schema_mismatch_response()
+            return self._make_ok_response()
+
+        handler._stub.Insert.side_effect = stub_insert
+
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        with patch.object(
+            handler, "_get_schema", side_effect=lambda *a, **kw: next(schema_iter)
+        ), patch.object(handler, "_invalidate_schema") as mock_invalidate:
+            handler.insert_rows(
+                "test_coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        mock_invalidate.assert_called_once_with("test_coll", db_name="mydb")
+
+    def test_insert_schema_mismatch_still_fails_after_retry(self, handler, old_schema):
+        """If schema mismatch persists after retry, the exception propagates."""
+        context = CallContext(db_name="test_db")
+
+        # Server always returns SchemaMismatch
+        handler._stub.Insert.return_value = self._make_schema_mismatch_response()
+
+        with patch.object(handler, "_get_schema", return_value=(old_schema, 100)):
+            with pytest.raises(SchemaMismatchRetryableException, match="schema mismatch"):
+                handler.insert_rows(
+                    "coll",
+                    [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                    context=context,
+                )
+
+        # Insert called twice: original + one retry
+        assert handler._stub.Insert.call_count == 2
+
+    def test_insert_client_side_data_mismatch_triggers_retry(self, handler, old_schema, new_schema):
+        """DataNotMatchException (client-side validation) also triggers schema retry.
+
+        This happens when cached schema has fewer fields than the data, or
+        vice versa — the client detects the mismatch before sending the RPC.
+        """
+        context = CallContext(db_name="test_db")
+        call_count = 0
+
+        def mock_prepare(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise DataNotMatchException(message="field count mismatch")
+            # Second call uses fresh schema, builds request successfully
+            return MagicMock()
+
+        handler._stub.Insert.return_value = self._make_ok_response()
+
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        with patch.object(
+            handler, "_get_schema", side_effect=lambda *a, **kw: next(schema_iter)
+        ), patch.object(handler, "_prepare_row_insert_request", side_effect=mock_prepare):
+            result = handler.insert_rows(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        assert call_count == 2
+        assert result.insert_count == 1
+
+    def test_insert_schema_mismatch_no_context_raises_param_error(self, handler, old_schema):
+        """Schema mismatch without context kwarg raises ParamError (not retried)."""
+        handler._stub.Insert.return_value = self._make_schema_mismatch_response()
+
+        with patch.object(handler, "_get_schema", return_value=(old_schema, 100)):
+            with pytest.raises(Exception) as exc_info:
+                handler.insert_rows(
+                    "coll",
+                    [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                    # no context= kwarg
+                )
+
+        # ParamError from the decorator or SchemaMismatchRetryableException
+        # depends on how check_status raises it; the decorator catches it
+        # and tries to get context, which is None → ParamError
+        assert "context is required" in str(exc_info.value)
+
+    def test_insert_schema_timestamp_updated_on_retry(self, handler, old_schema, new_schema):
+        """After schema invalidation, the retried request uses the new schema_timestamp.
+
+        The schema_timestamp is embedded in the insert request and checked by the
+        Milvus proxy. A stale timestamp causes SchemaMismatch rejection.
+        """
+        context = CallContext(db_name="test_db")
+        captured_timestamps = []
+
+        original_prepare = handler._prepare_row_insert_request
+
+        def tracking_prepare(*args, **kwargs):
+            # Call the real _prepare_row_insert_request but capture schema timestamps
+            result = original_prepare(*args, **kwargs)
+            # The schema_timestamp is set on the request protobuf
+            if hasattr(result, "schema_timestamp"):
+                captured_timestamps.append(result.schema_timestamp)
+            return result
+
+        call_count = 0
+
+        def stub_insert(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return self._make_schema_mismatch_response()
+            return self._make_ok_response()
+
+        handler._stub.Insert.side_effect = stub_insert
+
+        get_schema_calls = []
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        def mock_get_schema(*args, **kwargs):
+            result = next(schema_iter)
+            get_schema_calls.append(result[1])  # capture timestamp
+            return result
+
+        with patch.object(handler, "_get_schema", side_effect=mock_get_schema):
+            handler.insert_rows(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        # Schema fetched twice: first with old ts (100), then with new ts (200)
+        assert get_schema_calls == [100, 200]
+
+    def test_upsert_schema_mismatch_still_fails_after_retry(self, handler, old_schema):
+        """upsert_rows: persistent SchemaMismatch propagates after retry exhaustion."""
+        context = CallContext(db_name="test_db")
+
+        handler._stub.Upsert.return_value = self._make_schema_mismatch_response()
+
+        with patch.object(handler, "_get_schema", return_value=(old_schema, 100)):
+            with pytest.raises(SchemaMismatchRetryableException, match="schema mismatch"):
+                handler.upsert_rows(
+                    "coll",
+                    [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                    context=context,
+                )
+
+    def test_insert_re_prepares_request_with_fresh_schema_on_retry(
+        self, handler, old_schema, new_schema
+    ):
+        """End-to-end: retry re-prepares the request through _parse_row_request.
+
+        Simulates the milvus-io/milvus#48522 scenario:
+        1. Rows have 2 fields (id, vector) — matching old schema
+        2. Concurrent add_field adds a 3rd nullable field
+        3. Server returns SchemaMismatch on first attempt
+        4. retry_on_schema_mismatch invalidates cache, retries
+        5. Retry fetches new schema (3 fields), _parse_row_request auto-fills
+           None for the missing nullable field
+        6. New request carries updated schema_timestamp → server accepts
+
+        This test does NOT mock _prepare_row_insert_request — it exercises
+        the real Prepare.row_insert_param → _parse_row_request path to
+        prove nullable auto-fill works.
+        """
+        context = CallContext(db_name="test_db")
+        call_count = 0
+        captured_requests = []
+
+        def stub_insert_capture(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Capture the request protobuf for inspection
+            request = args[0] if args else kwargs.get("request")
+            captured_requests.append(request)
+            if call_count == 1:
+                return self._make_schema_mismatch_response()
+            return self._make_ok_response()
+
+        handler._stub.Insert.side_effect = stub_insert_capture
+
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        # Only mock _get_schema — let _prepare_row_insert_request and
+        # Prepare.row_insert_param run for real
+        with patch.object(handler, "_get_schema", side_effect=lambda *a, **kw: next(schema_iter)):
+            result = handler.insert_rows(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        assert call_count == 2
+        assert result.insert_count == 1
+
+        # First request: built with old schema (2 fields), schema_timestamp=100
+        req1 = captured_requests[0]
+        assert req1.schema_timestamp == 100
+        req1_field_names = {fd.field_name for fd in req1.fields_data}
+        assert "extra" not in req1_field_names
+
+        # Second request: built with new schema (3 fields), schema_timestamp=200
+        # _parse_row_request auto-filled None for the nullable "extra" field
+        req2 = captured_requests[1]
+        assert req2.schema_timestamp == 200
+        req2_field_names = {fd.field_name for fd in req2.fields_data}
+        assert "extra" in req2_field_names
+
+    def test_upsert_re_prepares_request_with_fresh_schema_on_retry(
+        self, handler, old_schema, new_schema
+    ):
+        """End-to-end: upsert retry re-prepares with fresh schema, auto-fills nullable."""
+        context = CallContext(db_name="test_db")
+        call_count = 0
+        captured_requests = []
+
+        def stub_upsert_capture(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            request = args[0] if args else kwargs.get("request")
+            captured_requests.append(request)
+            if call_count == 1:
+                return self._make_schema_mismatch_response()
+            return make_mutation_response(upsert_cnt=1, ids=[1])
+
+        handler._stub.Upsert.side_effect = stub_upsert_capture
+
+        schema_sequence = [(old_schema, 100), (new_schema, 200)]
+        schema_iter = iter(schema_sequence)
+
+        with patch.object(handler, "_get_schema", side_effect=lambda *a, **kw: next(schema_iter)):
+            result = handler.upsert_rows(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                context=context,
+            )
+
+        assert call_count == 2
+        assert result.upsert_count == 1
+
+        req1 = captured_requests[0]
+        assert req1.schema_timestamp == 100
+        assert "extra" not in {fd.field_name for fd in req1.fields_data}
+
+        req2 = captured_requests[1]
+        assert req2.schema_timestamp == 200
+        assert "extra" in {fd.field_name for fd in req2.fields_data}

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -2,12 +2,14 @@
 """Tests for ConnectionManager and related classes."""
 
 import asyncio
+import threading
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
 import grpc
 import pytest
 from pymilvus import AsyncMilvusClient, MilvusClient
+from pymilvus.client.async_grpc_handler import AsyncGrpcHandler
 from pymilvus.client.connection_manager import (
     IDLE_THRESHOLD_SECONDS,
     AsyncConnectionManager,
@@ -22,6 +24,7 @@ from pymilvus.client.connection_manager import (
     _GlobalStrategyMixin,
 )
 from pymilvus.client.global_topology import ClusterInfo
+from pymilvus.client.grpc_handler import GrpcHandler
 from pymilvus.exceptions import ConnectionConfigException, MilvusException
 
 # =============================================================================
@@ -41,6 +44,7 @@ def _make_sync_handler(**overrides):
     handler = Mock()
     handler._wait_for_channel_ready = Mock()
     handler.close = Mock()
+    handler.reconnect = Mock()
     for k, v in overrides.items():
         setattr(handler, k, v)
     return handler
@@ -51,6 +55,7 @@ def _make_async_handler(**overrides):
     handler = Mock(spec=[])
     handler.ensure_channel_ready = AsyncMock()
     handler.close = AsyncMock()
+    handler.reconnect = AsyncMock()
     for k, v in overrides.items():
         setattr(handler, k, v)
     return handler
@@ -672,29 +677,28 @@ class TestConnectionManager:
         assert mgr._get_managed(unknown_handler) is None
 
     def test_health_check_triggers_on_idle_connection(self):
-        """Test that an idle shared connection triggers health check and recovery."""
+        """Test that an idle shared connection triggers health check and in-place recovery."""
         mgr = ConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
-            old_handler = _make_sync_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
 
             h1 = mgr.get_or_create(config)
-            assert h1 is old_handler
+            assert h1 is handler
 
             # Artificially make the connection idle beyond the threshold
             managed = mgr._get_managed(h1)
             managed.last_used_at = time.time() - IDLE_THRESHOLD_SECONDS - 1
 
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
-
             with patch.object(mgr, "_check_health", return_value=False):
                 h2 = mgr.get_or_create(config)
 
-            assert h2 is new_handler
-            assert managed.handler is new_handler
+            # In-place recovery: same handler object, reconnected
+            assert h2 is handler
+            assert managed.handler is handler
+            handler.reconnect.assert_called_once()
 
     def test_no_health_check_when_recently_used(self):
         """Test that a recently-used connection skips health check."""
@@ -767,7 +771,7 @@ class TestConnectionManager:
         assert mgr._check_health(managed) is False
 
     def test_recover_raises_on_failure(self):
-        """Test _recover logs and re-raises when handler creation fails."""
+        """Test _recover logs and re-raises when reconnect fails."""
         mgr = ConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
@@ -778,7 +782,7 @@ class TestConnectionManager:
             handler = mgr.get_or_create(config)
             managed = mgr._get_managed(handler)
 
-            mock_handler_cls.side_effect = RuntimeError("cannot connect")
+            handler.reconnect.side_effect = RuntimeError("cannot connect")
 
             with pytest.raises(RuntimeError, match="cannot connect"):
                 mgr._recover(managed)
@@ -797,7 +801,7 @@ class TestConnectionManager:
         mgr.handle_error(handler, _MockRpcError())
 
     def test_handle_error_already_recovered(self):
-        """Test handle_error skips recovery if handler already replaced."""
+        """Test handle_error skips recovery if another thread already recovered."""
         mgr = ConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
@@ -808,42 +812,40 @@ class TestConnectionManager:
             managed = mgr._get_managed(handler)
 
             # Simulate another thread recovering between lock release and re-acquire
-            new_handler = _make_sync_handler()
+            # by bumping recovery_gen during on_unavailable
             original_on_unavailable = managed.strategy.on_unavailable
 
-            def swap_handler_then_return_true(m):
+            def bump_gen_then_return_true(m):
                 original_on_unavailable(m)
-                managed.handler = new_handler  # simulate concurrent recovery
+                managed.recovery_gen += 1  # simulate concurrent recovery
                 return True
 
-            managed.strategy.on_unavailable = swap_handler_then_return_true
+            managed.strategy.on_unavailable = bump_gen_then_return_true
 
             mgr.handle_error(handler, _MockRpcError())
 
-            # The handler should be new_handler (set by our swap), not re-recovered
-            assert managed.handler is new_handler
+            # reconnect should NOT have been called - concurrent recovery detected
+            handler.reconnect.assert_not_called()
 
     def test_dedicated_connection_findable_after_recovery(self):
-        """Test that after recovery, the new handler is still findable in _dedicated."""
+        """Test that after in-place recovery, dedicated connection is still findable."""
         mgr = ConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
-            old_handler = _make_sync_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = mgr.get_or_create(config, dedicated=True)
-            assert id(handler) in mgr._dedicated
-
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
+            conn = mgr.get_or_create(config, dedicated=True)
+            assert id(conn) in mgr._dedicated
 
             mgr.handle_error(handler, _MockRpcError())
 
-            assert id(old_handler) not in mgr._dedicated
-            assert id(new_handler) in mgr._dedicated
-            assert mgr._get_managed(new_handler) is not None
-            assert mgr._get_managed(new_handler).handler is new_handler
+            # Handler identity is preserved — same key, same object
+            assert id(handler) in mgr._dedicated
+            assert mgr._get_managed(handler) is not None
+            assert mgr._get_managed(handler).handler is handler
+            handler.reconnect.assert_called_once()
 
     def test_dedicated_connection_releasable_after_recovery(self):
         """Test that a recovered dedicated connection can be released."""
@@ -851,21 +853,18 @@ class TestConnectionManager:
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
-            old_handler = _make_sync_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = mgr.get_or_create(config, dedicated=True)
-
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
+            mgr.get_or_create(config, dedicated=True)
 
             mgr.handle_error(handler, _MockRpcError())
 
-            managed = mgr._get_managed(new_handler)
+            managed = mgr._get_managed(handler)
             assert managed is not None
 
-            mgr.release(new_handler)
-            assert id(new_handler) not in mgr._dedicated
+            mgr.release(handler)
+            assert id(handler) not in mgr._dedicated
 
     def test_managed_connection_creation_and_timestamps(self):
         """Test ManagedConnection creation and timestamp tracking."""
@@ -1156,22 +1155,19 @@ class TestAsyncConnectionManager:
 
     @pytest.mark.asyncio
     async def test_async_health_check_triggers_on_idle_connection(self):
-        """Test that an idle async shared connection triggers health check and recovery."""
+        """Test that an idle async shared connection triggers health check and in-place recovery."""
         mgr = AsyncConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
-            old_handler = _make_async_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
 
             h1 = await mgr.get_or_create(config)
-            assert h1 is old_handler
+            assert h1 is handler
 
             managed = mgr._get_managed(h1)
             managed.last_used_at = time.time() - IDLE_THRESHOLD_SECONDS - 1
-
-            new_handler = _make_async_handler()
-            mock_handler_cls.return_value = new_handler
 
             async def _failing_health_check(m):
                 return False
@@ -1179,8 +1175,10 @@ class TestAsyncConnectionManager:
             mgr._check_health = _failing_health_check
             h2 = await mgr.get_or_create(config)
 
-            assert h2 is new_handler
-            assert managed.handler is new_handler
+            # In-place recovery: same handler object, reconnected
+            assert h2 is handler
+            assert managed.handler is handler
+            handler.reconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_async_check_health_healthy(self):
@@ -1283,18 +1281,18 @@ class TestAsyncConnectionManager:
 
     @pytest.mark.asyncio
     async def test_recover_raises_on_failure(self):
-        """Test async _recover logs and re-raises when handler creation fails."""
+        """Test async _recover logs and re-raises when reconnect fails."""
         mgr = AsyncConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
-            old_handler = _make_async_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = await mgr.get_or_create(config)
+            await mgr.get_or_create(config)
             managed = mgr._get_managed(handler)
 
-            mock_handler_cls.side_effect = RuntimeError("cannot connect")
+            handler.reconnect = AsyncMock(side_effect=RuntimeError("cannot connect"))
 
             with pytest.raises(RuntimeError, match="cannot connect"):
                 await mgr._recover(managed)
@@ -1349,25 +1347,23 @@ class TestAsyncConnectionManager:
 
     @pytest.mark.asyncio
     async def test_async_dedicated_connection_findable_after_recovery(self):
-        """Test async dedicated connection key update after recovery."""
+        """Test async dedicated connection still findable after in-place recovery."""
         mgr = AsyncConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
-            old_handler = _make_async_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = await mgr.get_or_create(config, dedicated=True)
+            await mgr.get_or_create(config, dedicated=True)
             assert id(handler) in mgr._dedicated
-
-            new_handler = _make_async_handler()
-            mock_handler_cls.return_value = new_handler
 
             await mgr.handle_error(handler, _MockRpcError())
 
-            assert id(old_handler) not in mgr._dedicated
-            assert id(new_handler) in mgr._dedicated
-            assert mgr._get_managed(new_handler).handler is new_handler
+            # Handler identity preserved — same key, same object
+            assert id(handler) in mgr._dedicated
+            assert mgr._get_managed(handler).handler is handler
+            handler.reconnect.assert_called_once()
 
 
 # =============================================================================
@@ -1401,16 +1397,12 @@ class TestErrorHandling:
                 def code(self):
                     return error_code
 
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
-
             mgr.handle_error(handler, _CodedRpcError())
 
             if expect_recovery:
-                mock_handler.close.assert_called()
-                assert mock_handler_cls.call_count >= 2
+                mock_handler.reconnect.assert_called_once()
             else:
-                mock_handler.close.assert_not_called()
+                mock_handler.reconnect.assert_not_called()
 
     def test_error_callback_registered_on_handler(self):
         """Test that _on_rpc_error callback is set on handler after creation."""
@@ -1444,25 +1436,24 @@ class TestErrorHandling:
                 handler._on_rpc_error(error)
                 mock_handle.assert_called_once_with(handler, error)
 
-    def test_error_callback_re_registered_after_recovery(self):
-        """Test that _on_rpc_error is re-registered on new handler after recovery."""
+    def test_error_callback_preserved_after_recovery(self):
+        """Test that _on_rpc_error callback remains valid after in-place recovery."""
         mgr = ConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
-            old_handler = _make_sync_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = mgr.get_or_create(config)
-
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
+            mgr.get_or_create(config)
+            original_callback = handler._on_rpc_error
 
             mgr.handle_error(handler, _MockRpcError())
 
+            # Same handler, same callback (no re-registration needed)
             managed = next(iter(mgr._registry.values()))
-            assert hasattr(managed.handler, "_on_rpc_error")
-            assert callable(managed.handler._on_rpc_error)
+            assert managed.handler is handler
+            assert managed.handler._on_rpc_error is original_callback
 
     @pytest.mark.asyncio
     async def test_async_error_callback_registered(self):
@@ -1495,43 +1486,38 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_async_handle_error_unavailable(self):
-        """Test async handle_error triggers recovery for UNAVAILABLE."""
+        """Test async handle_error triggers in-place recovery for UNAVAILABLE."""
         mgr = AsyncConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
-            old_handler = _make_async_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = await mgr.get_or_create(config)
-
-            new_handler = _make_async_handler()
-            mock_handler_cls.return_value = new_handler
+            await mgr.get_or_create(config)
 
             await mgr.handle_error(handler, _MockRpcError())
 
             managed = next(iter(mgr._registry.values()))
-            assert managed.handler is new_handler
-            assert hasattr(managed.handler, "_on_rpc_error")
+            # Handler identity preserved — in-place recovery
+            assert managed.handler is handler
+            handler.reconnect.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_async_recover_calls_ensure_channel_ready(self):
-        """Test that async _recover awaits ensure_channel_ready on new handler."""
+    async def test_async_recover_calls_reconnect(self):
+        """Test that async _recover calls reconnect on the existing handler."""
         mgr = AsyncConnectionManager.get_instance()
         config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
 
         with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
-            old_handler = _make_async_handler()
-            mock_handler_cls.return_value = old_handler
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
 
-            handler = await mgr.get_or_create(config)
-
-            new_handler = _make_async_handler()
-            mock_handler_cls.return_value = new_handler
+            await mgr.get_or_create(config)
 
             await mgr.handle_error(handler, _MockRpcError())
 
-            new_handler.ensure_channel_ready.assert_called_once()
+            handler.reconnect.assert_called_once()
 
 
 # =============================================================================
@@ -1701,9 +1687,6 @@ class TestReplicateViolationRecovery:
             managed = mgr._get_managed(handler)
             assert isinstance(managed.strategy, GlobalStrategy)
 
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
-
             with patch(
                 "pymilvus.client.connection_manager.fetch_topology",
                 return_value=new_topology,
@@ -1711,7 +1694,10 @@ class TestReplicateViolationRecovery:
                 result = mgr.handle_error(handler, self._make_replicate_error())
 
             assert result is True
-            mock_handler.close.assert_called()
+            # In-place recovery: reconnect called with new primary address
+            handler.reconnect.assert_called_once()
+            call_kwargs = handler.reconnect.call_args
+            assert call_kwargs.kwargs.get("address") == "in02.zilliz.com:19530"
 
     def test_replicate_violation_ignored_for_regular_strategy(self):
         """Test handle_error returns True for REPLICATE_VIOLATION on regular connections
@@ -1727,11 +1713,9 @@ class TestReplicateViolationRecovery:
             managed = mgr._get_managed(handler)
             assert isinstance(managed.strategy, RegularStrategy)
 
-            new_handler = _make_sync_handler()
-            mock_handler_cls.return_value = new_handler
-
             result = mgr.handle_error(handler, self._make_replicate_error())
             assert result is True
+            handler.reconnect.assert_called_once()
 
     def test_unrelated_milvus_exception_not_retried(self):
         """Test handle_error ignores MilvusExceptions without REPLICATE_VIOLATION."""
@@ -1772,7 +1756,7 @@ class TestReplicateViolationRecovery:
                 result = mgr.handle_error(handler, self._make_replicate_error())
 
             assert result is False
-            mock_handler.close.assert_not_called()
+            mock_handler.reconnect.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_replicate_violation_triggers_recovery(self):
@@ -1793,9 +1777,6 @@ class TestReplicateViolationRecovery:
 
             handler = await mgr.get_or_create(config)
 
-            new_handler = _make_async_handler()
-            mock_handler_cls.return_value = new_handler
-
             with patch(
                 "pymilvus.client.connection_manager.fetch_topology",
                 return_value=new_topology,
@@ -1803,6 +1784,10 @@ class TestReplicateViolationRecovery:
                 result = await mgr.handle_error(handler, self._make_replicate_error())
 
             assert result is True
+            # In-place recovery: reconnect called with new primary address
+            handler.reconnect.assert_called_once()
+            call_kwargs = handler.reconnect.call_args
+            assert call_kwargs.kwargs.get("address") == "in02.zilliz.com:19530"
 
     @pytest.mark.asyncio
     async def test_async_unrelated_milvus_exception_not_retried(self):
@@ -1812,6 +1797,504 @@ class TestReplicateViolationRecovery:
 
         error = MilvusException(code=1, message="collection not found")
         assert await mgr.handle_error(handler, error) is False
+
+
+# =============================================================================
+# TestInPlaceRecovery — regression tests for "Cannot invoke RPC on closed channel"
+# =============================================================================
+
+
+class TestInPlaceRecovery:
+    """Tests that recovery preserves handler identity.
+
+    Before the fix, _recover() created a new handler object. This caused
+    "Cannot invoke RPC on closed channel" because:
+    - MilvusClient._handler still referenced the old (closed) handler
+    - retry_on_rpc_failure loops still used the old handler via args[0]
+    """
+
+    def setup_method(self):
+        ConnectionManager._reset_instance()
+        AsyncConnectionManager._reset_instance()
+
+    def teardown_method(self):
+        ConnectionManager._reset_instance()
+        AsyncConnectionManager._reset_instance()
+
+    def test_recover_preserves_handler_identity(self):
+        """After recovery, managed.handler is the SAME object (not a new one)."""
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            conn = mgr.get_or_create(config)
+            assert conn is handler
+
+            mgr.handle_error(handler, _MockRpcError())
+
+            managed = mgr._get_managed(handler)
+            assert managed is not None
+            assert managed.handler is handler  # Same object — in-place recovery
+            handler.reconnect.assert_called_once()
+
+    def test_client_handler_reference_valid_after_recovery(self):
+        """MilvusClient._handler remains usable after UNAVAILABLE recovery."""
+        mgr = ConnectionManager.get_instance()
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler(get_server_type=Mock(return_value="milvus"))
+            mock_handler_cls.return_value = handler
+
+            client = MilvusClient(uri="http://localhost:19530")
+            original_handler = client._handler
+            assert original_handler is handler
+
+            # Simulate UNAVAILABLE error triggering recovery
+            mgr.handle_error(handler, _MockRpcError())
+
+            # Client's handler reference is STILL valid (same object)
+            assert client._handler is original_handler
+            assert client._get_connection() is original_handler
+            handler.reconnect.assert_called_once()
+
+            client.close()
+
+    def test_recovery_gen_incremented(self):
+        """recovery_gen counter increments on each recovery."""
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+            managed = mgr._get_managed(handler)
+
+            assert managed.recovery_gen == 0
+            mgr.handle_error(handler, _MockRpcError())
+            assert managed.recovery_gen == 1
+            mgr.handle_error(handler, _MockRpcError())
+            assert managed.recovery_gen == 2
+
+    def test_global_recovery_passes_new_primary_address(self):
+        """Global strategy recovery passes the new primary endpoint to reconnect."""
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri(
+            "https://glo-xxx.global-cluster.vectordb.zilliz.com", token="test"
+        )
+
+        old_topology = _make_topology(1, "in01", "https://old-primary.zilliz.com:19530")
+        new_topology = _make_topology(2, "in02", "https://new-primary.zilliz.com:19530")
+
+        with patch(
+            "pymilvus.client.connection_manager.fetch_topology", return_value=old_topology
+        ), patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+
+            with patch(
+                "pymilvus.client.connection_manager.fetch_topology",
+                return_value=new_topology,
+            ):
+                mgr.handle_error(handler, _MockRpcError())
+
+            call_kwargs = handler.reconnect.call_args
+            assert call_kwargs.kwargs.get("address") == "new-primary.zilliz.com:19530"
+
+    def test_regular_recovery_keeps_same_address(self):
+        """Regular strategy recovery passes address=None (keep current)."""
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+            mgr.handle_error(handler, _MockRpcError())
+
+            call_kwargs = handler.reconnect.call_args
+            assert call_kwargs.kwargs.get("address") is None
+
+    def test_global_recovery_warns_when_no_topology(self):
+        """GlobalStrategy logs warning when get_recovery_address returns None.
+
+        This happens when on_unavailable fails to fetch topology (e.g., network
+        error during refresh) but still returns True to trigger recovery.
+        """
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri(
+            "https://glo-xxx.global-cluster.vectordb.zilliz.com", token="test"
+        )
+
+        mock_topology = _make_topology(1, "in01", "https://in01.zilliz.com")
+
+        with patch(
+            "pymilvus.client.connection_manager.fetch_topology", return_value=mock_topology
+        ), patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+            managed = mgr._get_managed(handler)
+
+            # Clear topology AND make fetch_topology fail — simulates
+            # on_unavailable returning True despite no topology available
+            managed.strategy._topology = None
+
+            with patch(
+                "pymilvus.client.connection_manager.fetch_topology",
+                side_effect=RuntimeError("network error"),
+            ), patch("pymilvus.client.connection_manager.logger") as mock_logger:
+                mgr.handle_error(handler, _MockRpcError())
+
+                # Should warn about missing topology
+                mock_logger.warning.assert_any_call(
+                    "Global strategy has no topology; reconnecting to current address"
+                )
+                # reconnect still called (with address=None, falls back to current)
+                handler.reconnect.assert_called_once()
+                assert handler.reconnect.call_args.kwargs.get("address") is None
+
+    @pytest.mark.asyncio
+    async def test_async_recover_preserves_handler_identity(self):
+        """Async: after recovery, managed.handler is the SAME object."""
+        mgr = AsyncConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
+
+            conn = await mgr.get_or_create(config)
+            assert conn is handler
+
+            await mgr.handle_error(handler, _MockRpcError())
+
+            managed = mgr._get_managed(handler)
+            assert managed is not None
+            assert managed.handler is handler
+            handler.reconnect.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_recovery_gen_incremented(self):
+        """Async: recovery_gen increments on each recovery."""
+        mgr = AsyncConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
+
+            await mgr.get_or_create(config)
+            managed = mgr._get_managed(handler)
+
+            assert managed.recovery_gen == 0
+            await mgr.handle_error(handler, _MockRpcError())
+            assert managed.recovery_gen == 1
+
+    def test_concurrent_handle_error_only_one_reconnect(self):
+        """Two threads hitting handle_error simultaneously: only one reconnects.
+
+        Thread A and B both get UNAVAILABLE. on_unavailable is called outside
+        the lock, so both can enter. But the recovery_gen guard ensures only
+        one actually calls reconnect.
+        """
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+            managed = mgr._get_managed(handler)
+
+            # Barrier so both threads enter on_unavailable at the same time
+            barrier = threading.Barrier(2)
+
+            original_on_unavailable = managed.strategy.on_unavailable
+
+            def slow_on_unavailable(m):
+                barrier.wait(timeout=2)
+                return original_on_unavailable(m)
+
+            managed.strategy.on_unavailable = slow_on_unavailable
+
+            results = [None, None]
+
+            def call_handle_error(idx):
+                results[idx] = mgr.handle_error(handler, _MockRpcError())
+
+            t1 = threading.Thread(target=call_handle_error, args=(0,))
+            t2 = threading.Thread(target=call_handle_error, args=(1,))
+            t1.start()
+            t2.start()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+            # Both return True (recovery was handled)
+            assert results[0] is True
+            assert results[1] is True
+            # But reconnect called only once — the second thread saw the gen bump
+            assert handler.reconnect.call_count == 1
+            assert managed.recovery_gen == 1
+
+    def test_concurrent_handle_error_and_health_check_both_recover_safely(self):
+        """handle_error and get_or_create health-check both recover, serialized by lock.
+
+        Thread A triggers recovery via handle_error (under lock).
+        Thread B triggers health-check recovery via get_or_create (under lock).
+        Both reconnect (one from each path), but they don't corrupt each other
+        because self._lock serializes access. The handler object is preserved.
+        """
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+            managed = mgr._get_managed(handler)
+            # Make idle to trigger health check
+            managed.last_used_at = time.time() - IDLE_THRESHOLD_SECONDS - 1
+
+            barrier = threading.Barrier(2, timeout=3)
+
+            original_on_unavailable = managed.strategy.on_unavailable
+
+            def slow_on_unavailable(m):
+                barrier.wait()
+                return original_on_unavailable(m)
+
+            managed.strategy.on_unavailable = slow_on_unavailable
+
+            results = {}
+
+            def thread_handle_error():
+                results["handle_error"] = mgr.handle_error(handler, _MockRpcError())
+
+            def thread_get_or_create():
+                with patch.object(mgr, "_check_health", return_value=False):
+                    barrier.wait()
+                    results["get_or_create"] = mgr.get_or_create(config)
+
+            t1 = threading.Thread(target=thread_handle_error)
+            t2 = threading.Thread(target=thread_get_or_create)
+            t1.start()
+            t2.start()
+            t1.join(timeout=5)
+            t2.join(timeout=5)
+
+            # Both completed without error
+            assert "handle_error" in results
+            assert "get_or_create" in results
+            # Both paths recover independently (serialized by lock):
+            # - handle_error path: gen guard lets it through
+            # - get_or_create health-check path: no gen guard, always recovers
+            # Either way, the handler object is the same.
+            assert managed.handler is handler
+
+    def test_recovery_gen_guard_deterministic(self):
+        """Directly verify: if gen was bumped during on_unavailable, reconnect is skipped.
+
+        This is a deterministic (non-threaded) test of the gen guard logic.
+        The concurrent variant (test_concurrent_handle_error_only_one_reconnect)
+        proves it works under real thread contention.
+        """
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config)
+            managed = mgr._get_managed(handler)
+
+            # Simulate: another thread recovers during on_unavailable
+            original_on_unavailable = managed.strategy.on_unavailable
+
+            def bump_gen_during_on_unavailable(m):
+                managed.recovery_gen += 1  # simulate concurrent recovery
+                return original_on_unavailable(m)
+
+            managed.strategy.on_unavailable = bump_gen_during_on_unavailable
+
+            result = mgr.handle_error(handler, _MockRpcError())
+
+            assert result is True
+            # reconnect should NOT have been called — gen was bumped
+            handler.reconnect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_sequential_handle_errors_both_recover(self):
+        """Async: two sequential handle_error calls both reconnect.
+
+        In the async path, saved_gen is read and checked within the same
+        lock acquisition (no release between read and check). So each
+        call independently recovers — this is correct behavior since
+        each UNAVAILABLE error indicates a real problem.
+        """
+        mgr = AsyncConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
+
+            await mgr.get_or_create(config)
+
+            r1, r2 = await asyncio.gather(
+                mgr.handle_error(handler, _MockRpcError()),
+                mgr.handle_error(handler, _MockRpcError()),
+            )
+
+            assert r1 is True
+            assert r2 is True
+            # Both recover: the asyncio lock serializes them, but each
+            # reads saved_gen within its own lock scope, so both match.
+            assert handler.reconnect.call_count == 2
+            # Handler identity still preserved
+            managed = mgr._get_managed(handler)
+            assert managed is not None
+            assert managed.handler is handler
+
+
+# =============================================================================
+# TestHandlerReconnect — unit tests for reconnect() on real handler objects
+# =============================================================================
+
+
+def _make_real_sync_handler(address="localhost:19530"):
+    """Create a real GrpcHandler with mocked gRPC channel for reconnect testing."""
+    with patch("pymilvus.client.grpc_handler.grpc.insecure_channel") as mock_ch:
+        mock_ch.return_value = Mock()
+        return GrpcHandler(uri=f"http://{address}", address=address)
+
+
+def _make_real_async_handler(address="localhost:19530"):
+    """Create a real AsyncGrpcHandler with mocked gRPC channel for reconnect testing."""
+    with patch("pymilvus.client.async_grpc_handler.grpc.aio.insecure_channel") as mock_ch:
+        mock_ch.return_value = AsyncMock()
+        return AsyncGrpcHandler(uri=f"http://{address}", address=address)
+
+
+class TestHandlerReconnect:
+    """Tests for GrpcHandler.reconnect() and AsyncGrpcHandler.reconnect().
+
+    Exercises the real reconnect() implementations (not mocked) to cover
+    the close-then-recreate-channel logic.
+    """
+
+    @pytest.mark.parametrize(
+        "new_address,expected_address",
+        [
+            (None, "localhost:19530"),
+            ("newhost:19530", "newhost:19530"),
+        ],
+        ids=["keep_address", "change_address"],
+    )
+    def test_sync_reconnect_address_handling(self, new_address, expected_address):
+        """reconnect() keeps or updates address, closes old channel, creates new one."""
+        handler = _make_real_sync_handler()
+        old_channel = handler._channel
+
+        with patch("pymilvus.client.grpc_handler.grpc.insecure_channel") as mock_ch, patch.object(
+            handler, "_wait_for_channel_ready"
+        ):
+            new_channel = Mock()
+            mock_ch.return_value = new_channel
+            handler.reconnect(address=new_address)
+
+        old_channel.close.assert_called_once()
+        assert handler._channel is new_channel
+        assert handler._address == expected_address
+
+    def test_sync_reconnect_close_failure_recovers(self):
+        """When close() raises, channel is cleared and a new one is created."""
+        handler = _make_real_sync_handler()
+        handler._channel.close = Mock(side_effect=RuntimeError("broken"))
+
+        with patch("pymilvus.client.grpc_handler.grpc.insecure_channel") as mock_ch, patch.object(
+            handler, "_wait_for_channel_ready"
+        ):
+            new_channel = Mock()
+            mock_ch.return_value = new_channel
+            handler.reconnect()
+
+        assert handler._channel is new_channel
+
+    def test_sync_reconnect_passes_timeout(self):
+        """reconnect() forwards timeout to _wait_for_channel_ready."""
+        handler = _make_real_sync_handler()
+
+        with patch(
+            "pymilvus.client.grpc_handler.grpc.insecure_channel", return_value=Mock()
+        ), patch.object(handler, "_wait_for_channel_ready") as mock_wait:
+            handler.reconnect(timeout=30)
+
+        mock_wait.assert_called_once_with(timeout=30)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "new_address,expected_address",
+        [
+            (None, "localhost:19530"),
+            ("newhost:19530", "newhost:19530"),
+        ],
+        ids=["keep_address", "change_address"],
+    )
+    async def test_async_reconnect_address_handling(self, new_address, expected_address):
+        """Async reconnect() keeps or updates address, closes old channel, creates new one."""
+        handler = _make_real_async_handler()
+        old_channel = handler._async_channel
+
+        with patch(
+            "pymilvus.client.async_grpc_handler.grpc.aio.insecure_channel"
+        ) as mock_ch, patch.object(handler, "ensure_channel_ready", new_callable=AsyncMock):
+            new_channel = AsyncMock()
+            mock_ch.return_value = new_channel
+            await handler.reconnect(address=new_address)
+
+        old_channel.close.assert_called_once()
+        assert handler._async_channel is new_channel
+        assert handler._address == expected_address
+        assert handler._is_channel_ready is False
+
+    @pytest.mark.asyncio
+    async def test_async_reconnect_close_failure_recovers(self):
+        """When async close() raises, channel is cleared and a new one is created."""
+        handler = _make_real_async_handler()
+        handler._async_channel.close = AsyncMock(side_effect=RuntimeError("broken"))
+
+        with patch(
+            "pymilvus.client.async_grpc_handler.grpc.aio.insecure_channel"
+        ) as mock_ch, patch.object(handler, "ensure_channel_ready", new_callable=AsyncMock):
+            new_channel = AsyncMock()
+            mock_ch.return_value = new_channel
+            await handler.reconnect()
+
+        assert handler._async_channel is new_channel
+
+    @pytest.mark.asyncio
+    async def test_async_reconnect_passes_timeout(self):
+        """Async reconnect() forwards timeout to ensure_channel_ready."""
+        handler = _make_real_async_handler()
+
+        with patch(
+            "pymilvus.client.async_grpc_handler.grpc.aio.insecure_channel", return_value=AsyncMock()
+        ), patch.object(handler, "ensure_channel_ready", new_callable=AsyncMock) as mock_ensure:
+            await handler.reconnect(timeout=30)
+
+        mock_ensure.assert_called_once_with(timeout=30)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Fix "Cannot invoke RPC on closed channel" error caused by stale handler references after `ConnectionManager._recover()` — a regression from the ConnectionManager introduced in 2.6.10 (#3283)
- `_recover()` previously created a new handler object, but `MilvusClient._handler` and in-flight retry loops still referenced the old (closed) handler
- Fix: add `reconnect()` to `GrpcHandler`/`AsyncGrpcHandler` that resets the gRPC channel in-place (same object, new channel), so all references remain valid
- Add `recovery_gen` counter to `ManagedConnection` for concurrent recovery guard
- Add `get_recovery_address()` to strategies so `GlobalStrategy` passes new primary endpoint
- Add warning log when global topology is unavailable during recovery
- Add concurrency unit tests proving lock + gen guard prevent double reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)