### PR TITLE
feat: add MOL field support in Python SDK

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -710,6 +710,20 @@ def pack_field_value_to_field_data(
                 % (field_name, "array", type(field_value))
                 + f" Detail: {e!s}"
             ) from e
+    elif field_type == DataType.MOL:
+        try:
+            if field_value is None:
+                field_data.scalars.mol_smiles_data.data.extend([])
+            else:
+                field_data.scalars.mol_smiles_data.data.append(
+                    convert_to_str_array(field_value, field_info, CHECK_STR_ARRAY)
+                )
+        except (TypeError, ValueError) as e:
+            raise DataNotMatchException(
+                message=ExceptionsMessage.FieldDataInconsistent
+                % (field_name, "mol", type(field_value))
+                + f" Detail: {e!s}"
+            ) from e
     else:
         raise ParamError(message=f"Unsupported data type: {field_type}")
 
@@ -799,6 +813,10 @@ def entity_to_field_data(entity: Dict, field_info: Any, num_rows: int) -> schema
             )
         elif entity_type == DataType.GEOMETRY:
             field_data.scalars.geometry_wkt_data.data.extend(
+                entity_to_str_arr(entity_values, field_info, CHECK_STR_ARRAY)
+            )
+        elif entity_type == DataType.MOL:
+            field_data.scalars.mol_smiles_data.data.extend(
                 entity_to_str_arr(entity_values, field_info, CHECK_STR_ARRAY)
             )
         else:
@@ -998,6 +1016,11 @@ def extract_row_data_from_fields_data_v2(
         assign_scalar(data)
         return False
 
+    if field_data.type == DataType.MOL:
+        data = field_data.scalars.mol_smiles_data.data
+        assign_scalar(data)
+        return False
+
     if field_data.type == DataType.JSON:
         return True
 
@@ -1137,6 +1160,12 @@ def extract_row_data_from_fields_data(
             scalar_data = field_data.scalars.geometry_wkt_data.data
             if len(scalar_data) >= index:
                 entity_row_data[field_name] = None if is_null else scalar_data[index]
+                return
+
+        if field_data.type == DataType.MOL:
+            scalar_data = field_data.scalars.mol_smiles_data.data
+            if len(scalar_data) >= index:
+                row_data[field_name] = None if is_null else scalar_data[index]
                 return
 
         if field_data.type == DataType.JSON:

--- a/pymilvus/client/search_result.py
+++ b/pymilvus/client/search_result.py
@@ -21,6 +21,7 @@ _SCALAR_TYPES = frozenset(
         DataType.VARCHAR,
         DataType.GEOMETRY,
         DataType.TIMESTAMPTZ,
+        DataType.MOL,
     }
 )
 
@@ -52,6 +53,7 @@ _SCALAR_DATA_ATTR = {
     DataType.VARCHAR: "string_data",
     DataType.TIMESTAMPTZ: "string_data",
     DataType.GEOMETRY: "geometry_wkt_data",
+    DataType.MOL: "mol_smiles_data",
     DataType.JSON: "json_data",
     DataType.ARRAY: "array_data",
 }
@@ -539,6 +541,16 @@ class SearchResult(list):
                 )
                 continue
 
+            if dtype == DataType.MOL:
+                field2data[name] = (
+                    apply_valid_data(
+                        scalars.mol_smiles_data.data[start:end],
+                        field.valid_data[start:end] if field.valid_data else None,
+                    ),
+                    field_meta,
+                )
+                continue
+
             if dtype == DataType.JSON:
                 res = apply_valid_data(
                     scalars.json_data.data[start:end],
@@ -912,6 +924,9 @@ def extract_struct_field_value(field_data: schema_pb2.FieldData, index: int) -> 
     elif field_data.type == DataType.VARCHAR:
         if index < len(field_data.scalars.string_data.data):
             return field_data.scalars.string_data.data[index]
+    elif field_data.type == DataType.MOL:
+        if index < len(field_data.scalars.mol_smiles_data.data):
+            return field_data.scalars.mol_smiles_data.data[index]
     elif field_data.type == DataType.JSON:
         if index < len(field_data.scalars.json_data.data):
             return orjson.loads(field_data.scalars.json_data.data[index])

--- a/pymilvus/client/types.py
+++ b/pymilvus/client/types.py
@@ -117,6 +117,7 @@ class DataType(IntEnum):
     JSON = schema_pb2.JSON
     GEOMETRY = schema_pb2.Geometry
     TIMESTAMPTZ = schema_pb2.Timestamptz
+    MOL = schema_pb2.Mol
 
     BINARY_VECTOR = schema_pb2.BinaryVector
     FLOAT_VECTOR = schema_pb2.FloatVector
@@ -143,6 +144,7 @@ class FunctionType(IntEnum):
     TEXTEMBEDDING = 2
     RERANK = 3
     MINHASH = 4
+    MOL_FINGERPRINT = 5
 
 
 class HighlightType(IntEnum):

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -958,11 +958,32 @@ class Function:
                     message=ExceptionsMessage.TextEmbeddingFunctionIncorrectOutputFieldType
                 )
 
