### PR TITLE
fix: include password in connection alias to prevent incorrect reuse

### DIFF
--- a/pymilvus/milvus_client/_utils.py
+++ b/pymilvus/milvus_client/_utils.py
@@ -29,7 +29,9 @@ def create_connection(
 
         auth_fmt = ""
         if user:
-            auth_fmt = f"{user}"
+            md5 = hashlib.new("md5", usedforsecurity=False)
+            md5.update(f"{user}:{password}".encode())
+            auth_fmt = md5.hexdigest()
         elif token:
             md5 = hashlib.new("md5", usedforsecurity=False)
             md5.update(token.encode())

--- a/tests/test_create_connection.py
+++ b/tests/test_create_connection.py
@@ -39,9 +39,12 @@ class TestCreateConnectionSyncAlias:
     def test_user_included_in_alias(self):
         with patch("pymilvus.milvus_client._utils.connections") as mock_conns:
             mock_conns.has_connection.return_value = True
-            result = create_connection("http://localhost:19530", user="alice")
-            assert "alice" in result
+            result = create_connection("http://localhost:19530", user="alice", password="pass")
             assert "http://localhost:19530" in result
+            # alias now contains md5 hash of "alice:pass", not raw username
+            md5 = hashlib.new("md5", usedforsecurity=False)
+            md5.update(b"alice:pass")
+            assert md5.hexdigest() in result
 
     def test_token_md5_included_in_alias(self):
         with patch("pymilvus.milvus_client._utils.connections") as mock_conns:
@@ -56,8 +59,18 @@ class TestCreateConnectionSyncAlias:
     def test_user_takes_priority_over_token(self):
         with patch("pymilvus.milvus_client._utils.connections") as mock_conns:
             mock_conns.has_connection.return_value = True
-            result = create_connection("http://localhost:19530", user="bob", token="tok")
-            assert "bob" in result
+            result = create_connection("http://localhost:19530", user="bob", password="pw", token="tok")
+            # Should use md5 of "bob:pw", not token hash
+            md5 = hashlib.new("md5", usedforsecurity=False)
+            md5.update(b"bob:pw")
+            assert md5.hexdigest() in result
+
+    def test_different_passwords_produce_different_aliases(self):
+        with patch("pymilvus.milvus_client._utils.connections") as mock_conns:
+            mock_conns.has_connection.return_value = True
+            result1 = create_connection("http://localhost:19530", user="alice", password="pass1")
+            result2 = create_connection("http://localhost:19530", user="alice", password="pass2")
+            assert result1 != result2
 
     def test_no_async_prefix_in_sync_mode(self):
         with patch("pymilvus.milvus_client._utils.connections") as mock_conns:


### PR DESCRIPTION
## Summary

- **Bug**: When `user`/`password` auth is used, only the username is included in the connection alias (`auth_fmt = f"{user}"`). This means two `MilvusClient` instances with the same URI and username but **different passwords** produce the same alias, causing the second to silently reuse the first connection without re-authenticating.
- **Fix**: Hash both `user` and `password` together (via MD5, consistent with the existing `token` branch) so different credentials always produce distinct aliases.
- **Tests**: Updated existing tests and added `test_different_passwords_produce_different_aliases` to cover this case.

## Reproduction

```python
# Same process, same URI, same user, different passwords
client1 = MilvusClient(uri="localhost:19530", user="alice", password="correct")
# → alias = "localhost:19530-alice" → new connection, auth succeeds

client2 = MilvusClient(uri="localhost:19530", user="alice", password="wrong")
# → alias = "localhost:19530-alice" → has_connection() = True → reuses client1!
# No authentication error despite wrong password
```

After this fix, the two calls produce different aliases (based on `md5("alice:correct")` vs `md5("alice:wrong")`), so the second call correctly triggers a new `connections.connect()`.

## Test plan

- [x] All 17 tests in `test_create_connection.py` pass
- [x] New test `test_different_passwords_produce_different_aliases` verifies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)