### PR TITLE
fix: guard MilvusClient._get_connection against None handler

### DIFF
--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -972,6 +972,8 @@ class MilvusClient(BaseMilvusClient):
 
     def _get_connection(self):
         """Return the handler for this client."""
+        if self._handler is None:
+            raise MilvusException(message="should create connection first")
         return self._handler
 
     def close(self):

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1856,6 +1856,17 @@ class TestMilvusClientChangedCode:
             assert client._get_connection() is mock_handler
             client.close()
 
+    def test_get_connection_raises_when_closed(self):
+        """Test _get_connection raises MilvusException after close()."""
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            mock_handler = _make_sync_handler(get_server_type=Mock(return_value="milvus"))
+            mock_handler_cls.return_value = mock_handler
+            client = MilvusClient(uri="http://localhost:19530")
+            client.close()
+
+            with pytest.raises(MilvusException, match="should create connection first"):
+                client._get_connection()
+
     def test_use_database_updates_config(self):
         """Test use_database updates _config.db_name."""
         with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:


### PR DESCRIPTION
## Summary

MilvusClient._get_connection() blindly returned self._handler, which
could be None after close() or if connection was never established.
This caused confusing AttributeError ('NoneType' has no attribute ...)
instead of a clear MilvusException.

Add the same None-check guard that AsyncMilvusClient already has.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: yangxuan <xuan.yang@zilliz.com>