### PR TITLE
[Backport 2.6] fix: resolve bytes vector type misidentification in search path

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -962,6 +962,12 @@ class AsyncGrpcHandler:
             collection_name, kwargs, self.server_address, (context.get_db_name() if context else "")
         )
 
+        if not kwargs.get("schema") and data and isinstance(data[0], bytes):
+            schema_dict, _ = await self._get_schema(
+                collection_name, timeout=timeout, context=context, **kwargs
+            )
+            kwargs["schema"] = schema_dict
+
         request = Prepare.search_requests_with_expr(
             collection_name=collection_name,
             data=data,
@@ -1009,6 +1015,15 @@ class AsyncGrpcHandler:
             collection_name, kwargs, self.server_address, (context.get_db_name() if context else "")
         )
 
+        _cached_schema = kwargs.get("schema")
+        if not _cached_schema:
+            for req in reqs:
+                if req.data and isinstance(req.data[0], bytes):
+                    _cached_schema, _ = await self._get_schema(
+                        collection_name, timeout=timeout, context=context, **kwargs
+                    )
+                    break
+
         requests = []
         for req in reqs:
             data = req.data
@@ -1017,6 +1032,9 @@ class AsyncGrpcHandler:
             if isinstance(data, list) and len(data) > 0 and isinstance(data[0], EmbeddingList):
                 data = [emb_list.to_flat_array() for emb_list in data]
                 req_kwargs["is_embedding_list"] = True
+
+            if _cached_schema and not req_kwargs.get("schema"):
+                req_kwargs["schema"] = _cached_schema
 
             search_request = Prepare.search_requests_with_expr(
                 collection_name=collection_name,

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1203,6 +1203,12 @@ class GrpcHandler:
             collection_name, kwargs, self.server_address, (context.get_db_name() if context else "")
         )
 
+        if not kwargs.get("schema") and data and isinstance(data[0], bytes):
+            schema_dict, _ = self._get_schema(
+                collection_name, timeout=timeout, context=context, **kwargs
+            )
+            kwargs["schema"] = schema_dict
+
         request = Prepare.search_requests_with_expr(
             collection_name=collection_name,
             anns_field=anns_field,
@@ -1250,6 +1256,15 @@ class GrpcHandler:
             collection_name, kwargs, self.server_address, (context.get_db_name() if context else "")
         )
 
+        _cached_schema = kwargs.get("schema")
+        if not _cached_schema:
+            for req in reqs:
+                if req.data and isinstance(req.data[0], bytes):
+                    _cached_schema, _ = self._get_schema(
+                        collection_name, timeout=timeout, context=context, **kwargs
+                    )
+                    break
+
         requests = []
         for req in reqs:
             # Convert EmbeddingList to flat array if present in the request data
@@ -1258,6 +1273,9 @@ class GrpcHandler:
             if isinstance(data, list) and data and isinstance(data[0], EmbeddingList):
                 data = [emb_list.to_flat_array() for emb_list in data]
                 req_kwargs["is_embedding_list"] = True
+
+            if _cached_schema and not req_kwargs.get("schema"):
+                req_kwargs["schema"] = _cached_schema
 
             search_request = Prepare.search_requests_with_expr(
                 collection_name=collection_name,

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -66,6 +66,17 @@ _JSON_TYPE_MAP = {
     DataType.STRING: "VarChar",
 }
 
+# Maps DataType to (regular PlaceholderType, EmbeddingList PlaceholderType) for bytes input
+_BYTES_PH_MAP = {
+    DataType.FLOAT16_VECTOR: (PlaceholderType.FLOAT16_VECTOR, PlaceholderType.EmbListFloat16Vector),
+    DataType.BFLOAT16_VECTOR: (
+        PlaceholderType.BFLOAT16_VECTOR,
+        PlaceholderType.EmbListBFloat16Vector,
+    ),
+    DataType.BINARY_VECTOR: (PlaceholderType.BinaryVector, PlaceholderType.EmbListBinaryVector),
+}
+_BYTES_PH_DEFAULT = (PlaceholderType.BinaryVector, PlaceholderType.EmbListBinaryVector)
+
 
 class Prepare:
     @classmethod
@@ -1304,7 +1315,12 @@ class Prepare:
         )
 
     @classmethod
