### PR TITLE
[Cherry-pick 2.6] ci: bump actions/checkout to v6 and actions/setup-python to v6

### DIFF
--- a/.github/workflows/check_milvus_proto.yml
+++ b/.github/workflows/check_milvus_proto.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         python-version: [3.8, 3.13]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/code_checker.yml
+++ b/.github/workflows/code_checker.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [3.8, 3.14]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Check pyproject.toml install

--- a/.github/workflows/publish_dev_package.yml
+++ b/.github/workflows/publish_dev_package.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
     - name: Check out from Git
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Get history and tags for SCM versioning
       run: |
           git fetch --prune --unshallow
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.13
     - name: Install pypa/build

--- a/.github/workflows/publish_on_release.yml
+++ b/.github/workflows/publish_on_release.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
     - name: Check out from Git
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Get history and tags for SCM versioning
       run: |
           git fetch --prune --unshallow
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Set up Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.13
     - name: Install pypa/build

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Cherry-pick of #3400 for 2.6 branch.

Resolved conflicts: removed `auto-cherrypick.yml` and `update-milvus-pymilvus-dev.yml` (don't exist on 2.6).

See also: #3399

Signed-off-by: pymilvus-bot <pymilvus@zilliz.com>