### PR TITLE
feat: add external collection API support

### DIFF
--- a/examples/external_collection_example.py
+++ b/examples/external_collection_example.py
@@ -1,0 +1,238 @@
+"""
+Milvus External Collection API Usage Examples
+
+This script demonstrates how to use the external collection functionality in Milvus for:
+- Creating external collections with external data source mapping
+- Refreshing external collection data from external sources
+- Monitoring refresh job progress
+- Listing refresh jobs
+
+External collections allow Milvus to query data stored in external systems (e.g., Iceberg,
+Hudi, Delta Lake on S3/GCS) by mapping external fields to Milvus schema fields.
+
+Requirements:
+- Milvus server running with external table support
+- pymilvus with external collection API support
+- An accessible external data source (e.g., S3 bucket with Iceberg table)
+"""
+
+import asyncio
+import sys
+import time
+
+from pymilvus import AsyncMilvusClient, MilvusClient, DataType
+
+# Configuration
+MILVUS_URI = "http://localhost:19530"
+COLLECTION_NAME = "my_external_table"
+
+
+def demo_create_external_collection(client: MilvusClient):
+    """Create an external collection with field mappings to an external data source."""
+    print("\n=== Creating External Collection ===")
+
+    # Define schema with external field mappings
+    schema = client.create_schema(
+        auto_id=False,
+        enable_dynamic_field=False,
+        # External data source configuration
+        external_source="s3://my-data-lake/iceberg/user_embeddings",
+        external_spec='{"format": "iceberg", "catalog": "glue", "database": "analytics"}',
+    )
+
+    # Fields with external_field specify the mapping to columns in the external data source
+    schema.add_field(
+        field_name="id",
+        datatype=DataType.INT64,
+        is_primary=True,
+        external_field="row_id",  # Maps to "row_id" column in external table
+    )
+    schema.add_field(
+        field_name="text",
+        datatype=DataType.VARCHAR,
+        max_length=1024,
+        external_field="content",  # Maps to "content" column in external table
+    )
+    # Vector field without external_field - generated/managed by Milvus
+    schema.add_field(
+        field_name="embedding",
+        datatype=DataType.FLOAT_VECTOR,
+        dim=768,
+    )
+
+    # Drop existing collection if any
+    if client.has_collection(COLLECTION_NAME):
+        client.drop_collection(COLLECTION_NAME)
+
+    client.create_collection(
+        collection_name=COLLECTION_NAME,
+        schema=schema,
+    )
+    print(f"Created external collection '{COLLECTION_NAME}'")
+    print(f"  External source: s3://my-data-lake/iceberg/user_embeddings")
+    print(f"  Field mappings: id->row_id, text->content")
+
+
+def demo_refresh_external_collection(client: MilvusClient):
+    """Trigger a data refresh to sync data from the external source."""
+    print("\n=== Refreshing External Collection ===")
+
+    # Trigger refresh - data will be synced from the external source
+    job_id = client.refresh_external_collection(
+        collection_name=COLLECTION_NAME,
+    )
+    print(f"Refresh job started: job_id={job_id}")
+
+    # Monitor progress until completion
+    while True:
+        progress = client.get_refresh_external_collection_progress(job_id=job_id)
+        print(
+            f"  State: {progress.state}, Progress: {progress.progress}%, "
+            f"Source: {progress.external_source}"
+        )
+
+        if progress.state == "RefreshCompleted":
+            elapsed = progress.end_time - progress.start_time
+            print(f"Refresh completed in {elapsed}ms")
+            break
+        elif progress.state == "RefreshFailed":
+            print(f"Refresh failed: {progress.reason}")
+            break
+
+        time.sleep(2)
+
+
+def demo_refresh_with_new_source(client: MilvusClient):
+    """Refresh an external collection with a new/updated data source."""
+    print("\n=== Refreshing With New Source ===")
+
+    # Optionally override the external source for this refresh
+    job_id = client.refresh_external_collection(
+        collection_name=COLLECTION_NAME,
+        external_source="s3://my-data-lake/iceberg/user_embeddings_v2",
+        external_spec='{"format": "iceberg", "catalog": "glue", "snapshot": "latest"}',
+    )
+    print(f"Refresh with new source started: job_id={job_id}")
+
+    # Poll for completion
+    while True:
+        progress = client.get_refresh_external_collection_progress(job_id=job_id)
+        if progress.state in ("RefreshCompleted", "RefreshFailed"):
+            print(f"Final state: {progress.state}")
+            break
+        time.sleep(2)
+
+
+def demo_list_refresh_jobs(client: MilvusClient):
+    """List all refresh jobs for an external collection."""
+    print("\n=== Listing Refresh Jobs ===")
+
+    # List jobs for a specific collection
+    jobs = client.list_refresh_external_collection_jobs(
+        collection_name=COLLECTION_NAME,
+    )
+
+    if not jobs:
+        print("No refresh jobs found.")
+        return
+
+    for job in jobs:
+        print(
+            f"  Job {job.job_id}: state={job.state}, "
+            f"progress={job.progress}%, "
+            f"collection={job.collection_name}"
+        )
+
+    # List all jobs across all collections
+    print("\nAll refresh jobs:")
+    all_jobs = client.list_refresh_external_collection_jobs()
+    print(f"  Total jobs: {len(all_jobs)}")
+
+
+def demo_cleanup(client: MilvusClient):
+    """Clean up the demo collection."""
+    print("\n=== Cleanup ===")
+    if client.has_collection(COLLECTION_NAME):
+        client.drop_collection(COLLECTION_NAME)
+        print(f"Dropped collection '{COLLECTION_NAME}'")
+
+
+# ============================================================
+# Async version
+# ============================================================
+
+async def async_demo():
+    """Async version of the external collection demo."""
+    print("\n" + "=" * 50)
+    print("ASYNC EXTERNAL COLLECTION DEMO")
+    print("=" * 50)
+
+    client = AsyncMilvusClient(uri=MILVUS_URI)
+
+    # Create external collection (reuse sync schema creation)
+    from pymilvus.orm.schema import CollectionSchema, FieldSchema
+
+    schema = CollectionSchema(
+        fields=[
+            FieldSchema("id", DataType.INT64, is_primary=True, external_field="row_id"),
+            FieldSchema("text", DataType.VARCHAR, max_length=1024, external_field="content"),
+            FieldSchema("embedding", DataType.FLOAT_VECTOR, dim=768),
+        ],
+        external_source="s3://my-data-lake/iceberg/user_embeddings",
+        external_spec='{"format": "iceberg", "catalog": "glue"}',
+    )
+
+    if await client.has_collection(COLLECTION_NAME):
+        await client.drop_collection(COLLECTION_NAME)
+    await client.create_collection(collection_name=COLLECTION_NAME, schema=schema)
+    print(f"Created external collection '{COLLECTION_NAME}' (async)")
+
+    # Refresh
+    job_id = await client.refresh_external_collection(collection_name=COLLECTION_NAME)
+    print(f"Refresh started: job_id={job_id}")
+
+    # Monitor
+    while True:
+        progress = await client.get_refresh_external_collection_progress(job_id=job_id)
+        print(f"  {progress.state}: {progress.progress}%")
+        if progress.state in ("RefreshCompleted", "RefreshFailed"):
+            break
+        await asyncio.sleep(2)
+
+    # List jobs
+    jobs = await client.list_refresh_external_collection_jobs(collection_name=COLLECTION_NAME)
+    print(f"Total refresh jobs: {len(jobs)}")
+
+    # Cleanup
+    await client.drop_collection(COLLECTION_NAME)
+    print("Cleanup done (async)")
+    await client.close()
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    """Run the sync demo."""
+    print("=" * 50)
+    print("EXTERNAL COLLECTION API DEMO")
+    print("=" * 50)
+
+    client = MilvusClient(uri=MILVUS_URI)
+
+    try:
+        demo_create_external_collection(client)
+        demo_refresh_external_collection(client)
+        demo_refresh_with_new_source(client)
+        demo_list_refresh_jobs(client)
+    finally:
+        demo_cleanup(client)
+        client.close()
+
+
+if __name__ == "__main__":
+    if "--async" in sys.argv:
+        asyncio.run(async_demo())
+    else:
+        main()

