### PR TITLE
fix: display human-readable state and level in SegmentInfo repr

### DIFF
--- a/pymilvus/client/types.py
+++ b/pymilvus/client/types.py
@@ -1483,17 +1483,25 @@ class SegmentInfo:
 
 @dataclass
 class LoadedSegmentInfo(SegmentInfo):
+    partition_id: int
+    index_name: str
+    index_id: int
+    node_ids: List[int]
     mem_size: int
 
     def __repr__(self) -> str:
         return (
             f"LoadedSegmentInfo(segment_id={self.segment_id}, "
             f"collection_id={self.collection_id}, "
+            f"partition_id={self.partition_id}, "
             f"collection_name='{self.collection_name}', "
             f"num_rows={self.num_rows}, "
             f"is_sorted={self.is_sorted}, "
             f"state='{self.state_name}', "
             f"level='{self.level_name}', "
+            f"index_name='{self.index_name}', "
+            f"index_id={self.index_id}, "
+            f"node_ids={self.node_ids}, "
             f"storage_version={self.storage_version}, "
             f"mem_size={self.mem_size})"
         )

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2297,15 +2297,19 @@ class MilvusClient(BaseMilvusClient):
         )
         return [
             LoadedSegmentInfo(
-                info.segmentID,
-                info.collectionID,
-                collection_name,
-                info.num_rows,
-                info.is_sorted,
-                info.state,
-                info.level,
-                info.storage_version,
-                info.mem_size,
+                segment_id=info.segmentID,
+                collection_id=info.collectionID,
+                collection_name=collection_name,
+                num_rows=info.num_rows,
+                is_sorted=info.is_sorted,
+                state=info.state,
+                level=info.level,
+                storage_version=info.storage_version,
+                partition_id=info.partitionID,
+                index_name=info.index_name,
+                index_id=info.indexID,
+                node_ids=list(info.nodeIds),
+                mem_size=info.mem_size,
             )
             for info in infos
         ]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -112,7 +112,7 @@ class TestSegmentInfoRepr:
         assert "segment_id=123" in r
         assert "collection_name='test_col'" in r
 
-    def test_loaded_segment_info_repr_shows_state_and_level_names(self):
+    def test_loaded_segment_info_repr_shows_all_fields(self):
         info = LoadedSegmentInfo(
             segment_id=789,
             collection_id=456,
@@ -122,12 +122,20 @@ class TestSegmentInfoRepr:
             state=3,  # Sealed
             level=1,  # L0
             storage_version=1,
+            partition_id=100,
+            index_name="idx_vec",
+            index_id=200,
+            node_ids=[1, 2, 3],
             mem_size=4096,
         )
         r = repr(info)
         assert "LoadedSegmentInfo(" in r
         assert "state='Sealed'" in r
         assert "level='L0'" in r
+        assert "partition_id=100" in r
+        assert "index_name='idx_vec'" in r
+        assert "index_id=200" in r
+        assert "node_ids=[1, 2, 3]" in r
         assert "mem_size=4096" in r
 
     def test_segment_info_state_name_property(self):


### PR DESCRIPTION
SegmentInfo and LoadedSegmentInfo now show enum names (e.g. 'Flushed',
'L2') instead of raw integer values for state and level fields.
Also adds state_name and level_name properties for programmatic access.

Signed-off-by: yangxuan <xuan.yang@zilliz.com>