+    def _check_mol_fingerprint_function(self, schema: CollectionSchema):
+        if len(self._input_field_names) != 1 or len(self._output_field_names) != 1:
+            raise ParamError(
+                message="MOL_FINGERPRINT function must have exactly one input field and one output field"
+            )
+
+        for field in schema.fields:
+            if field.name == self._input_field_names[0] and field.dtype != DataType.MOL:
+                raise ParamError(
+                    message=f"MOL_FINGERPRINT function input field must be MOL type, got {field.dtype}"
+                )
+            if (
+                field.name == self._output_field_names[0]
+                and field.dtype != DataType.BINARY_VECTOR
+            ):
+                raise ParamError(
+                    message=f"MOL_FINGERPRINT function output field must be BINARY_VECTOR type, got {field.dtype}"
+                )
+
     def verify(self, schema: CollectionSchema):
         if self._type == FunctionType.BM25:
             self._check_bm25_function(schema)
         elif self._type == FunctionType.TEXTEMBEDDING:
             self._check_text_embedding_function(schema)
+        elif self._type == FunctionType.MOL_FINGERPRINT:
+            self._check_mol_fingerprint_function(schema)
         elif self._type == FunctionType.MINHASH:
             # MinHash validation is handled by the proxy
             pass

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -969,10 +969,7 @@ class Function:
                 raise ParamError(
                     message=f"MOL_FINGERPRINT function input field must be MOL type, got {field.dtype}"
                 )
-            if (
-                field.name == self._output_field_names[0]
-                and field.dtype != DataType.BINARY_VECTOR
-            ):
+            if field.name == self._output_field_names[0] and field.dtype != DataType.BINARY_VECTOR:
                 raise ParamError(
                     message=f"MOL_FINGERPRINT function output field must be BINARY_VECTOR type, got {field.dtype}"
                 )

