### PR TITLE
[Backport 2.6] fix: rewrite _version_helper.py to use only public setuptools_scm API (#3359)

### DIFF
--- a/_version_helper.py
+++ b/_version_helper.py
@@ -1,71 +1,51 @@
 """
-this module is a hack only in place to allow for setuptools
-to use the attribute for the versions
+Custom version scheme for pymilvus using setuptools_scm public API only.
 
-it works only if the backend-path of the build-system section
-from pyproject.toml is respected
+Loaded via pyproject.toml:
+    [tool.setuptools.dynamic]
+    version = { attr = "_version_helper.version"}
+
+Uses only public setuptools_scm API so it stays compatible with
+setuptools_scm 10.x+ where private modules (_types, fallbacks) are removed.
 """
 from __future__ import annotations
 
-import logging
-from typing import Callable
+import re
 
 from setuptools import build_meta as build_meta  # noqa
-
-from setuptools_scm import _types as _t
-from setuptools_scm import Configuration
 from setuptools_scm import get_version
-from setuptools_scm import git
-from setuptools_scm import hg
-from setuptools_scm.fallbacks import parse_pkginfo
 from setuptools_scm.version import (
-    get_no_local_node,
-    _parse_version_tag,
-    guess_next_simple_semver,
     SEMVER_MINOR,
-    guess_next_version,
     ScmVersion,
+    get_no_local_node,
+    guess_next_simple_semver,
+    guess_next_version,
 )
 
-log = logging.getLogger("setuptools_scm")
-# todo: take fake entrypoints from pyproject.toml
-try_parse: list[Callable[[_t.PathT, Configuration], ScmVersion | None]] = [
-    parse_pkginfo,
-    git.parse,
-    hg.parse,
-    git.parse_archival,
-    hg.parse_archival,
-]
+_VERSION_RE = re.compile(r"^v?(\d+(?:\.\d+)*)$")
+
+fmt = "{guessed}rc{distance}"  # align with PEP440 public version that has no dot before rc
 
 
-def parse(root: str, config: Configuration) -> ScmVersion | None:
-    for maybe_parse in try_parse:
-        try:
-            parsed = maybe_parse(root, config)
-        except OSError as e:
-            log.warning("parse with %s failed with: %s", maybe_parse, e)
-        else:
-            if parsed is not None:
-                return parsed
+def _parse_branch_version(branch: str) -> str | None:
+    """Extract a version string from a branch name like '2.6' or 'v2.6.1'.
 
-fmt = "{guessed}rc{distance}" # align with PEP440 public version that has no dot before rc
+    Returns the version without leading 'v', or None if the branch name
+    doesn't look like a version number.
+    """
+    name = branch.split("/")[-1]
+    m = _VERSION_RE.match(name)
+    if m is None:
+        return None
+    return m.group(1)
+
 
 def custom_version(version: ScmVersion) -> str:
     if version.exact:
         return version.format_with("{tag}")
     if version.branch is not None:
-        # Does the branch name (stripped of namespace) parse as a version?
-        branch_ver_data = _parse_version_tag(
-            version.branch.split("/")[-1], version.config
-        )
-        if branch_ver_data is not None:
-            branch_ver = branch_ver_data["version"]
-            if branch_ver[0] == "v":
-                # Allow branches that start with 'v', similar to Version.
-                branch_ver = branch_ver[1:]
-            # Does the branch version up to the minor part match the tag? If not it
-            # might be like, an issue number or something and not a version number, so
-            # we only want to use it if it matches.
+        branch_ver = _parse_branch_version(version.branch)
+        if branch_ver is not None:
             tag_ver_up_to_minor = str(version.tag).split(".")[:SEMVER_MINOR]
             branch_ver_up_to_minor = branch_ver.split(".")[:SEMVER_MINOR]
             if branch_ver_up_to_minor == tag_ver_up_to_minor:
@@ -78,7 +58,6 @@ def custom_version(version: ScmVersion) -> str:
 def scm_version() -> str:
     return get_version(
         relative_to=__file__,
-        parse=parse,
         version_scheme=custom_version,
         local_scheme=get_no_local_node,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
   "setuptools >= 67",
   "wheel",
   "gitpython",
-  "setuptools_scm[toml]>=6.2,<9",
+  "setuptools_scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Cherry-pick of #3359 to 2.6.

Rewrites `_version_helper.py` to use only public `setuptools_scm` API, fixing compatibility with setuptools_scm 10.x+ where private modules (`_types`, `fallbacks`) are removed.

pr: #3359
See also: #3349

Signed-off-by: yangxuan <xuan.yang@zilliz.com>