### PR TITLE
fix: return consistency_level as name string from describe_collection

### DIFF
--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -13,7 +13,7 @@ from .constants import DEFAULT_CONSISTENCY_LEVEL, RANKER_TYPE_RRF, RANKER_TYPE_W
 # ruff: noqa: F401
 # TODO: This is a patch for older version
 from .search_result import Hit, Hits, SearchResult
-from .types import DataType, FunctionType
+from .types import ConsistencyLevel, DataType, FunctionType
 
 logger = logging.getLogger(__name__)
 
@@ -327,7 +327,7 @@ class CollectionSchema:
             "functions": [f.dict() for f in self.functions],
             "aliases": self.aliases,
             "collection_id": self.collection_id,
-            "consistency_level": self.consistency_level,
+            "consistency_level": ConsistencyLevel.Name(self.consistency_level),
             "properties": self.properties,
             "num_partitions": self.num_partitions,
             "enable_dynamic_field": self.enable_dynamic_field,

--- a/tests/test_client_abstract.py
+++ b/tests/test_client_abstract.py
@@ -516,6 +516,24 @@ class TestCollectionSchema:
         assert "created_timestamp" not in d
         assert "update_timestamp" not in d
 
+    def test_collection_schema_dict_consistency_level_is_string(self):
+        """dict() must return consistency_level as a human-readable name, not an int (issue #2985)."""
+        from pymilvus.client.types import ConsistencyLevel
+
+        expected = {
+            ConsistencyLevel.Strong: "Strong",
+            ConsistencyLevel.Session: "Session",
+            ConsistencyLevel.Bounded: "Bounded",
+            ConsistencyLevel.Eventually: "Eventually",
+            ConsistencyLevel.Customized: "Customized",
+        }
+        for int_val, name in expected.items():
+            raw = self._create_mock_collection_raw(consistency_level=int_val)
+            d = CollectionSchema(raw).dict()
+            assert d["consistency_level"] == name, (
+                f"Expected '{name}' for level {int_val}, got {d['consistency_level']!r}"
+            )
+
     def test_collection_schema_rewrite_schema_dict(self):
         """Test CollectionSchema._rewrite_schema_dict method."""
         schema_dict = {

--- a/tests/test_client_abstract.py
+++ b/tests/test_client_abstract.py
@@ -27,7 +27,7 @@ from pymilvus.client.abstract import (
     WeightedRanker,
 )
 from pymilvus.client.constants import RANKER_TYPE_RRF, RANKER_TYPE_WEIGHTED
-from pymilvus.client.types import DataType, FunctionType
+from pymilvus.client.types import ConsistencyLevel, DataType, FunctionType
 from pymilvus.exceptions import DataTypeNotMatchException
 
 
@@ -518,8 +518,6 @@ class TestCollectionSchema:
 
     def test_collection_schema_dict_consistency_level_is_string(self):
         """dict() must return consistency_level as a human-readable name, not an int (issue #2985)."""
-        from pymilvus.client.types import ConsistencyLevel
-
         expected = {
             ConsistencyLevel.Strong: "Strong",
             ConsistencyLevel.Session: "Session",
@@ -530,9 +528,9 @@ class TestCollectionSchema:
         for int_val, name in expected.items():
             raw = self._create_mock_collection_raw(consistency_level=int_val)
             d = CollectionSchema(raw).dict()
-            assert d["consistency_level"] == name, (
-                f"Expected '{name}' for level {int_val}, got {d['consistency_level']!r}"
-            )
+            assert (
+                d["consistency_level"] == name
+            ), f"Expected '{name}' for level {int_val}, got {d['consistency_level']!r}"
 
     def test_collection_schema_rewrite_schema_dict(self):
         """Test CollectionSchema._rewrite_schema_dict method."""


### PR DESCRIPTION
## Summary

`CollectionSchema.dict()` exposed the raw protobuf integer for `consistency_level` (e.g. `0`) instead of its human-readable name (e.g. `"Strong"`), making the output of `describe_collection()` difficult to interpret without consulting the enum definition.

issue: #2985

## Changes

**`pymilvus/client/abstract.py`**
- Import `ConsistencyLevel` alongside `DataType` and `FunctionType`.
- In `CollectionSchema.dict()`, replace `self.consistency_level` with `ConsistencyLevel.Name(self.consistency_level)`.
- `self.consistency_level` keeps its integer value internally so existing search/query code paths that forward it to gRPC are unaffected.

**`tests/test_client_abstract.py`**
- Added `test_collection_schema_dict_consistency_level_is_string` covering all five enum values.

## Before / After

```python
# Before
client.describe_collection("my_col")
# {'consistency_level': 0, ...}

# After
client.describe_collection("my_col")
# {'consistency_level': 'Strong', ...}
```

## Test plan

- [x] `python3 -m pytest tests/test_client_abstract.py tests/test_types.py` — 116 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)