--- a/tests/orm/test_schema.py
+++ b/tests/orm/test_schema.py
@@ -53,6 +53,64 @@ from pymilvus.orm.schema import (
 # ============================================================
 
 
+class TestMolFunction:
+    def test_mol_fingerprint_function_verify_success(self):
+        schema = CollectionSchema(
+            fields=[
+                FieldSchema("id", DataType.INT64, is_primary=True),
+                FieldSchema("mol", DataType.MOL),
+                FieldSchema("fp", DataType.BINARY_VECTOR, dim=2048),
+            ]
+        )
+        function = Function(
+            "mol_fp",
+            FunctionType.MOL_FINGERPRINT,
+            ["mol"],
+            ["fp"],
+            params={"fingerprint_type": "morgan", "fingerprint_size": "2048"},
+        )
+
+        function.verify(schema)
+
+    def test_mol_fingerprint_function_rejects_non_mol_input(self):
+        schema = CollectionSchema(
+            fields=[
+                FieldSchema("id", DataType.INT64, is_primary=True),
+                FieldSchema("text", DataType.VARCHAR, max_length=128),
+                FieldSchema("fp", DataType.BINARY_VECTOR, dim=2048),
+            ]
+        )
+        function = Function(
+            "mol_fp",
+            FunctionType.MOL_FINGERPRINT,
+            ["text"],
+            ["fp"],
+            params={"fingerprint_type": "morgan", "fingerprint_size": "2048"},
+        )
+
+        with pytest.raises(ParamError, match="input field must be MOL type"):
+            function.verify(schema)
+
+    def test_mol_fingerprint_function_rejects_non_binary_vector_output(self):
+        schema = CollectionSchema(
+            fields=[
+                FieldSchema("id", DataType.INT64, is_primary=True),
+                FieldSchema("mol", DataType.MOL),
+                FieldSchema("fp", DataType.FLOAT_VECTOR, dim=128),
+            ]
+        )
+        function = Function(
+            "mol_fp",
+            FunctionType.MOL_FINGERPRINT,
+            ["mol"],
+            ["fp"],
+            params={"fingerprint_type": "morgan", "fingerprint_size": "2048"},
+        )
+
+        with pytest.raises(ParamError, match="output field must be BINARY_VECTOR type"):
+            function.verify(schema)
+
+
 class TestFieldSchemaCreation:
     """Tests for FieldSchema creation with various data types."""
 

--- a/tests/test_client_entity_helper.py
+++ b/tests/test_client_entity_helper.py
@@ -199,6 +199,30 @@ class TestEntityHelperExtended:
         assert field_data.type == DataType.INT64
         assert field_data.scalars.long_data.data[0] == 42
 
+    def test_pack_field_value_to_field_data_mol(self):
+        """Test packing MOL scalar field values"""
+        field_data = schema_pb2.FieldData()
+        field_data.type = DataType.MOL
+        field_data.field_name = "mol_field"
+        field_info = {"name": "mol_field", "params": {Config.MaxVarCharLengthKey: 256}}
+        vector_bytes_cache: Dict[int, List[bytes]] = {}
+
+        pack_field_value_to_field_data("CCO", field_data, field_info, vector_bytes_cache)
+
+        assert field_data.type == DataType.MOL
+        assert list(field_data.scalars.mol_smiles_data.data) == ["CCO"]
+
+    def test_pack_field_value_to_field_data_mol_invalid_input(self):
+        """Test MOL packing rejects non-string input"""
+        field_data = schema_pb2.FieldData()
+        field_data.type = DataType.MOL
+        field_data.field_name = "mol_field"
+        field_info = {"name": "mol_field", "params": {Config.MaxVarCharLengthKey: 256}}
+        vector_bytes_cache: Dict[int, List[bytes]] = {}
+
+        with pytest.raises(DataNotMatchException, match="mol"):
+            pack_field_value_to_field_data(123, field_data, field_info, vector_bytes_cache)
+
     def test_extract_field_info(self):
         """Test extracting primary field from schema"""
         # Create schema with primary field
@@ -334,6 +358,88 @@ class TestEntityHelperExtended:
         assert result.field_name == "test_field"
         assert result.type == DataType.INT64
         assert list(result.scalars.long_data.data) == [1, 2, 3, 4, 5]
+
+    def test_entity_to_field_data_mol(self):
+        """Test converting MOL entity to field data"""
+        entity = {"name": "mol_field", "type": DataType.MOL, "values": ["CCO", "c1ccccc1"]}
+        field_info = {"name": "mol_field", "params": {Config.MaxVarCharLengthKey: 256}}
+
+        result = entity_to_field_data(entity, field_info, 2)
+
+        assert result.field_name == "mol_field"
+        assert result.type == DataType.MOL
+        assert list(result.scalars.mol_smiles_data.data) == ["CCO", "c1ccccc1"]
+
+    def test_entity_to_field_data_mol_invalid_input(self):
+        """Test MOL entity conversion rejects non-string input"""
+        entity = {"name": "mol_field", "type": DataType.MOL, "values": ["CCO", 123]}
+        field_info = {"name": "mol_field", "params": {Config.MaxVarCharLengthKey: 256}}
+
+        with pytest.raises(ParamError, match="expects string input"):
+            entity_to_field_data(entity, field_info, 2)
+
+    def test_extract_row_data_from_fields_data_v2_mol(self):
+        """Test extracting MOL scalar values via extract_row_data_from_fields_data_v2"""
+        field_data = schema_pb2.FieldData()
+        field_data.field_name = "mol"
+        field_data.type = DataType.MOL
+        field_data.scalars.mol_smiles_data.CopyFrom(
+            schema_pb2.MolSmilesArray(data=["CCO", "c1ccccc1"])
+        )
+
+        entity_rows = [{}, {}]
+        is_vector = extract_row_data_from_fields_data_v2(field_data, entity_rows)
+
+        assert is_vector is False
+        assert entity_rows == [{"mol": "CCO"}, {"mol": "c1ccccc1"}]
+
+    def test_extract_row_data_from_fields_data_mol(self):
+        """Test extracting a single MOL scalar value via extract_row_data_from_fields_data"""
+        field_data = schema_pb2.FieldData()
+        field_data.field_name = "mol"
+        field_data.type = DataType.MOL
+        field_data.scalars.mol_smiles_data.CopyFrom(
+            schema_pb2.MolSmilesArray(data=["CCO", "c1ccccc1"])
+        )
+
+        row = extract_row_data_from_fields_data([field_data], 1)
+        assert row == {"mol": "c1ccccc1"}
+
+    def test_entity_to_field_data_nullable_mol(self):
+        """Test entity_to_field_data with nullable MOL values"""
+        entity = {
+            "name": "nullable_mol",
+            "type": DataType.MOL,
+            "values": ["CCO", None, "CCN"],
+        }
+        field_info = {
+            "name": "nullable_mol",
+            "nullable": True,
+            "params": {Config.MaxVarCharLengthKey: 256},
+        }
+
+        result = entity_to_field_data(entity, field_info, 3)
+
+        assert result.field_name == "nullable_mol"
+        assert result.type == DataType.MOL
+        assert list(result.valid_data) == [True, False, True]
+        assert list(result.scalars.mol_smiles_data.data) == ["CCO", "CCN"]
+
+    def test_pack_field_value_nullable_mol_none(self):
+        """Test pack_field_value_to_field_data with None MOL value"""
+        field_data = schema_pb2.FieldData()
+        field_data.type = DataType.MOL
+        field_data.field_name = "nullable_mol"
+        field_info = {
+            "name": "nullable_mol",
+            "nullable": True,
+            "params": {Config.MaxVarCharLengthKey: 256},
+        }
+        vector_bytes_cache: Dict[int, List[bytes]] = {}
+
+        pack_field_value_to_field_data(None, field_data, field_info, vector_bytes_cache)
+
+        assert len(field_data.scalars.mol_smiles_data.data) == 0
 
 
 class TestNullableVectorSupport:

--- a/tests/test_client_types.py
+++ b/tests/test_client_types.py
@@ -465,6 +465,7 @@ class TestFunctionType:
             ("TEXTEMBEDDING", 2),
             ("RERANK", 3),
             ("MINHASH", 4),
+            ("MOL_FINGERPRINT", 5),
         ],
     )
     def test_function_type_values(self, attr, value):

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -561,6 +561,27 @@ class TestSearchResultExtended:
         assert hits[0].entity["geom"] == "POINT(1 1)"
         assert hits[1].entity["geom"] == "POINT(2 2)"
 
