### PR TITLE
fix: handle None response in search to prevent AttributeError

### DIFF
--- a/pymilvus/client/asynch.py
+++ b/pymilvus/client/asynch.py
@@ -3,6 +3,8 @@ import inspect
 import threading
 from typing import Any, Callable, Optional
 
+import grpc
+
 from pymilvus.exceptions import MilvusException
 from pymilvus.grpc_gen import milvus_pb2
 
@@ -10,6 +12,27 @@ from .abstract import MutationResult
 from .search_result import SearchResult
 from .types import Status
 from .utils import check_status
+
+
+def _build_none_response_exception(future: Any) -> MilvusException:
+    """Build a MilvusException when a gRPC future returns None as the response message.
+
+    This is a gRPC Python edge-case (race condition between client-side cancellation
+    and the server response arriving) rather than a normal timeout flow.  Checking
+    ``future.code()`` lets us surface the real gRPC status — in particular
+    DEADLINE_EXCEEDED — so callers get an actionable error instead of an opaque
+    AttributeError on ``None.status``.
+    """
+    try:
+        code = future.code()
+        details = future.details() or ""
+        if code == grpc.StatusCode.DEADLINE_EXCEEDED:
+            return MilvusException(message=f"gRPC call timed out (DEADLINE_EXCEEDED): {details}")
+        return MilvusException(
+            message=f"Received None response from server (code={code.name}, details={details})"
+        )
+    except Exception:
+        return MilvusException(message="Received None response from server")
 
 
 # TODO: remove this to a common util
@@ -114,6 +137,8 @@ class Future(AbstractFuture):
                     self._response = self._future.result(timeout=to)
                 except Exception as e:
                     raise MilvusException(message=str(e)) from e
+                if self._response is None:
+                    raise _build_none_response_exception(self._future)
                 self._results = self.on_response(self._response)
 
                 self._callback()
@@ -127,7 +152,7 @@ class Future(AbstractFuture):
             # just return response object received from gRPC
             return self._response
 
-        if self._results:
+        if self._results is not None:
             return self._results
         return self.on_response(self._response)
 
@@ -145,8 +170,11 @@ class Future(AbstractFuture):
             if self._future and self._results is None:
                 try:
                     self._response = self._future.result()
-                    self._results = self.on_response(self._response)
-                    self._callback()  # https://github.com/milvus-io/milvus/issues/6160
+                    if self._response is None:
+                        self._exception = _build_none_response_exception(self._future)
+                    else:
+                        self._results = self.on_response(self._response)
+                        self._callback()  # https://github.com/milvus-io/milvus/issues/6160
                 except Exception as e:
                     self._exception = e
 
@@ -163,6 +191,8 @@ class Future(AbstractFuture):
 
 class SearchFuture(Future):
     def on_response(self, response: milvus_pb2.SearchResults):
+        if response is None:
+            raise MilvusException(message="Received None response from server during search")
         check_status(response.status)
         return SearchResult(response.results, status=response.status)
 

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1123,6 +1123,8 @@ class GrpcHandler:
                 return SearchFuture(future, func)
 
             response = self._stub.Search(request, timeout=timeout, metadata=_api_level_md(context))
+            if response is None:
+                raise MilvusException(message="Received None response from server during search")
             check_status(response.status)
             round_decimal = kwargs.get("round_decimal", -1)
             return SearchResult(
@@ -1156,6 +1158,8 @@ class GrpcHandler:
             response = self._stub.HybridSearch(
                 request, timeout=timeout, metadata=_api_level_md(context)
             )
+            if response is None:
+                raise MilvusException(message="Received None response from server during search")
             check_status(response.status)
             round_decimal = kwargs.get("round_decimal", -1)
             return SearchResult(response.results, round_decimal, status=response.status)

--- a/tests/grpc_handler/test_data.py
+++ b/tests/grpc_handler/test_data.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pymilvus import AnnSearchRequest, RRFRanker
 from pymilvus.client.types import DataType
-from pymilvus.exceptions import ParamError
+from pymilvus.exceptions import MilvusException, ParamError
 
 from .conftest import make_mutation_response
 
@@ -125,6 +125,33 @@ class TestGrpcHandlerSearchOps:
         ):
             result = handler.hybrid_search("coll", [req], RRFRanker(), 10, _async=True)
             assert result is not None
+
+    def test_search_stub_returns_none_raises_milvus_exception(self, handler):
+        handler._stub.Search.return_value = None
+
+        with patch(
+            "pymilvus.client.grpc_handler.ts_utils.construct_guarantee_ts", return_value=True
+        ):
+            with pytest.raises(
+                MilvusException, match="Received None response from server during search"
+            ):
+                handler.search(
+                    "coll", "vec", {"metric_type": "L2"}, 10, data=[[0.1, 0.2, 0.3, 0.4]]
+                )
+
+    def test_hybrid_search_stub_returns_none_raises_milvus_exception(self, handler):
+        handler._stub.HybridSearch.return_value = None
+
+        req = AnnSearchRequest(
+            data=[[0.1, 0.2, 0.3, 0.4]], anns_field="vec", param={"metric_type": "L2"}, limit=10
+        )
+        with patch(
+            "pymilvus.client.grpc_handler.ts_utils.construct_guarantee_ts", return_value=True
+        ):
+            with pytest.raises(
+                MilvusException, match="Received None response from server during search"
+            ):
+                handler.hybrid_search("coll", [req], RRFRanker(), 10)
 
     def test_search_with_ids(self, handler):
         mock_resp = MagicMock()

