### PR TITLE
fix: propagate top-level filter to sub-requests in hybrid_search

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1054,6 +1054,8 @@ class AsyncGrpcHandler:
                     )
                     break
 
+        top_level_filter = kwargs.pop("filter", None)
+
         requests = []
         for req in reqs:
             data = req.data
@@ -1066,13 +1068,16 @@ class AsyncGrpcHandler:
             if _cached_schema and not req_kwargs.get("schema"):
                 req_kwargs["schema"] = _cached_schema
 
+            # Use top-level filter when the sub-request has no expr
+            expr = req.expr if req.expr else top_level_filter
+
             search_request = Prepare.search_requests_with_expr(
                 collection_name=collection_name,
                 data=data,
                 anns_field=req.anns_field,
                 param=req.param,
                 limit=req.limit,
-                expr=req.expr,
+                expr=expr,
                 partition_names=partition_names,
                 round_decimal=round_decimal,
                 expr_params=req.expr_params,

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1293,6 +1293,8 @@ class GrpcHandler:
                     )
                     break
 
+        top_level_filter = kwargs.pop("filter", None)
+
         requests = []
         for req in reqs:
             # Convert EmbeddingList to flat array if present in the request data
@@ -1305,13 +1307,16 @@ class GrpcHandler:
             if _cached_schema and not req_kwargs.get("schema"):
                 req_kwargs["schema"] = _cached_schema
 
+            # Use top-level filter when the sub-request has no expr
+            expr = req.expr if req.expr else top_level_filter
+
             search_request = Prepare.search_requests_with_expr(
                 collection_name=collection_name,
                 data=data,
                 anns_field=req.anns_field,
                 param=req.param,
                 limit=req.limit,
-                expr=req.expr,
+                expr=expr,
                 partition_names=partition_names,
                 round_decimal=round_decimal,
                 expr_params=req.expr_params,

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -523,11 +523,15 @@ class AsyncMilvusClient(BaseMilvusClient):
         reqs: List[AnnSearchRequest],
         ranker: Union[BaseRanker, Function],
         limit: int = 10,
+        filter: str = "",
         output_fields: Optional[List[str]] = None,
         timeout: Optional[float] = None,
         partition_names: Optional[List[str]] = None,
         **kwargs,
     ) -> List[List[dict]]:
+        if filter:
+            kwargs["filter"] = filter
+
         conn = await self._get_connection()
         return await conn.hybrid_search(
             collection_name,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -340,6 +340,7 @@ class MilvusClient(BaseMilvusClient):
         reqs: List[AnnSearchRequest],
         ranker: Union[BaseRanker, Function],
         limit: int = 10,
+        filter: str = "",
         output_fields: Optional[List[str]] = None,
         timeout: Optional[float] = None,
         partition_names: Optional[List[str]] = None,
@@ -352,6 +353,8 @@ class MilvusClient(BaseMilvusClient):
             reqs (``List[AnnSearchRequest]``): The vector search requests.
             ranker (``Union[BaseRanker, Function]``): The ranker.
             limit (``int``): The max number of returned record, also known as `topk`.
+            filter (``str``, optional): A scalar filtering expression to apply to all
+                sub-requests that do not have their own expr set.
 
             partition_names (``List[str]``, optional): The names of partitions to search on.
             output_fields (``List[str]``, optional):
@@ -382,6 +385,8 @@ class MilvusClient(BaseMilvusClient):
         Raises:
             MilvusException: If anything goes wrong
         """
+        if filter:
+            kwargs["filter"] = filter
 
         conn = self._get_connection()
         return conn.hybrid_search(

--- a/tests/grpc_handler/test_data.py
+++ b/tests/grpc_handler/test_data.py
@@ -120,6 +120,66 @@ class TestGrpcHandlerSearchOps:
             handler.hybrid_search("coll", [req], RRFRanker(), 10)
             handler._stub.HybridSearch.assert_called_once()
 
+    def test_hybrid_search_top_level_filter(self, handler):
+        """Test that a top-level filter kwarg is propagated to sub-requests without their own expr."""
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.results = MagicMock()
+        mock_resp.results.top_k = 10
+        mock_resp.results.scores = []
+        mock_resp.results.ids.WhichOneof.return_value = "int_id"
+        mock_resp.results.ids.int_id.data = []
+        mock_resp.results.output_fields = []
+        mock_resp.results.fields_data = []
+        handler._stub.HybridSearch.return_value = mock_resp
+
+        req = AnnSearchRequest(
+            data=[[0.1, 0.2, 0.3, 0.4]], anns_field="vec", param={"metric_type": "L2"}, limit=10
+        )
+        with patch(
+            "pymilvus.client.grpc_handler.ts_utils.construct_guarantee_ts", return_value=True
+        ):
+            handler.hybrid_search("coll", [req], RRFRanker(), 10, filter="age > 18")
+            handler._stub.HybridSearch.assert_called_once()
+            # Verify the filter was set as dsl on the sub-request
+            call_args = handler._stub.HybridSearch.call_args
+            hybrid_req = call_args[0][0]
+            assert hybrid_req.requests[0].dsl == "age > 18"
+
+    def test_hybrid_search_top_level_filter_no_override(self, handler):
+        """Test that a top-level filter does NOT override a sub-request's own expr."""
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.results = MagicMock()
+        mock_resp.results.top_k = 10
+        mock_resp.results.scores = []
+        mock_resp.results.ids.WhichOneof.return_value = "int_id"
+        mock_resp.results.ids.int_id.data = []
+        mock_resp.results.output_fields = []
+        mock_resp.results.fields_data = []
+        handler._stub.HybridSearch.return_value = mock_resp
+
+        req = AnnSearchRequest(
+            data=[[0.1, 0.2, 0.3, 0.4]],
+            anns_field="vec",
+            param={"metric_type": "L2"},
+            limit=10,
+            expr="status == 'active'",
+        )
+        with patch(
+            "pymilvus.client.grpc_handler.ts_utils.construct_guarantee_ts", return_value=True
+        ):
+            handler.hybrid_search("coll", [req], RRFRanker(), 10, filter="age > 18")
+            handler._stub.HybridSearch.assert_called_once()
+            # Sub-request's own expr should take precedence
+            call_args = handler._stub.HybridSearch.call_args
+            hybrid_req = call_args[0][0]
+            assert hybrid_req.requests[0].dsl == "status == 'active'"
+
     def test_hybrid_search_async(self, handler):
         mock_future = MagicMock()
         handler._stub.HybridSearch.future.return_value = mock_future


### PR DESCRIPTION
The `filter` parameter passed to `hybrid_search` was silently ignored because it was only carried through `**kwargs` without being applied to each sub-request's `expr`. This caused hybrid search results to include rows that violated the filter condition.

The fix extracts the `filter` kwarg and uses it as `expr` for any sub-request that does not have its own `expr` set. Sub-requests with their own `expr` are not affected.

Also adds `filter` as an explicit parameter to `MilvusClient.hybrid_search` and `AsyncMilvusClient.hybrid_search` for API consistency with `search`.

issue: https://github.com/milvus-io/milvus/issues/48578