+    def test_mol(self):
+        fields_data = [
+            schema_pb2.FieldData(
+                type=DataType.MOL,
+                field_name="mol",
+                field_id=105,
+                scalars=schema_pb2.ScalarField(
+                    mol_smiles_data=schema_pb2.MolSmilesArray(
+                        data=["CCO", "c1ccccc1", "CC(=O)O"]
+                    )
+                ),
+            )
+        ]
+
+        res_data = self._create_base_result(fields_data)
+        sr = SearchResult(res_data)
+        hits = sr[0]
+
+        assert hits[0].entity["mol"] == "CCO"
+        assert hits[1].entity["mol"] == "c1ccccc1"
+
     def test_get_field_data_with_mol(self):
         field_data = _make_scalar_field(DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=200)
         assert get_field_data(field_data) == ["CCO", "c1ccccc1"]
@@ -642,6 +663,15 @@ class TestSearchResultExtended:
                     json_data=schema_pb2.JSONArray(data=[b'{"a":1}', b"", b'{"c":3}'])
                 ),
             ),
+            # MOL
+            schema_pb2.FieldData(
+                type=DataType.MOL,
+                field_name="mol_field",
+                valid_data=valid_data,
+                scalars=schema_pb2.ScalarField(
+                    mol_smiles_data=schema_pb2.MolSmilesArray(data=["CCO", "", "CCN"])
+                ),
+            ),
         ]
 
         res_data = self._create_base_result(fields_data)
@@ -653,15 +683,18 @@ class TestSearchResultExtended:
         assert hits[0].entity["float_field"] == pytest.approx(1.1)
         assert hits[0].entity["str_field"] == "a"
         assert hits[0].entity["json_field"] == {"a": 1}
+        assert hits[0].entity["mol_field"] == "CCO"
 
         # Row 2 (null)
         assert hits[1].entity["int_field"] is None
         assert hits[1].entity["float_field"] is None
         assert hits[1].entity["str_field"] is None
         assert hits[1].entity["json_field"] is None
+        assert hits[1].entity["mol_field"] is None
 
         # Row 3 (valid)
         assert hits[2].entity["int_field"] == 30
+        assert hits[2].entity["mol_field"] == "CCN"
 
     def test_json_error_handling(self):
         # Test malformed JSON

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -568,9 +568,7 @@ class TestSearchResultExtended:
                 field_name="mol",
                 field_id=105,
                 scalars=schema_pb2.ScalarField(
-                    mol_smiles_data=schema_pb2.MolSmilesArray(
-                        data=["CCO", "c1ccccc1", "CC(=O)O"]
-                    )
+                    mol_smiles_data=schema_pb2.MolSmilesArray(data=["CCO", "c1ccccc1", "CC(=O)O"])
                 ),
             )
         ]
