### PR TITLE
fix: infer uuid.UUID and os.PathLike as VARCHAR in dtype inference

### DIFF
--- a/pymilvus/orm/types.py
+++ b/pymilvus/orm/types.py
@@ -10,6 +10,8 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 
+import os
+import uuid
 from typing import Any
 
 import numpy as np
@@ -92,6 +94,8 @@ def infer_dtype_by_scalar_data(data: Any, dtype: DataType = None):
         return DataType.VARCHAR
     if isinstance(data, bytes):
         return DataType.BINARY_VECTOR
+    if isinstance(data, (uuid.UUID, os.PathLike)):
+        return DataType.VARCHAR
 
     return DataType.UNKNOWN
 
@@ -100,6 +104,9 @@ def infer_dtype_bydata(data: Any):
     d_type = DataType.UNKNOWN
     if is_scalar(data):
         return infer_dtype_by_scalar_data(data)
+
+    if isinstance(data, (uuid.UUID, os.PathLike)):
+        return DataType.VARCHAR
 
     if isinstance(data, dict):
         return DataType.JSON
@@ -121,7 +128,7 @@ def infer_dtype_bydata(data: Any):
     if d_type == DataType.UNKNOWN:
         try:
             elem = data[0]
-        except IndexError:
+        except (IndexError, TypeError):
             elem = None
 
         if elem is not None and is_scalar(elem):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,6 +9,9 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under the License.
 
+import uuid
+from pathlib import PurePosixPath, PureWindowsPath
+
 import numpy as np
 import pytest
 from pymilvus import DataType
@@ -47,6 +50,19 @@ class TestTypes:
     def test_infer_dtype_bydata(self, data, expect):
         got = infer_dtype_bydata(data)
         assert got == expect
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            uuid.UUID("12345678-1234-5678-1234-567812345678"),
+            uuid.uuid4(),
+            PurePosixPath("/foo/bar"),
+            PureWindowsPath("C:/Users/foo"),
+        ],
+    )
+    def test_infer_dtype_bydata_uuid_and_pathlike(self, data):
+        """uuid.UUID and os.PathLike objects should infer as VARCHAR (issue #2917)."""
+        assert infer_dtype_bydata(data) == DataType.VARCHAR
 
     def test_str_of_data_type(self):
         for v in DataType:


### PR DESCRIPTION
## Summary

- `uuid.UUID` values returned `DataType.UNKNOWN` because `infer_dtype_by_scalar_data` had no branch for them (pandas considers UUID scalar, so `infer_dtype_bydata` delegates to `infer_dtype_by_scalar_data`, which fell through to `return DataType.UNKNOWN`).
- `os.PathLike` objects (e.g. `WindowsPath`, `PurePosixPath`) caused an unhandled `TypeError` crash in `infer_dtype_bydata` — only `IndexError` was caught on the `data[0]` subscript probe.

Both types represent string-serializable values and should map to `DataType.VARCHAR`.

issue: #2917

## Changes

**`pymilvus/orm/types.py`**
- Added `isinstance(data, (uuid.UUID, os.PathLike))` → `DataType.VARCHAR` in `infer_dtype_by_scalar_data`.
- Added the same guard near the top of `infer_dtype_bydata` (before the list/array branch) to catch PathLike objects that pandas does not consider scalar.
- Broadened the subscript probe `except` to catch `TypeError` in addition to `IndexError`.

**`tests/test_types.py`**
- Added `test_infer_dtype_bydata_uuid_and_pathlike` covering fixed UUID, PurePosixPath, and PureWindowsPath cases.

## Test plan

- [x] `python3 -m pytest tests/test_types.py` — 39 passed (35 pre-existing + 4 new)
- [x] All existing parametrized `test_infer_dtype_bydata` cases still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)