--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -52,6 +52,7 @@ from .types import (
     HybridExtraList,
     IndexState,
     LoadState,
+    RefreshExternalCollectionJobInfo,
     ReplicaInfo,
     RestoreSnapshotJobInfo,
     Shard,
@@ -59,6 +60,7 @@ from .types import (
     State,
     Status,
     get_extra_info,
+    parse_refresh_job_info,
 )
 from .utils import (
     check_invalid_binary_vector,
@@ -2657,3 +2659,59 @@ class AsyncGrpcHandler:
         )
         check_status(resp.status)
         return [FileResourceInfo(info) for info in resp.resources]
+
+    @retry_on_rpc_failure()
+    async def refresh_external_collection(
+        self,
+        collection_name: str,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> int:
+        await self.ensure_channel_ready()
+        request = Prepare.refresh_external_collection_request(
+            collection_name=collection_name,
+            db_name=kwargs.get("db_name", ""),
+            external_source=kwargs.get("external_source", ""),
+            external_spec=kwargs.get("external_spec", ""),
+        )
+        response = await self._async_stub.RefreshExternalCollection(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return response.job_id
+
+    @retry_on_rpc_failure()
+    async def get_refresh_external_collection_progress(
+        self,
+        job_id: int,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> RefreshExternalCollectionJobInfo:
+        await self.ensure_channel_ready()
+        request = Prepare.get_refresh_external_collection_progress_request(job_id)
+        response = await self._async_stub.GetRefreshExternalCollectionProgress(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return parse_refresh_job_info(response.job_info)
+
+    @retry_on_rpc_failure()
+    async def list_refresh_external_collection_jobs(
+        self,
+        collection_name: str = "",
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> List[RefreshExternalCollectionJobInfo]:
+        await self.ensure_channel_ready()
+        request = Prepare.list_refresh_external_collection_jobs_request(
+            db_name=kwargs.get("db_name", ""),
+            collection_name=collection_name,
+        )
+        response = await self._async_stub.ListRefreshExternalCollectionJobs(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return [parse_refresh_job_info(job) for job in response.jobs]

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -70,6 +70,7 @@ from .types import (
     LoadState,
     Plan,
     PrivilegeGroupInfo,
+    RefreshExternalCollectionJobInfo,
     Replica,
     ReplicaInfo,
     ResourceGroupConfig,
@@ -82,6 +83,7 @@ from .types import (
     Status,
     UserInfo,
     get_extra_info,
+    parse_refresh_job_info,
 )
 from .utils import (
     check_invalid_binary_vector,
@@ -3381,3 +3383,56 @@ class GrpcHandler:
         )
         check_status(resp.status)
         return [FileResourceInfo(info) for info in resp.resources]
+
+    @retry_on_rpc_failure()
+    def refresh_external_collection(
+        self,
+        collection_name: str,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> int:
+        request = Prepare.refresh_external_collection_request(
+            collection_name=collection_name,
+            db_name=kwargs.get("db_name", ""),
+            external_source=kwargs.get("external_source", ""),
+            external_spec=kwargs.get("external_spec", ""),
+        )
+        response = self._stub.RefreshExternalCollection(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return response.job_id
+
+    @retry_on_rpc_failure()
+    def get_refresh_external_collection_progress(
+        self,
+        job_id: int,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> "RefreshExternalCollectionJobInfo":
+        request = Prepare.get_refresh_external_collection_progress_request(job_id)
+        response = self._stub.GetRefreshExternalCollectionProgress(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return parse_refresh_job_info(response.job_info)
+
+    @retry_on_rpc_failure()
+    def list_refresh_external_collection_jobs(
+        self,
+        collection_name: str = "",
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> List["RefreshExternalCollectionJobInfo"]:
+        request = Prepare.list_refresh_external_collection_jobs_request(
+            db_name=kwargs.get("db_name", ""),
+            collection_name=collection_name,
+        )
+        response = self._stub.ListRefreshExternalCollectionJobs(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return [parse_refresh_job_info(job) for job in response.jobs]

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -171,6 +171,8 @@ class Prepare:
             description=coll_description,
             enable_dynamic_field=fields.enable_dynamic_field,
             enable_namespace=fields.enable_namespace,
+            external_source=fields.external_source,
+            external_spec=fields.external_spec,
         )
         for f in fields.fields:
             field_schema = schema_types.FieldSchema(
@@ -186,6 +188,7 @@ class Prepare:
                 element_type=f.element_type,
                 is_clustering_key=f.is_clustering_key,
                 is_function_output=f.is_function_output,
+                external_field=f.external_field,
             )
             for k, v in f.params.items():
                 kv_pair = common_types.KeyValuePair(
@@ -2737,3 +2740,38 @@ class Prepare:
     @classmethod
     def list_file_resources(cls):
         return milvus_types.ListFileResourcesRequest()
+
+    @classmethod
+    def refresh_external_collection_request(
+        cls,
+        collection_name: str,
+        db_name: str = "",
+        external_source: str = "",
+        external_spec: str = "",
+    ) -> milvus_types.RefreshExternalCollectionRequest:
+        return milvus_types.RefreshExternalCollectionRequest(
+            db_name=db_name,
+            collection_name=collection_name,
+            external_source=external_source,
+            external_spec=external_spec,
+        )
+
+    @classmethod
+    def get_refresh_external_collection_progress_request(
+        cls,
+        job_id: int,
+    ) -> milvus_types.GetRefreshExternalCollectionProgressRequest:
+        return milvus_types.GetRefreshExternalCollectionProgressRequest(
+            job_id=job_id,
+        )
+
+    @classmethod
+    def list_refresh_external_collection_jobs_request(
+        cls,
+        db_name: str = "",
+        collection_name: str = "",
+    ) -> milvus_types.ListRefreshExternalCollectionJobsRequest:
+        return milvus_types.ListRefreshExternalCollectionJobsRequest(
+            db_name=db_name,
+            collection_name=collection_name,
+        )

--- a/pymilvus/client/types.py
+++ b/pymilvus/client/types.py
@@ -1558,3 +1558,44 @@ class RestoreSnapshotJobInfo:
     reason: str
     start_time: int
     time_cost: int
+
+
+@dataclass
+class RefreshExternalCollectionJobInfo:
+    """Information about an external collection refresh job.
+
+    Attributes:
+        job_id: The refresh job ID.
+        collection_name: The collection being refreshed.
+        state: Current state (proto enum name, e.g. RefreshPending, RefreshCompleted).
+        progress: Progress percentage (0-100).
+        reason: Error message if failed.
+        external_source: External source used for this job.
+        start_time: Job start timestamp in milliseconds.
+        end_time: Job end timestamp in milliseconds (0 if not completed).
+    """
+
+    job_id: int
+    collection_name: str
+    state: str
+    progress: int
+    reason: str
+    external_source: str
+    start_time: int
+    end_time: int
+
+
+def parse_refresh_job_info(
+    info: "milvus_types.RefreshExternalCollectionJobInfo",
+) -> RefreshExternalCollectionJobInfo:
+    """Parse a protobuf RefreshExternalCollectionJobInfo into a dataclass."""
+    return RefreshExternalCollectionJobInfo(
+        job_id=info.job_id,
+        collection_name=info.collection_name,
+        state=milvus_types.RefreshExternalCollectionState.Name(info.state),
+        progress=info.progress,
+        reason=info.reason,
+        external_source=info.external_source,
+        start_time=info.start_time,
+        end_time=info.end_time,
+    )

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -10,6 +10,7 @@ from pymilvus.client.types import (
     ExceptionsMessage,
     LoadState,
     OmitZeroDict,
+    RefreshExternalCollectionJobInfo,
     ResourceGroupConfig,
     RestoreSnapshotJobInfo,
     RoleInfo,
@@ -2182,6 +2183,81 @@ class AsyncMilvusClient(BaseMilvusClient):
     ):
         conn = await self._get_connection()
         return await conn.list_file_resources(
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    async def refresh_external_collection(
+        self,
+        collection_name: str,
+        external_source: str = "",
+        external_spec: str = "",
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> int:
+        """Trigger a data refresh for an external collection (async).
+
+        Args:
+            collection_name: The external collection to refresh.
+            external_source: Optional new external data source path.
+            external_spec: Optional new external spec configuration.
+            timeout: RPC timeout in seconds.
+
+        Returns:
+            int: A job_id for tracking the refresh progress.
+        """
+        conn = await self._get_connection()
+        return await conn.refresh_external_collection(
+            collection_name=collection_name,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            external_source=external_source,
+            external_spec=external_spec,
+            **kwargs,
+        )
+
+    async def get_refresh_external_collection_progress(
+        self,
+        job_id: int,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> RefreshExternalCollectionJobInfo:
+        """Get the progress of an external collection refresh job (async).
+
+        Args:
+            job_id: The job ID returned by refresh_external_collection().
+            timeout: RPC timeout in seconds.
+
+        Returns:
+            RefreshExternalCollectionJobInfo with job details.
+        """
+        conn = await self._get_connection()
+        return await conn.get_refresh_external_collection_progress(
+            job_id=job_id,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    async def list_refresh_external_collection_jobs(
+        self,
+        collection_name: str = "",
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> List:
+        """List external collection refresh jobs (async).
+
+        Args:
+            collection_name: Optional filter by collection name. Empty lists all.
+            timeout: RPC timeout in seconds.
+
+        Returns:
+            List of RefreshExternalCollectionJobInfo.
+        """
+        conn = await self._get_connection()
+        return await conn.list_refresh_external_collection_jobs(
+            collection_name=collection_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -13,6 +13,7 @@ from pymilvus.client.types import (
     LoadedSegmentInfo,
     LoadState,
     OmitZeroDict,
+    RefreshExternalCollectionJobInfo,
     ReplicaInfo,
     ResourceGroupConfig,
     RestoreSnapshotJobInfo,
@@ -2896,6 +2897,82 @@ class MilvusClient(BaseMilvusClient):
         **kwargs,
     ):
         return self._get_connection().list_file_resources(
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    def refresh_external_collection(
+        self,
+        collection_name: str,
+        external_source: str = "",
+        external_spec: str = "",
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> int:
+        """Trigger a data refresh for an external collection.
+
+        Args:
+            collection_name: The external collection to refresh.
+            external_source: Optional new external data source path.
+            external_spec: Optional new external spec configuration.
+            timeout: RPC timeout in seconds.
+
+        Returns:
+            int: A job_id for tracking the refresh progress.
+        """
+        conn = self._get_connection()
+        return conn.refresh_external_collection(
+            collection_name=collection_name,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            external_source=external_source,
+            external_spec=external_spec,
+            **kwargs,
+        )
+
+    def get_refresh_external_collection_progress(
+        self,
+        job_id: int,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> RefreshExternalCollectionJobInfo:
+        """Get the progress of an external collection refresh job.
+
+        Args:
+            job_id: The job ID returned by refresh_external_collection().
+            timeout: RPC timeout in seconds.
+
+        Returns:
+            RefreshExternalCollectionJobInfo with job_id, collection_name,
+            state, progress, reason, external_source, start_time, end_time.
+        """
+        conn = self._get_connection()
+        return conn.get_refresh_external_collection_progress(
+            job_id=job_id,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    def list_refresh_external_collection_jobs(
+        self,
+        collection_name: str = "",
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> List:
+        """List external collection refresh jobs.
+
+        Args:
+            collection_name: Optional filter by collection name. Empty lists all.
+            timeout: RPC timeout in seconds.
+
+        Returns:
+            List of RefreshExternalCollectionJobInfo.
+        """
+        conn = self._get_connection()
+        return conn.list_refresh_external_collection_jobs(
+            collection_name=collection_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -105,6 +105,8 @@ class CollectionSchema:
         # if "enable_dynamic_field" is not in kwargs, we keep None here
         self._enable_dynamic_field = self._kwargs.get("enable_dynamic_field", None)
         self._enable_namespace = self._kwargs.get("enable_namespace", None)
+        self._external_source = self._kwargs.get("external_source", "")
+        self._external_spec = self._kwargs.get("external_spec", "")
         self._primary_field = None
         self._partition_key_field = None
         self._clustering_key_field = None
@@ -290,6 +292,8 @@ class CollectionSchema:
             functions=functions,
             enable_dynamic_field=enable_dynamic_field,
             enable_namespace=enable_namespace,
+            external_source=raw.get("external_source", ""),
+            external_spec=raw.get("external_spec", ""),
         )
 
     @property
@@ -389,6 +393,22 @@ class CollectionSchema:
     def enable_namespace(self, value: bool):
         self._enable_namespace = bool(value)
 
+    @property
+    def external_source(self) -> str:
+        return self._external_source
+
+    @external_source.setter
+    def external_source(self, value: str):
+        self._external_source = str(value)
+
+    @property
+    def external_spec(self) -> str:
+        return self._external_spec
+
+    @external_spec.setter
+    def external_spec(self, value: str):
+        self._external_spec = str(value)
+
     def to_dict(self):
         res = {
             "auto_id": self.auto_id,
@@ -397,6 +417,10 @@ class CollectionSchema:
             "enable_dynamic_field": self.enable_dynamic_field,
             "enable_namespace": self.enable_namespace,
         }
+        if self._external_source:
+            res["external_source"] = self._external_source
+        if self._external_spec:
+            res["external_spec"] = self._external_spec
         if self._functions is not None and len(self._functions) > 0:
             res["functions"] = [s.to_dict() for s in self._functions]
         if self._struct_fields is not None and len(self._struct_fields) > 0:
@@ -501,6 +525,7 @@ class FieldSchema:
 
         self._parse_type_params()
         self.is_function_output = False
+        self.external_field = kwargs.get("external_field", "")
 
     def __repr__(self) -> str:
         return str(self.to_dict())
@@ -554,6 +579,8 @@ class FieldSchema:
         kwargs["is_dynamic"] = raw.get("is_dynamic", False)
         kwargs["nullable"] = raw.get("nullable", False)
         kwargs["element_type"] = raw.get("element_type")
+        if raw.get("external_field"):
+            kwargs["external_field"] = raw["external_field"]
         is_function_output = raw.get("is_function_output", False)
         fs = FieldSchema(raw["name"], raw["type"], raw.get("description", ""), **kwargs)
         fs.is_function_output = is_function_output
@@ -588,6 +615,8 @@ class FieldSchema:
             _dict["is_clustering_key"] = True
         if self.is_function_output:
             _dict["is_function_output"] = True
+        if self.external_field:
+            _dict["external_field"] = self.external_field
         return _dict
 
     def __getattr__(self, item: str):

--- a/tests/async_grpc_handler/test_async_external_collection.py
+++ b/tests/async_grpc_handler/test_async_external_collection.py
@@ -1,0 +1,136 @@
+"""Tests for AsyncGrpcHandler external collection operations."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pymilvus.client.async_grpc_handler import AsyncGrpcHandler
+from pymilvus.client.types import RefreshExternalCollectionJobInfo
+
+
+def _make_async_handler():
+    """Create an AsyncGrpcHandler with mocked channel and stub."""
+    mock_channel = MagicMock()
+    mock_channel.channel_ready = AsyncMock()
+    mock_channel.close = AsyncMock()
+    mock_channel._unary_unary_interceptors = []
+
+    handler = AsyncGrpcHandler(channel=mock_channel)
+    handler._is_channel_ready = True
+
+    mock_stub = AsyncMock()
+    handler._async_stub = mock_stub
+    return handler, mock_stub
+
+
+def _make_job_info_pb(job_id=1, state=2, progress=100):
+    """Create a mock job info protobuf object."""
+    info = MagicMock()
+    info.job_id = job_id
+    info.collection_name = "ext_coll"
+    info.state = state
+    info.progress = progress
+    info.reason = ""
+    info.external_source = "s3://bucket/path"
+    info.start_time = 1000
+    info.end_time = 2000
+    return info
+
+
+class TestAsyncGrpcHandlerExternalCollection:
+    """Tests for async external collection refresh operations."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_external_collection(self):
+        handler, mock_stub = _make_async_handler()
+
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_id = 42
+        mock_stub.RefreshExternalCollection = AsyncMock(return_value=mock_resp)
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_status"
+        ):
+            mock_prepare.refresh_external_collection_request.return_value = MagicMock()
+
+            result = await handler.refresh_external_collection(
+                collection_name="ext_coll",
+                timeout=30,
+            )
+
+            assert result == 42
+            mock_prepare.refresh_external_collection_request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_with_new_source(self):
+        handler, mock_stub = _make_async_handler()
+
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_id = 43
+        mock_stub.RefreshExternalCollection = AsyncMock(return_value=mock_resp)
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_status"
+        ):
+            mock_prepare.refresh_external_collection_request.return_value = MagicMock()
+
+            result = await handler.refresh_external_collection(
+                collection_name="ext_coll",
+                external_source="s3://new-path",
+                external_spec='{"format": "iceberg"}',
+            )
+
+            assert result == 43
+
+    @pytest.mark.asyncio
+    async def test_get_refresh_progress(self):
+        handler, mock_stub = _make_async_handler()
+
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_info = _make_job_info_pb(job_id=42, state=2, progress=100)
+        mock_stub.GetRefreshExternalCollectionProgress = AsyncMock(return_value=mock_resp)
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_status"
+        ):
+            mock_prepare.get_refresh_external_collection_progress_request.return_value = MagicMock()
+
+            result = await handler.get_refresh_external_collection_progress(job_id=42)
+
+            assert isinstance(result, RefreshExternalCollectionJobInfo)
+            assert result.job_id == 42
+            assert result.state == "RefreshCompleted"
+            assert result.progress == 100
+
+    @pytest.mark.asyncio
+    async def test_list_refresh_jobs(self):
+        handler, mock_stub = _make_async_handler()
+
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.jobs = [
+            _make_job_info_pb(job_id=1, state=2, progress=100),
+            _make_job_info_pb(job_id=2, state=1, progress=50),
+        ]
+        mock_stub.ListRefreshExternalCollectionJobs = AsyncMock(return_value=mock_resp)
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_status"
+        ):
+            mock_prepare.list_refresh_external_collection_jobs_request.return_value = MagicMock()
+
+            result = await handler.list_refresh_external_collection_jobs(collection_name="ext_coll")
+
+            assert len(result) == 2
+            assert result[0].state == "RefreshCompleted"
+            assert result[1].state == "RefreshInProgress"

--- a/tests/grpc_handler/test_external_collection.py
+++ b/tests/grpc_handler/test_external_collection.py
@@ -1,0 +1,124 @@
+"""Tests for GrpcHandler external collection operations."""
+
+from unittest.mock import MagicMock
+
+from pymilvus.client.types import RefreshExternalCollectionJobInfo
+
+from .conftest import make_response
+
+
+def _make_job_info(job_id=1, collection_name="ext_coll", state=2, progress=100, reason=""):
+    """Create a mock RefreshExternalCollectionJobInfo protobuf."""
+    info = MagicMock()
+    info.job_id = job_id
+    info.collection_name = collection_name
+    info.state = state
+    info.progress = progress
+    info.reason = reason
+    info.external_source = "s3://bucket/path"
+    info.start_time = 1000
+    info.end_time = 2000
+    return info
+
+
+class TestGrpcHandlerExternalCollectionOps:
+    """Tests for external collection refresh operations."""
+
+    def test_refresh_external_collection(self, handler):
+        handler._stub.RefreshExternalCollection.return_value = make_response(job_id=42)
+        result = handler.refresh_external_collection("ext_coll")
+        assert result == 42
+        handler._stub.RefreshExternalCollection.assert_called_once()
+
+    def test_refresh_external_collection_with_new_source(self, handler):
+        handler._stub.RefreshExternalCollection.return_value = make_response(job_id=43)
+        result = handler.refresh_external_collection(
+            "ext_coll",
+            external_source="s3://new-bucket/path",
+            external_spec='{"format": "iceberg"}',
+        )
+        assert result == 43
+        handler._stub.RefreshExternalCollection.assert_called_once()
+
+    def test_get_refresh_progress_completed(self, handler):
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_info = _make_job_info(job_id=42, state=2, progress=100)
+        handler._stub.GetRefreshExternalCollectionProgress.return_value = mock_resp
+
+        result = handler.get_refresh_external_collection_progress(42)
+        assert isinstance(result, RefreshExternalCollectionJobInfo)
+        assert result.job_id == 42
+        assert result.state == "RefreshCompleted"
+        assert result.progress == 100
+        assert result.external_source == "s3://bucket/path"
+
+    def test_get_refresh_progress_in_progress(self, handler):
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_info = _make_job_info(job_id=42, state=1, progress=50)
+        handler._stub.GetRefreshExternalCollectionProgress.return_value = mock_resp
+
+        result = handler.get_refresh_external_collection_progress(42)
+        assert result.state == "RefreshInProgress"
+        assert result.progress == 50
+
+    def test_get_refresh_progress_pending(self, handler):
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_info = _make_job_info(job_id=42, state=0, progress=0)
+        handler._stub.GetRefreshExternalCollectionProgress.return_value = mock_resp
+
+        result = handler.get_refresh_external_collection_progress(42)
+        assert result.state == "RefreshPending"
+        assert result.progress == 0
+
+    def test_get_refresh_progress_failed(self, handler):
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.job_info = _make_job_info(
+            job_id=42, state=3, progress=60, reason="data source unreachable"
+        )
+        handler._stub.GetRefreshExternalCollectionProgress.return_value = mock_resp
+
+        result = handler.get_refresh_external_collection_progress(42)
+        assert result.state == "RefreshFailed"
+        assert result.progress == 60
+        assert result.reason == "data source unreachable"
+
+    def test_list_refresh_external_collection_jobs(self, handler):
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.jobs = [
+            _make_job_info(job_id=1, state=2, progress=100),
+            _make_job_info(job_id=2, state=1, progress=30),
+        ]
+        handler._stub.ListRefreshExternalCollectionJobs.return_value = mock_resp
+
+        result = handler.list_refresh_external_collection_jobs("ext_coll")
+        assert len(result) == 2
+        assert result[0].job_id == 1
+        assert result[0].state == "RefreshCompleted"
+        assert result[1].job_id == 2
+        assert result[1].state == "RefreshInProgress"
+
+    def test_list_refresh_jobs_empty(self, handler):
+        mock_resp = MagicMock()
+        mock_resp.status.code = 0
+        mock_resp.status.error_code = 0
+        mock_resp.status.reason = ""
+        mock_resp.jobs = []
+        handler._stub.ListRefreshExternalCollectionJobs.return_value = mock_resp
+
+        result = handler.list_refresh_external_collection_jobs()
+        assert result == []

--- a/tests/orm/test_schema.py
+++ b/tests/orm/test_schema.py
@@ -1871,3 +1871,122 @@ class TestMarkOutputFields:
         # vec should NOT be marked as output
         vec_field = next(f for f in schema.fields if f.name == "vec")
         assert vec_field.is_function_output is False
+
+
+class TestExternalCollectionSchema:
+    """Tests for external collection schema fields."""
+
+    def test_collection_schema_external_fields(self):
+        schema = CollectionSchema(
+            [FieldSchema("pk", DataType.INT64, is_primary=True)],
+            external_source="s3://bucket/path",
+            external_spec='{"format": "iceberg"}',
+        )
+        assert schema.external_source == "s3://bucket/path"
+        assert schema.external_spec == '{"format": "iceberg"}'
+
+    def test_collection_schema_external_defaults(self):
+        schema = CollectionSchema(
+            [FieldSchema("pk", DataType.INT64, is_primary=True)],
+        )
+        assert schema.external_source == ""
+        assert schema.external_spec == ""
+
+    def test_collection_schema_external_setters(self):
+        schema = CollectionSchema(
+            [FieldSchema("pk", DataType.INT64, is_primary=True)],
+        )
+        schema.external_source = "s3://new"
+        schema.external_spec = '{"x": 1}'
+        assert schema.external_source == "s3://new"
+        assert schema.external_spec == '{"x": 1}'
+
+    def test_collection_schema_to_dict_with_external(self):
+        schema = CollectionSchema(
+            [FieldSchema("pk", DataType.INT64, is_primary=True)],
+            external_source="s3://bucket",
+            external_spec='{"format": "iceberg"}',
+        )
+        d = schema.to_dict()
+        assert d["external_source"] == "s3://bucket"
+        assert d["external_spec"] == '{"format": "iceberg"}'
+
+    def test_collection_schema_to_dict_without_external(self):
+        schema = CollectionSchema(
+            [FieldSchema("pk", DataType.INT64, is_primary=True)],
+        )
+        d = schema.to_dict()
+        assert "external_source" not in d
+        assert "external_spec" not in d
+
+    def test_collection_schema_construct_from_dict_with_external(self):
+        raw = {
+            "fields": [{"name": "pk", "type": DataType.INT64, "is_primary": True}],
+            "external_source": "s3://bucket",
+            "external_spec": '{"format": "iceberg"}',
+            "enable_dynamic_field": False,
+        }
+        schema = CollectionSchema.construct_from_dict(raw)
+        assert schema.external_source == "s3://bucket"
+        assert schema.external_spec == '{"format": "iceberg"}'
+
+    def test_collection_schema_construct_from_dict_without_external(self):
+        raw = {
+            "fields": [{"name": "pk", "type": DataType.INT64, "is_primary": True}],
+            "enable_dynamic_field": False,
+        }
+        schema = CollectionSchema.construct_from_dict(raw)
+        assert schema.external_source == ""
+        assert schema.external_spec == ""
+
+    def test_field_schema_external_field(self):
+        f = FieldSchema("col", DataType.VARCHAR, max_length=512, external_field="ext_col")
+        assert f.external_field == "ext_col"
+
+    def test_field_schema_external_field_default(self):
+        f = FieldSchema("col", DataType.VARCHAR, max_length=512)
+        assert f.external_field == ""
+
+    def test_field_schema_to_dict_with_external_field(self):
+        f = FieldSchema("col", DataType.VARCHAR, max_length=512, external_field="ext_col")
+        d = f.to_dict()
+        assert d["external_field"] == "ext_col"
+
+    def test_field_schema_to_dict_without_external_field(self):
+        f = FieldSchema("col", DataType.VARCHAR, max_length=512)
+        d = f.to_dict()
+        assert "external_field" not in d
+
+    def test_field_schema_construct_from_dict_with_external(self):
+        raw = {
+            "name": "col",
+            "type": DataType.VARCHAR,
+            "params": {"max_length": 512},
+            "external_field": "ext_col",
+        }
+        f = FieldSchema.construct_from_dict(raw)
+        assert f.external_field == "ext_col"
+
+    def test_field_schema_construct_from_dict_without_external(self):
+        raw = {"name": "col", "type": DataType.VARCHAR, "params": {"max_length": 512}}
+        f = FieldSchema.construct_from_dict(raw)
+        assert f.external_field == ""
+
+    def test_collection_schema_roundtrip(self):
+        """Full round-trip: create → to_dict → construct_from_dict → verify."""
+        schema = CollectionSchema(
+            [
+                FieldSchema("pk", DataType.INT64, is_primary=True, external_field="row_id"),
+                FieldSchema("text", DataType.VARCHAR, max_length=512, external_field="content"),
+                FieldSchema("vec", DataType.FLOAT_VECTOR, dim=768),
+            ],
+            external_source="s3://bucket/path",
+            external_spec='{"format": "iceberg"}',
+        )
+        d = schema.to_dict()
+        restored = CollectionSchema.construct_from_dict(d)
+        assert restored.external_source == "s3://bucket/path"
+        assert restored.external_spec == '{"format": "iceberg"}'
+        assert restored.fields[0].external_field == "row_id"
+        assert restored.fields[1].external_field == "content"
+        assert restored.fields[2].external_field == ""

--- a/tests/prepare/test_coverage_gaps.py
+++ b/tests/prepare/test_coverage_gaps.py
@@ -377,6 +377,46 @@ class TestSnapshotRequests:
         assert req.collection_name == "test_coll"
 
 
+class TestExternalCollectionRequests:
+    """Tests for external collection refresh requests."""
+
+    def test_refresh_external_collection(self):
+        req = Prepare.refresh_external_collection_request(
+            collection_name="ext_coll",
+            db_name="default",
+            external_source="s3://bucket/path",
+            external_spec='{"format": "iceberg"}',
+        )
+        assert req.collection_name == "ext_coll"
+        assert req.db_name == "default"
+        assert req.external_source == "s3://bucket/path"
+        assert req.external_spec == '{"format": "iceberg"}'
+
+    def test_refresh_external_collection_minimal(self):
+        req = Prepare.refresh_external_collection_request(collection_name="ext_coll")
+        assert req.collection_name == "ext_coll"
+        assert req.db_name == ""
+        assert req.external_source == ""
+        assert req.external_spec == ""
+
+    def test_get_refresh_progress(self):
+        req = Prepare.get_refresh_external_collection_progress_request(job_id=42)
+        assert req.job_id == 42
+
+    def test_list_refresh_jobs(self):
+        req = Prepare.list_refresh_external_collection_jobs_request(
+            db_name="default",
+            collection_name="ext_coll",
+        )
+        assert req.db_name == "default"
+        assert req.collection_name == "ext_coll"
+
+    def test_list_refresh_jobs_all(self):
+        req = Prepare.list_refresh_external_collection_jobs_request()
+        assert req.db_name == ""
+        assert req.collection_name == ""
+
+
 class TestReleaseRequests:
     """Tests for release requests."""
 

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -7,7 +7,13 @@ import pytest_asyncio
 from pymilvus import AsyncMilvusClient, DataType
 from pymilvus.client.abstract import AnnSearchRequest
 from pymilvus.client.connection_manager import AsyncConnectionManager
-from pymilvus.client.types import CompactionPlans, LoadState, RestoreSnapshotJobInfo, SnapshotInfo
+from pymilvus.client.types import (
+    CompactionPlans,
+    LoadState,
+    RefreshExternalCollectionJobInfo,
+    RestoreSnapshotJobInfo,
+    SnapshotInfo,
+)
 from pymilvus.orm.collection import Function
 from pymilvus.orm.schema import StructFieldSchema
 
@@ -905,3 +911,68 @@ class TestAsyncFileResourceMethods:
         mock_handler.list_file_resources.assert_called_once()
         assert result == ["file1", "file2"]
         assert "context" in mock_handler.list_file_resources.call_args.kwargs
+
+
+class TestAsyncMilvusClientExternalCollection:
+    """Test external collection refresh APIs in AsyncMilvusClient."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_external_collection(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.refresh_external_collection = AsyncMock(return_value=42)
+
+        result = await client.refresh_external_collection(collection_name="ext_coll")
+
+        assert result == 42
+        mock_handler.refresh_external_collection.assert_called_once_with(
+            collection_name="ext_coll",
+            timeout=None,
+            context=ANY,
+            external_source="",
+            external_spec="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_refresh_with_new_source(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.refresh_external_collection = AsyncMock(return_value=43)
+
+        result = await client.refresh_external_collection(
+            collection_name="ext_coll",
+            external_source="s3://new-path",
+            external_spec='{"format": "iceberg"}',
+        )
+
+        assert result == 43
+
+    @pytest.mark.asyncio
+    async def test_get_refresh_progress(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        job_info = RefreshExternalCollectionJobInfo(
+            job_id=42,
+            collection_name="ext_coll",
+            state="RefreshCompleted",
+            progress=100,
+            reason="",
+            external_source="s3://bucket",
+            start_time=1000,
+            end_time=2000,
+        )
+        mock_handler.get_refresh_external_collection_progress = AsyncMock(return_value=job_info)
+
+        result = await client.get_refresh_external_collection_progress(job_id=42)
+
+        assert result.job_id == 42
+        assert result.state == "RefreshCompleted"
+
+    @pytest.mark.asyncio
+    async def test_list_refresh_jobs(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.list_refresh_external_collection_jobs = AsyncMock(return_value=[])
+
+        result = await client.list_refresh_external_collection_jobs(collection_name="ext_coll")
+
+        assert result == []
+        mock_handler.list_refresh_external_collection_jobs.assert_called_once_with(
+            collection_name="ext_coll", timeout=None, context=ANY
+        )

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -4,7 +4,12 @@ from unittest.mock import ANY, MagicMock, patch
 import pytest
 from pymilvus import DataType
 from pymilvus.client.connection_manager import ConnectionManager
-from pymilvus.client.types import LoadState, RestoreSnapshotJobInfo, SnapshotInfo
+from pymilvus.client.types import (
+    LoadState,
+    RefreshExternalCollectionJobInfo,
+    RestoreSnapshotJobInfo,
+    SnapshotInfo,
+)
 from pymilvus.exceptions import (
     DataTypeNotMatchException,
     MilvusException,
@@ -1502,3 +1507,114 @@ class TestFileResourceMethods(TestMilvusClient):
             mock_handler.list_file_resources.assert_called_once()
             assert result == ["file1", "file2"]
             assert "context" in mock_handler.list_file_resources.call_args.kwargs
+
+
+class TestMilvusClientExternalCollection:
+    """Test external collection refresh APIs in MilvusClient."""
+
+    def test_refresh_external_collection(self):
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.refresh_external_collection.return_value = 42
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+            result = client.refresh_external_collection(collection_name="ext_coll")
+
+            assert result == 42
+            mock_handler.refresh_external_collection.assert_called_once_with(
+                collection_name="ext_coll",
+                timeout=None,
+                context=ANY,
+                external_source="",
+                external_spec="",
+            )
+
+    def test_refresh_with_new_source(self):
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.refresh_external_collection.return_value = 43
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+            result = client.refresh_external_collection(
+                collection_name="ext_coll",
+                external_source="s3://new-path",
+                external_spec='{"format": "iceberg"}',
+            )
+
+            assert result == 43
+            call_kwargs = mock_handler.refresh_external_collection.call_args[1]
+            assert call_kwargs["external_source"] == "s3://new-path"
+            assert call_kwargs["external_spec"] == '{"format": "iceberg"}'
+
+    def test_get_refresh_progress(self):
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.get_refresh_external_collection_progress.return_value = (
+            RefreshExternalCollectionJobInfo(
+                job_id=42,
+                collection_name="ext_coll",
+                state="RefreshCompleted",
+                progress=100,
+                reason="",
+                external_source="s3://bucket",
+                start_time=1000,
+                end_time=2000,
+            )
+        )
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+            result = client.get_refresh_external_collection_progress(job_id=42)
+
+            assert result.job_id == 42
+            assert result.state == "RefreshCompleted"
+            assert result.progress == 100
+            mock_handler.get_refresh_external_collection_progress.assert_called_once_with(
+                job_id=42, timeout=None, context=ANY
+            )
+
+    def test_list_refresh_jobs(self):
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.list_refresh_external_collection_jobs.return_value = [
+            RefreshExternalCollectionJobInfo(
+                job_id=1,
+                collection_name="ext_coll",
+                state="RefreshCompleted",
+                progress=100,
+                reason="",
+                external_source="s3://a",
+                start_time=1000,
+                end_time=2000,
+            ),
+        ]
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+            result = client.list_refresh_external_collection_jobs(collection_name="ext_coll")
+
+            assert len(result) == 1
+            assert result[0].job_id == 1
+            mock_handler.list_refresh_external_collection_jobs.assert_called_once_with(
+                collection_name="ext_coll", timeout=None, context=ANY
+            )
+
+    def test_list_refresh_jobs_all(self):
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.list_refresh_external_collection_jobs.return_value = []
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+            result = client.list_refresh_external_collection_jobs()
+
+            assert result == []
+            call_kwargs = mock_handler.list_refresh_external_collection_jobs.call_args[1]
+            assert call_kwargs["collection_name"] == ""


### PR DESCRIPTION
## Summary

- Add Python SDK support for external collection (external table) operations, enabling users to create collections backed by external data sources (e.g., Iceberg on S3) and refresh data from those sources
- Implements schema-level fields (`external_source`, `external_spec`, `external_field`) and 3 new refresh APIs (`refresh_external_collection`, `get_refresh_external_collection_progress`, `list_refresh_external_collection_jobs`) across all layers (Prepare, GrpcHandler, AsyncGrpcHandler, MilvusClient, AsyncMilvusClient)
- Includes 40 unit tests covering all layers + schema serialization round-trip, and an example file with sync/async demos

issue: https://github.com/milvus-io/milvus/issues/45881

## Test plan

- [x] 40 unit tests passing (`pytest -v`)
- [x] Lint passing (`make lint`)
- [x] Schema serialization round-trip verified (to_dict → construct_from_dict)
- [x] Protobuf wire format verified (empty external fields = zero wire overhead for normal collections)
- [x] Backward compatibility verified (no existing method signatures changed, all additions are pure new code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)