--- a/tests/test_asynch.py
+++ b/tests/test_asynch.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import grpc
 import pytest
 from pymilvus.client.asynch import (
     CreateFlatIndexFuture,
@@ -310,6 +311,60 @@ class TestSearchFutureOnResponse:
             result = f.on_response(mock_response)
             mock_check.assert_called_once_with(mock_response.status)
             assert result == "search_result"
+
+    def test_on_response_none_raises_milvus_exception(self, mock_future):
+        f = SearchFuture(mock_future)
+        with pytest.raises(
+            MilvusException, match="Received None response from server during search"
+        ):
+            f.on_response(None)
+
+    def test_result_returns_empty_search_result(self, mock_future):
+        """Empty SearchResult (0-hit, falsy list) must be returned as-is, not re-processed."""
+        empty_result = []  # falsy, simulates empty SearchResult
+        mock_future.result.return_value = MagicMock()
+        mock_future.exception.return_value = None
+
+        f = SearchFuture(mock_future)
+        f._results = empty_result  # pre-set to simulate already-processed empty result
+        f._future = None
+        result = f.result()
+        assert result is empty_result
+
+    def test_result_none_response_deadline_exceeded_raises_timeout(self, mock_future):
+        """result() with None gRPC response and DEADLINE_EXCEEDED code raises timeout error."""
+        mock_future.result.return_value = None
+        mock_future.exception.return_value = None
+        mock_future.code.return_value = grpc.StatusCode.DEADLINE_EXCEEDED
+        mock_future.details.return_value = "Deadline Exceeded"
+
+        f = SearchFuture(mock_future)
+        with pytest.raises(MilvusException, match="gRPC call timed out"):
+            f.result()
+
+    def test_result_none_response_other_code_includes_code_name(self, mock_future):
+        """result() with None gRPC response and non-timeout code includes code name in error."""
+        mock_future.result.return_value = None
+        mock_future.exception.return_value = None
+        mock_future.code.return_value = grpc.StatusCode.UNAVAILABLE
+        mock_future.details.return_value = "connection reset"
+
+        f = SearchFuture(mock_future)
+        with pytest.raises(MilvusException, match="UNAVAILABLE"):
+            f.result()
+
+    def test_done_none_response_deadline_exceeded_stores_timeout_exception(self, mock_future):
+        """done() with None gRPC response and DEADLINE_EXCEEDED stores a timeout MilvusException."""
+        mock_future.result.return_value = None
+        mock_future.code.return_value = grpc.StatusCode.DEADLINE_EXCEEDED
+        mock_future.details.return_value = "Deadline Exceeded"
+
+        f = SearchFuture(mock_future)
+        f.done()
+
+        assert f._exception is not None
+        assert isinstance(f._exception, MilvusException)
+        assert "timed out" in str(f._exception)
 
 
 class TestMutationFutureOnResponse:


### PR DESCRIPTION
## What

Three fixes to prevent `AttributeError: 'NoneType' object has no attribute 'status'` in search operations:

1. **`asynch.py` logical bug fix**: Change `if self._results:` → `if self._results is not None:` in `Future.result()`. `SearchResult` inherits `list`, so an empty (0-hit) result is falsy — the old check incorrectly fell through to re-call `on_response(self._response)`.

2. **`asynch.py` defensive None guard**: `SearchFuture.on_response()` now raises a clear `MilvusException` if `response is None`, instead of letting `response.status` raise `AttributeError`.

3. **`grpc_handler.py` defensive None guard**: `_execute_search()` now checks `response is None` after `stub.Search()` before calling `check_status(response.status)`.

## Why

Observed in production: with `nq=10000, timeout=60s`, the Milvus proxy task queue delayed the request by **59 seconds**, leaving only 0.857s of deadline. The first call received `DEADLINE_EXCEEDED`; `retry_on_rpc_failure` retried. During the retry, `stub.Search()` returned `None` under server load conditions — causing `check_status(None.status)` → `AttributeError` → wrapped by `error_handler` as:

```
MilvusException: (code=1, message=Unexpected error, message=<'NoneType' object has no attribute 'status'>)
```

Fix 3 directly addresses the production error. Fixes 1 & 2 address the async path and the logical bug with empty results.

Related: https://github.com/milvus-io/milvus/issues/43341

## Test

All existing tests pass:
```
pytest tests/test_asynch.py -v  # 40 passed
```