@@ -583,11 +581,15 @@ class TestSearchResultExtended:
         assert hits[1].entity["mol"] == "c1ccccc1"
 
     def test_get_field_data_with_mol(self):
-        field_data = _make_scalar_field(DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=200)
+        field_data = _make_scalar_field(
+            DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=200
+        )
         assert get_field_data(field_data) == ["CCO", "c1ccccc1"]
 
     def test_extract_struct_field_value_with_mol(self):
-        field_data = _make_scalar_field(DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=201)
+        field_data = _make_scalar_field(
+            DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=201
+        )
         assert extract_struct_field_value(field_data, 0) == "CCO"
         assert extract_struct_field_value(field_data, 1) == "c1ccccc1"
 

--- a/tests/test_search_result.py
+++ b/tests/test_search_result.py
@@ -54,6 +54,9 @@ def _make_scalar_field(dtype, name, data, field_id=0, is_dynamic=False, valid_da
         DataType.GEOMETRY: lambda d: schema_pb2.ScalarField(
             geometry_wkt_data=schema_pb2.GeometryWktArray(data=d)
         ),
+        DataType.MOL: lambda d: schema_pb2.ScalarField(
+            mol_smiles_data=schema_pb2.MolSmilesArray(data=d)
+        ),
     }
     kwargs["scalars"] = scalar_map[dtype](data)
     return schema_pb2.FieldData(**kwargs)
@@ -557,6 +560,15 @@ class TestSearchResultExtended:
 
         assert hits[0].entity["geom"] == "POINT(1 1)"
         assert hits[1].entity["geom"] == "POINT(2 2)"
+
+    def test_get_field_data_with_mol(self):
+        field_data = _make_scalar_field(DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=200)
+        assert get_field_data(field_data) == ["CCO", "c1ccccc1"]
+
+    def test_extract_struct_field_value_with_mol(self):
+        field_data = _make_scalar_field(DataType.MOL, "mol_field", ["CCO", "c1ccccc1"], field_id=201)
+        assert extract_struct_field_value(field_data, 0) == "CCO"
+        assert extract_struct_field_value(field_data, 1) == "c1ccccc1"
 
     def test_search_result_extra_and_status(self):
         res_data = self._create_base_result()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -54,6 +54,10 @@ class TestTypes:
             assert str(v) == str(v.value)
             assert str(v) != v.name
 
+    def test_mol_data_type(self):
+        assert DataType.MOL.name == "MOL"
+        assert isinstance(DataType.MOL.value, int)
+
 
 class TestConsistencyLevel:
     def test_consistency_level_int(self):


### PR DESCRIPTION
## Summary
- expose `DataType.MOL` and `FunctionType.MOL_FINGERPRINT` in `pymilvus`
- support packing MOL scalar values on insert and decoding MOL scalar values from query/search results
- add focused tests for MOL type exposure, function schema validation, insert-path packing, result decoding, nullable scalar handling, and invalid input boundaries

## Dependencies
- Depends on `milvus-io/milvus-proto#554`

## Test plan
- [x] `PYTHONPATH=. python3 -m pytest --noconftest tests/test_types.py::TestTypes::test_mol_data_type tests/orm/test_schema.py::TestMolFunction tests/test_search_result.py::TestSearchResultExtended::test_mol tests/test_search_result.py::TestSearchResultExtended::test_get_field_data_with_mol tests/test_search_result.py::TestSearchResultExtended::test_extract_struct_field_value_with_mol tests/test_search_result.py::TestSearchResultExtended::test_null_values_all_scalar_types tests/test_client_types.py::TestFunctionType::test_function_type_values[MOL_FINGERPRINT-5] tests/test_client_entity_helper.py::TestEntityHelperExtended::test_pack_field_value_to_field_data_mol tests/test_client_entity_helper.py::TestEntityHelperExtended::test_pack_field_value_to_field_data_mol_invalid_input tests/test_client_entity_helper.py::TestEntityHelperExtended::test_entity_to_field_data_mol tests/test_client_entity_helper.py::TestEntityHelperExtended::test_entity_to_field_data_mol_invalid_input tests/test_client_entity_helper.py::TestEntityHelperExtended::test_extract_row_data_from_fields_data_v2_mol tests/test_client_entity_helper.py::TestEntityHelperExtended::test_extract_row_data_from_fields_data_mol tests/test_client_entity_helper.py::TestEntityHelperExtended::test_entity_to_field_data_nullable_mol tests/test_client_entity_helper.py::TestEntityHelperExtended::test_pack_field_value_nullable_mol_none -q -x`