-    def _prepare_placeholder_str(cls, data: Any, is_embedding_list: bool = False):
+    def _prepare_placeholder_str(
+        cls,
+        data: Any,
+        is_embedding_list: bool = False,
+        vector_data_type: Optional[DataType] = None,
+    ):
         # sparse vector
         if entity_helper.entity_is_sparse_matrix(data):
             pl_type = PlaceholderType.SparseFloatVector
@@ -1355,12 +1371,9 @@ class Prepare:
                 raise ParamError(message=err_msg)
 
         elif isinstance(data[0], bytes):
-            pl_type = (
-                PlaceholderType.BinaryVector
-                if not is_embedding_list
-                else PlaceholderType.EmbListBinaryVector
-            )
-            pl_values = data  # data is already a list of bytes
+            ph_regular, ph_emb = _BYTES_PH_MAP.get(vector_data_type, _BYTES_PH_DEFAULT)
+            pl_type = ph_emb if is_embedding_list else ph_regular
+            pl_values = data
 
         elif isinstance(data[0], str):
             pl_type = PlaceholderType.VARCHAR
@@ -1374,6 +1387,13 @@ class Prepare:
         return common_types.PlaceholderGroup.SerializeToString(
             common_types.PlaceholderGroup(placeholders=[pl])
         )
+
+    @staticmethod
+    def _get_vector_type_from_schema(schema: dict, anns_field: str) -> Optional[DataType]:
+        for f in schema.get("fields", []):
+            if f.get("name") == anns_field:
+                return f.get("type")
+        return None
 
     @classmethod
     def prepare_expression_template(cls, values: Dict) -> Any:
@@ -1613,10 +1633,18 @@ class Prepare:
         }
 
         is_embedding_list = kwargs.get(IS_EMBEDDING_LIST, False)
+
+        vector_data_type = None
+        schema = kwargs.get("schema")
+        if schema and anns_field:
+            vector_data_type = cls._get_vector_type_from_schema(schema, anns_field)
+
         if data is not None:
             request_kwargs.update(
                 nq=entity_helper.get_input_num_rows(data),
-                placeholder_group=cls._prepare_placeholder_str(data, is_embedding_list),
+                placeholder_group=cls._prepare_placeholder_str(
+                    data, is_embedding_list, vector_data_type
+                ),
             )
         elif ids is not None:
             request_kwargs.update(

--- a/tests/prepare/test_search.py
+++ b/tests/prepare/test_search.py
@@ -6,6 +6,7 @@ from pymilvus import DataType, Function, FunctionType
 from pymilvus.client.abstract import BaseRanker
 from pymilvus.client.prepare import Prepare
 from pymilvus.exceptions import ParamError
+from pymilvus.grpc_gen import common_pb2 as common_types
 from pymilvus.orm.schema import FunctionScore, LexicalHighlighter
 
 
@@ -500,6 +501,159 @@ class TestPreparePlaceholderStr:
         data = [np.array([1, 2], dtype=np.complex64)]
         with pytest.raises(ParamError, match="unsupported data type"):
             Prepare._prepare_placeholder_str(data)
+
+
+class TestSearchRequestsWithSchemaKwarg:
+    """Tests for search_requests_with_expr with schema kwarg to resolve vector type."""
+
+    @pytest.fixture
+    def basic_search_params(self):
+        return {"metric_type": "L2", "params": {"nprobe": 10}}
+
+    def test_bytes_data_with_schema_resolves_vector_type(self, basic_search_params):
+        """Test that bytes data + schema kwarg resolves vector_data_type correctly."""
+        schema = {
+            "fields": [
+                {"name": "id", "type": DataType.INT64},
+                {"name": "vec", "type": DataType.FLOAT16_VECTOR},
+            ]
+        }
+        data = [b"\x01\x02\x03\x04"]
+        req = Prepare.search_requests_with_expr(
+            collection_name="test",
+            data=data,
+            anns_field="vec",
+            param=basic_search_params,
+            limit=10,
+            schema=schema,
+        )
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(req.placeholder_group)
+        assert pg.placeholders[0].type == 102  # FLOAT16_VECTOR
+
+    def test_bytes_data_with_schema_bfloat16(self, basic_search_params):
+        """Test bytes data with schema resolves to BFLOAT16_VECTOR."""
+        schema = {
+            "fields": [
+                {"name": "vec", "type": DataType.BFLOAT16_VECTOR},
+            ]
+        }
+        data = [b"\x01\x02\x03\x04"]
+        req = Prepare.search_requests_with_expr(
+            collection_name="test",
+            data=data,
+            anns_field="vec",
+            param=basic_search_params,
+            limit=10,
+            schema=schema,
+        )
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(req.placeholder_group)
+        assert pg.placeholders[0].type == 103  # BFLOAT16_VECTOR
+
+    def test_bytes_data_without_schema_falls_back_to_binary(self, basic_search_params):
+        """Test bytes data without schema defaults to BinaryVector."""
+        data = [b"\x01\x02\x03\x04"]
+        req = Prepare.search_requests_with_expr(
+            collection_name="test",
+            data=data,
+            anns_field="vec",
+            param=basic_search_params,
+            limit=10,
+        )
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(req.placeholder_group)
+        assert pg.placeholders[0].type == 100  # BinaryVector
+
+
+class TestPreparePlaceholderStrBytesVectorType:
+    """Tests for _prepare_placeholder_str with bytes data and vector_data_type."""
+
+    @pytest.mark.parametrize(
+        "vector_data_type,expected_ph_type",
+        [
+            pytest.param(DataType.FLOAT16_VECTOR, 102, id="float16"),
+            pytest.param(DataType.BFLOAT16_VECTOR, 103, id="bfloat16"),
+            pytest.param(DataType.BINARY_VECTOR, 100, id="binary"),
+        ],
+    )
+    def test_bytes_with_vector_data_type(self, vector_data_type, expected_ph_type):
+        """Test bytes input correctly maps to the right PlaceholderType."""
+        data = [b"\x01\x02\x03\x04"]
+        result = Prepare._prepare_placeholder_str(data, vector_data_type=vector_data_type)
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(result)
+        assert pg.placeholders[0].type == expected_ph_type
+
+    @pytest.mark.parametrize(
+        "vector_data_type,expected_ph_type",
+        [
+            pytest.param(DataType.FLOAT16_VECTOR, 302, id="emb_float16"),
+            pytest.param(DataType.BFLOAT16_VECTOR, 303, id="emb_bfloat16"),
+            pytest.param(DataType.BINARY_VECTOR, 300, id="emb_binary"),
+        ],
+    )
+    def test_bytes_with_embedding_list(self, vector_data_type, expected_ph_type):
+        """Test bytes input with is_embedding_list=True maps to EmbList PlaceholderType."""
+        data = [b"\x01\x02\x03\x04"]
+        result = Prepare._prepare_placeholder_str(
+            data, is_embedding_list=True, vector_data_type=vector_data_type
+        )
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(result)
+        assert pg.placeholders[0].type == expected_ph_type
+
+    def test_bytes_with_none_vector_data_type(self):
+        """Test bytes input with None vector_data_type falls back to BinaryVector."""
+        data = [b"\x01\x02\x03\x04"]
+        result = Prepare._prepare_placeholder_str(data, vector_data_type=None)
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(result)
+        assert pg.placeholders[0].type == 100
+
+    def test_bytes_with_none_vector_data_type_embedding_list(self):
+        """Test bytes input with None vector_data_type and is_embedding_list falls back."""
+        data = [b"\x01\x02\x03\x04"]
+        result = Prepare._prepare_placeholder_str(
+            data, is_embedding_list=True, vector_data_type=None
+        )
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(result)
+        assert pg.placeholders[0].type == 300
+
+    def test_bytes_without_vector_data_type(self):
+        """Test bytes input without vector_data_type (backward compat)."""
+        data = [b"\x01\x02\x03\x04"]
+        result = Prepare._prepare_placeholder_str(data)
+        pg = common_types.PlaceholderGroup()
+        pg.ParseFromString(result)
+        assert pg.placeholders[0].type == 100
+
+
+class TestGetVectorTypeFromSchema:
+    """Tests for _get_vector_type_from_schema helper."""
+
+    def test_regular_field(self):
+        """Test extracting vector type from a regular field."""
+        schema = {
+            "fields": [
+                {"name": "id", "type": DataType.INT64},
+                {"name": "vec", "type": DataType.FLOAT16_VECTOR},
+            ]
+        }
+        result = Prepare._get_vector_type_from_schema(schema, "vec")
+        assert result == DataType.FLOAT16_VECTOR
+
+    def test_regular_field_not_found(self):
+        """Test returns None when field not found."""
+        schema = {"fields": [{"name": "id", "type": DataType.INT64}]}
+        result = Prepare._get_vector_type_from_schema(schema, "vec")
+        assert result is None
+
+    def test_empty_schema(self):
+        """Test with empty schema."""
+        result = Prepare._get_vector_type_from_schema({}, "vec")
+        assert result is None
 
 
 class TestHybridSearchRequest:

--- a/tests/test_bytes_vector_search.py
+++ b/tests/test_bytes_vector_search.py
@@ -1,0 +1,306 @@
+"""Tests for bytes vector type auto-detection in search/hybrid_search paths.
+
+Covers the schema auto-fetch logic in GrpcHandler and AsyncGrpcHandler
+when search data contains bytes vectors (float16/bfloat16/binary).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pymilvus import DataType
+from pymilvus.client.abstract import AnnSearchRequest
+from pymilvus.client.async_grpc_handler import AsyncGrpcHandler
+from pymilvus.client.grpc_handler import GrpcHandler
+
+MOCK_SCHEMA = {
+    "fields": [
+        {"name": "id", "type": DataType.INT64},
+        {"name": "vec", "type": DataType.FLOAT16_VECTOR},
+    ],
+    "update_timestamp": 12345,
+}
+
+
+def _make_grpc_handler():
+    """Create a GrpcHandler with mocked internals."""
+    handler = GrpcHandler.__new__(GrpcHandler)
+    handler._channel = MagicMock()
+    handler._address = "localhost:19530"
+    handler._schema_dict = {}
+    handler._get_schema = MagicMock(return_value=(MOCK_SCHEMA, 12345))
+    handler._execute_search = MagicMock(return_value=MagicMock())
+    handler._execute_hybrid_search = MagicMock(return_value=MagicMock())
+    return handler
+
+
+def _make_async_grpc_handler():
+    """Create an AsyncGrpcHandler with mocked internals."""
+    handler = AsyncGrpcHandler.__new__(AsyncGrpcHandler)
+    handler._channel = MagicMock()
+    handler._address = "localhost:19530"
+    handler._schema_dict = {}
+    handler._get_schema = AsyncMock(return_value=(MOCK_SCHEMA, 12345))
+    handler._execute_search = AsyncMock(return_value=MagicMock())
+    handler._execute_hybrid_search = AsyncMock(return_value=MagicMock())
+    handler.ensure_channel_ready = AsyncMock()
+    return handler
+
+
+class TestGrpcHandlerSearchBytesVector:
+    """Test GrpcHandler.search auto-fetches schema for bytes vectors."""
+
+    @patch("pymilvus.client.grpc_handler.ts_utils")
+    def test_search_bytes_data_fetches_schema(self, mock_ts_utils):
+        """When data[0] is bytes and no schema kwarg, _get_schema is called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_grpc_handler()
+
+        handler.search(
+            collection_name="test_col",
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+            data=[b"\x01\x02\x03\x04"],
+        )
+
+        handler._get_schema.assert_called_once()
+
+    @patch("pymilvus.client.grpc_handler.ts_utils")
+    def test_search_bytes_data_with_existing_schema_skips_fetch(self, mock_ts_utils):
+        """When schema kwarg already present, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_grpc_handler()
+
+        handler.search(
+            collection_name="test_col",
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+            data=[b"\x01\x02\x03\x04"],
+            schema=MOCK_SCHEMA,
+        )
+
+        handler._get_schema.assert_not_called()
+
+    @patch("pymilvus.client.grpc_handler.ts_utils")
+    def test_search_float_data_skips_schema_fetch(self, mock_ts_utils):
+        """When data is float vectors, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_grpc_handler()
+
+        handler.search(
+            collection_name="test_col",
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+            data=[[1.0, 2.0, 3.0]],
+        )
+
+        handler._get_schema.assert_not_called()
+
+
+class TestGrpcHandlerHybridSearchBytesVector:
+    """Test GrpcHandler.hybrid_search auto-fetches schema for bytes vectors."""
+
+    @patch("pymilvus.client.grpc_handler.ts_utils")
+    def test_hybrid_search_bytes_data_fetches_schema(self, mock_ts_utils):
+        """When any req has bytes data, _get_schema is called once."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_grpc_handler()
+
+        req1 = AnnSearchRequest(
+            data=[b"\x01\x02\x03\x04"],
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+        req2 = AnnSearchRequest(
+            data=[[1.0, 2.0, 3.0]],
+            anns_field="vec2",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+
+        handler.hybrid_search(
+            collection_name="test_col",
+            reqs=[req1, req2],
+            rerank=None,
+            limit=10,
+        )
+
+        handler._get_schema.assert_called_once()
+
+    @patch("pymilvus.client.grpc_handler.ts_utils")
+    def test_hybrid_search_no_bytes_skips_schema_fetch(self, mock_ts_utils):
+        """When no req has bytes data, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_grpc_handler()
+
+        req = AnnSearchRequest(
+            data=[[1.0, 2.0, 3.0]],
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+
+        handler.hybrid_search(
+            collection_name="test_col",
+            reqs=[req],
+            rerank=None,
+            limit=10,
+        )
+
+        handler._get_schema.assert_not_called()
+
+    @patch("pymilvus.client.grpc_handler.ts_utils")
+    def test_hybrid_search_with_existing_schema_skips_fetch(self, mock_ts_utils):
+        """When schema kwarg present, _get_schema is NOT called even with bytes."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_grpc_handler()
+
+        req = AnnSearchRequest(
+            data=[b"\x01\x02\x03\x04"],
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+
+        handler.hybrid_search(
+            collection_name="test_col",
+            reqs=[req],
+            rerank=None,
+            limit=10,
+            schema=MOCK_SCHEMA,
+        )
+
+        handler._get_schema.assert_not_called()
+
+
+class TestAsyncGrpcHandlerSearchBytesVector:
+    """Test AsyncGrpcHandler.search auto-fetches schema for bytes vectors."""
+
+    @pytest.mark.asyncio
+    @patch("pymilvus.client.async_grpc_handler.ts_utils")
+    async def test_async_search_bytes_data_fetches_schema(self, mock_ts_utils):
+        """When data[0] is bytes and no schema kwarg, _get_schema is called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_async_grpc_handler()
+
+        await handler.search(
+            collection_name="test_col",
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+            data=[b"\x01\x02\x03\x04"],
+        )
+
+        handler._get_schema.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("pymilvus.client.async_grpc_handler.ts_utils")
+    async def test_async_search_with_existing_schema_skips_fetch(self, mock_ts_utils):
+        """When schema kwarg already present, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_async_grpc_handler()
+
+        await handler.search(
+            collection_name="test_col",
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+            data=[b"\x01\x02\x03\x04"],
+            schema=MOCK_SCHEMA,
+        )
+
+        handler._get_schema.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("pymilvus.client.async_grpc_handler.ts_utils")
+    async def test_async_search_float_data_skips_schema_fetch(self, mock_ts_utils):
+        """When data is float vectors, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_async_grpc_handler()
+
+        await handler.search(
+            collection_name="test_col",
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+            data=[[1.0, 2.0, 3.0]],
+        )
+
+        handler._get_schema.assert_not_called()
+
+
+class TestAsyncGrpcHandlerHybridSearchBytesVector:
+    """Test AsyncGrpcHandler.hybrid_search auto-fetches schema for bytes vectors."""
+
+    @pytest.mark.asyncio
+    @patch("pymilvus.client.async_grpc_handler.ts_utils")
+    async def test_async_hybrid_search_bytes_data_fetches_schema(self, mock_ts_utils):
+        """When any req has bytes data, _get_schema is called once."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_async_grpc_handler()
+
+        req = AnnSearchRequest(
+            data=[b"\x01\x02\x03\x04"],
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+
+        await handler.hybrid_search(
+            collection_name="test_col",
+            reqs=[req],
+            rerank=None,
+            limit=10,
+        )
+
+        handler._get_schema.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("pymilvus.client.async_grpc_handler.ts_utils")
+    async def test_async_hybrid_search_no_bytes_skips_fetch(self, mock_ts_utils):
+        """When no req has bytes data, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_async_grpc_handler()
+
+        req = AnnSearchRequest(
+            data=[[1.0, 2.0, 3.0]],
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+
+        await handler.hybrid_search(
+            collection_name="test_col",
+            reqs=[req],
+            rerank=None,
+            limit=10,
+        )
+
+        handler._get_schema.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("pymilvus.client.async_grpc_handler.ts_utils")
+    async def test_async_hybrid_search_with_schema_skips_fetch(self, mock_ts_utils):
+        """When schema kwarg present, _get_schema is NOT called."""
+        mock_ts_utils.construct_guarantee_ts.return_value = True
+        handler = _make_async_grpc_handler()
+
+        req = AnnSearchRequest(
+            data=[b"\x01\x02\x03\x04"],
+            anns_field="vec",
+            param={"metric_type": "L2", "params": {"nprobe": 10}},
+            limit=10,
+        )
+
+        await handler.hybrid_search(
+            collection_name="test_col",
+            reqs=[req],
+            rerank=None,
+            limit=10,
+            schema=MOCK_SCHEMA,
+        )
+
+        handler._get_schema.assert_not_called()


### PR DESCRIPTION
## Summary
Backport of #3291 for 2.6 branch (without struct array support).

- When raw `bytes` are passed as search vectors for float16/bfloat16 fields, `_prepare_placeholder_str` unconditionally marked them as `BinaryVector`, causing search to fail
- Now auto-fetches schema from server when bytes data is detected, and uses `vector_data_type` from schema to set the correct `PlaceholderType`
- Covers `search` and `hybrid_search` in both `GrpcHandler` and `AsyncGrpcHandler`

## Test plan
- [x] Unit tests for `_prepare_placeholder_str` with bytes + vector_data_type (float16, bfloat16, binary)
- [x] Unit tests for `is_embedding_list=True` branch
- [x] Unit tests for schema auto-fetch in GrpcHandler.search / hybrid_search
- [x] Unit tests for schema auto-fetch in AsyncGrpcHandler.search / hybrid_search
- [x] Backward compatibility: bytes without schema still defaults to BinaryVector