### PR TITLE
enhance: adapt snapshot APIs to latest milvus-proto

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -2498,6 +2498,8 @@ class AsyncGrpcHandler:
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
+        compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -2506,6 +2508,8 @@ class AsyncGrpcHandler:
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
+            compaction_protection_seconds=compaction_protection_seconds,
         )
         status = await self._async_stub.CreateSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -2516,11 +2520,17 @@ class AsyncGrpcHandler:
     async def drop_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> None:
-        request = Prepare.drop_snapshot_req(snapshot_name)
+        request = Prepare.drop_snapshot_req(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+        )
         status = await self._async_stub.DropSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -2530,11 +2540,12 @@ class AsyncGrpcHandler:
     async def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[str]:
-        request = Prepare.list_snapshots_req(collection_name=collection_name)
+        request = Prepare.list_snapshots_req(collection_name=collection_name, db_name=db_name)
         response = await self._async_stub.ListSnapshots(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -2547,11 +2558,17 @@ class AsyncGrpcHandler:
     async def describe_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> SnapshotInfo:
-        request = Prepare.describe_snapshot_req(snapshot_name)
+        request = Prepare.describe_snapshot_req(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+        )
         response = await self._async_stub.DescribeSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -2569,8 +2586,11 @@ class AsyncGrpcHandler:
     @retry_on_rpc_failure()
     async def restore_snapshot(
         self,
-        collection_name: str,
         snapshot_name: str,
+        target_collection_name: str,
+        source_collection_name: str = "",
+        target_db_name: str = "",
+        source_db_name: str = "",
         rewrite_data: bool = False,
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -2578,7 +2598,10 @@ class AsyncGrpcHandler:
     ) -> int:
         request = Prepare.restore_snapshot_req(
             snapshot_name=snapshot_name,
-            collection_name=collection_name,
+            target_collection_name=target_collection_name,
+            source_collection_name=source_collection_name,
+            target_db_name=target_db_name,
+            source_db_name=source_db_name,
             rewrite_data=rewrite_data,
         )
         response = await self._async_stub.RestoreSnapshot(
@@ -2618,11 +2641,14 @@ class AsyncGrpcHandler:
     async def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
-        request = Prepare.list_restore_snapshot_jobs_req(collection_name=collection_name)
+        request = Prepare.list_restore_snapshot_jobs_req(
+            collection_name=collection_name, db_name=db_name
+        )
         response = await self._async_stub.ListRestoreSnapshotJobs(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -2642,6 +2668,45 @@ class AsyncGrpcHandler:
             )
             for info in response.jobs
         ]
+
+    @retry_on_rpc_failure()
+    async def pin_snapshot_data(
+        self,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+        ttl_seconds: int = 0,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> int:
+        """Pin snapshot-referenced data to prevent GC (async). Returns pin_id."""
+        request = Prepare.pin_snapshot_data_req(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+            ttl_seconds=ttl_seconds,
+        )
+        response = await self._async_stub.PinSnapshotData(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return response.pin_id
+
+    @retry_on_rpc_failure()
+    async def unpin_snapshot_data(
+        self,
+        pin_id: int,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> None:
+        """Release a pin created by ``pin_snapshot_data`` (async)."""
+        request = Prepare.unpin_snapshot_data_req(pin_id=pin_id)
+        status = await self._async_stub.UnpinSnapshotData(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(status)
 
     @retry_on_rpc_failure()
     async def add_file_resource(

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -3211,6 +3211,8 @@ class GrpcHandler:
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
+        compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -3219,6 +3221,8 @@ class GrpcHandler:
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
+            compaction_protection_seconds=compaction_protection_seconds,
         )
         status = self._stub.CreateSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -3229,11 +3233,17 @@ class GrpcHandler:
     def drop_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> None:
-        request = Prepare.drop_snapshot_req(snapshot_name)
+        request = Prepare.drop_snapshot_req(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+        )
         status = self._stub.DropSnapshot(request, timeout=timeout, metadata=_api_level_md(context))
         check_status(status)
 
@@ -3241,11 +3251,12 @@ class GrpcHandler:
     def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[str]:
-        request = Prepare.list_snapshots_req(collection_name=collection_name)
+        request = Prepare.list_snapshots_req(collection_name=collection_name, db_name=db_name)
         response = self._stub.ListSnapshots(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -3258,11 +3269,17 @@ class GrpcHandler:
     def describe_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> SnapshotInfo:
-        request = Prepare.describe_snapshot_req(snapshot_name)
+        request = Prepare.describe_snapshot_req(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+        )
         response = self._stub.DescribeSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -3280,8 +3297,11 @@ class GrpcHandler:
     @retry_on_rpc_failure()
     def restore_snapshot(
         self,
-        collection_name: str,
         snapshot_name: str,
+        target_collection_name: str,
+        source_collection_name: str = "",
+        target_db_name: str = "",
+        source_db_name: str = "",
         rewrite_data: bool = False,
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -3289,7 +3309,10 @@ class GrpcHandler:
     ) -> int:
         request = Prepare.restore_snapshot_req(
             snapshot_name=snapshot_name,
-            collection_name=collection_name,
+            target_collection_name=target_collection_name,
+            source_collection_name=source_collection_name,
+            target_db_name=target_db_name,
+            source_db_name=source_db_name,
             rewrite_data=rewrite_data,
         )
         response = self._stub.RestoreSnapshot(
@@ -3331,11 +3354,14 @@ class GrpcHandler:
     def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
-        request = Prepare.list_restore_snapshot_jobs_req(collection_name=collection_name)
+        request = Prepare.list_restore_snapshot_jobs_req(
+            collection_name=collection_name, db_name=db_name
+        )
         response = self._stub.ListRestoreSnapshotJobs(
             request, timeout=timeout, metadata=_api_level_md(context)
         )
@@ -3355,6 +3381,45 @@ class GrpcHandler:
             )
             for info in response.jobs
         ]
+
+    @retry_on_rpc_failure()
+    def pin_snapshot_data(
+        self,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+        ttl_seconds: int = 0,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> int:
+        """Pin snapshot-referenced data to prevent GC. Returns a pin_id for later unpin."""
+        request = Prepare.pin_snapshot_data_req(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+            ttl_seconds=ttl_seconds,
+        )
+        response = self._stub.PinSnapshotData(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return response.pin_id
+
+    @retry_on_rpc_failure()
+    def unpin_snapshot_data(
+        self,
+        pin_id: int,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ) -> None:
+        """Release a pin created by ``pin_snapshot_data``."""
+        request = Prepare.unpin_snapshot_data_req(pin_id=pin_id)
+        status = self._stub.UnpinSnapshotData(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(status)
 
     @retry_on_rpc_failure()
     def add_file_resource(

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2660,6 +2660,8 @@ class Prepare:
         snapshot_name: str,
         collection_name: str = "",
         description: str = "",
+        db_name: str = "",
+        compaction_protection_seconds: int = 0,
     ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
@@ -2667,49 +2669,85 @@ class Prepare:
         if not validate_str(collection_name):
             msg = "collection_name must be a non-empty string"
             raise ParamError(message=msg)
+        if not isinstance(compaction_protection_seconds, int) or compaction_protection_seconds < 0:
+            msg = "compaction_protection_seconds must be a non-negative integer"
+            raise ParamError(message=msg)
         return milvus_types.CreateSnapshotRequest(
             name=snapshot_name,
+            db_name=db_name,
             collection_name=collection_name,
             description=description,
+            compaction_protection_seconds=compaction_protection_seconds,
         )
 
     @classmethod
-    def drop_snapshot_req(cls, snapshot_name: str):
+    def drop_snapshot_req(
+        cls,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+    ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
             raise ParamError(message=msg)
-        return milvus_types.DropSnapshotRequest(name=snapshot_name)
-
-    @classmethod
-    def list_snapshots_req(cls, collection_name: str = ""):
-        return milvus_types.ListSnapshotsRequest(
+        if not validate_str(collection_name):
+            msg = "collection_name must be a non-empty string"
+            raise ParamError(message=msg)
+        return milvus_types.DropSnapshotRequest(
+            name=snapshot_name,
+            db_name=db_name,
             collection_name=collection_name,
         )
 
     @classmethod
-    def describe_snapshot_req(cls, snapshot_name: str):
+    def list_snapshots_req(cls, collection_name: str = "", db_name: str = ""):
+        return milvus_types.ListSnapshotsRequest(
+            db_name=db_name,
+            collection_name=collection_name,
+        )
+
+    @classmethod
+    def describe_snapshot_req(
+        cls,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+    ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
             raise ParamError(message=msg)
-        return milvus_types.DescribeSnapshotRequest(name=snapshot_name)
+        if not validate_str(collection_name):
+            msg = "collection_name must be a non-empty string"
+            raise ParamError(message=msg)
+        return milvus_types.DescribeSnapshotRequest(
+            name=snapshot_name,
+            db_name=db_name,
+            collection_name=collection_name,
+        )
 
     @classmethod
     def restore_snapshot_req(
         cls,
         snapshot_name: str,
-        collection_name: str = "",
+        target_collection_name: str,
+        source_collection_name: str = "",
+        target_db_name: str = "",
+        source_db_name: str = "",
         rewrite_data: bool = False,
     ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
             raise ParamError(message=msg)
-        if not validate_str(collection_name):
-            msg = "collection_name must be a non-empty string"
+        if not validate_str(target_collection_name):
+            msg = "target_collection_name must be a non-empty string"
             raise ParamError(message=msg)
         return milvus_types.RestoreSnapshotRequest(
             name=snapshot_name,
-            collection_name=collection_name,
+            db_name=source_db_name,
+            collection_name=source_collection_name,
             rewrite_data=rewrite_data,
+            target_db_name=target_db_name,
+            target_collection_name=target_collection_name,
         )
 
     @classmethod
@@ -2720,8 +2758,39 @@ class Prepare:
         return milvus_types.GetRestoreSnapshotStateRequest(job_id=job_id)
 
     @classmethod
-    def list_restore_snapshot_jobs_req(cls, collection_name: str = ""):
-        return milvus_types.ListRestoreSnapshotJobsRequest(collection_name=collection_name)
+    def list_restore_snapshot_jobs_req(cls, collection_name: str = "", db_name: str = ""):
+        return milvus_types.ListRestoreSnapshotJobsRequest(
+            db_name=db_name,
+            collection_name=collection_name,
+        )
+
+    @classmethod
+    def pin_snapshot_data_req(
+        cls,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+        ttl_seconds: int = 0,
+    ):
+        if not validate_str(snapshot_name):
+            msg = "snapshot_name must be a non-empty string"
+            raise ParamError(message=msg)
+        if not isinstance(ttl_seconds, int) or ttl_seconds < 0:
+            msg = "ttl_seconds must be a non-negative integer"
+            raise ParamError(message=msg)
+        return milvus_types.PinSnapshotDataRequest(
+            name=snapshot_name,
+            db_name=db_name,
+            collection_name=collection_name,
+            ttl_seconds=ttl_seconds,
+        )
+
+    @classmethod
+    def unpin_snapshot_data_req(cls, pin_id: int):
+        if not isinstance(pin_id, int) or isinstance(pin_id, bool):
+            msg = "pin_id must be an integer"
+            raise ParamError(message=msg)
+        return milvus_types.UnpinSnapshotDataRequest(pin_id=pin_id)
 
     @classmethod
     def add_file_resource(cls, name: str, path: str):

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1970,6 +1970,8 @@ class AsyncMilvusClient(BaseMilvusClient):
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
+        compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -1979,6 +1981,10 @@ class AsyncMilvusClient(BaseMilvusClient):
             collection_name (str): The name of the collection to snapshot.
             snapshot_name (str): The name of the snapshot. Must be unique.
             description (str): Optional description for the snapshot.
+            db_name (str): Optional database name (defaults to active db).
+            compaction_protection_seconds (int): Duration in seconds during which the
+                snapshot-referenced segments are protected from compaction.
+                0 = no protection (default). Max 7 days (604800).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -1988,7 +1994,8 @@ class AsyncMilvusClient(BaseMilvusClient):
             >>> await client.create_snapshot(
             ...     collection_name="my_collection",
             ...     snapshot_name="backup_20240101",
-            ...     description="Daily backup"
+            ...     description="Daily backup",
+            ...     compaction_protection_seconds=3600,
             ... )
         """
         conn = await self._get_connection()
@@ -1996,6 +2003,8 @@ class AsyncMilvusClient(BaseMilvusClient):
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
+            compaction_protection_seconds=compaction_protection_seconds,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2004,6 +2013,8 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def drop_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str,
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -2011,12 +2022,17 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             snapshot_name (str): The name of the snapshot to drop.
+            collection_name (str): The collection the snapshot belongs to
+                (required for collection-level authorization).
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
         """
         conn = await self._get_connection()
         await conn.drop_snapshot(
             snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2025,6 +2041,7 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[str]:
@@ -2032,6 +2049,7 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             collection_name (str): Optional collection name to filter snapshots.
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2041,6 +2059,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = await self._get_connection()
         return await conn.list_snapshots(
             collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2049,6 +2068,8 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def describe_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str,
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> SnapshotInfo:
@@ -2056,6 +2077,9 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             snapshot_name (str): The name of the snapshot to describe.
+            collection_name (str): The collection the snapshot belongs to
+                (required for collection-level authorization).
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2065,6 +2089,8 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = await self._get_connection()
         return await conn.describe_snapshot(
             snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2073,7 +2099,11 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def restore_snapshot(
         self,
         snapshot_name: str,
-        collection_name: str,
+        target_collection_name: str,
+        source_collection_name: str = "",
+        target_db_name: str = "",
+        source_db_name: str = "",
+        rewrite_data: bool = False,
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
@@ -2081,8 +2111,14 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             snapshot_name (str): The name of the snapshot to restore.
-            collection_name (str): The name of the target collection to create.
-            timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
+            target_collection_name (str): The collection the snapshot will be restored into.
+                Validated server-side; an existing collection causes the restore job to fail.
+            source_collection_name (str): The collection the snapshot belongs to.
+                If empty, resolved from snapshot metadata server-side.
+            target_db_name (str): Target database name (defaults to active db).
+            source_db_name (str): Source database name (defaults to active db).
+            rewrite_data (bool): If True, use import to rewrite data to the target collection.
+            timeout (Optional[float]): Optional RPC timeout in seconds.
             **kwargs: Additional arguments.
 
         Returns:
@@ -2091,8 +2127,11 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = await self._get_connection()
         return await conn.restore_snapshot(
             snapshot_name=snapshot_name,
-            collection_name=collection_name,
-            rewrite_data=False,
+            target_collection_name=target_collection_name,
+            source_collection_name=source_collection_name,
+            target_db_name=target_db_name,
+            source_db_name=source_db_name,
+            rewrite_data=rewrite_data,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2125,6 +2164,7 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
@@ -2132,6 +2172,7 @@ class AsyncMilvusClient(BaseMilvusClient):
 
         Args:
             collection_name (str): Optional collection name to filter jobs.
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2141,6 +2182,47 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = await self._get_connection()
         return await conn.list_restore_snapshot_jobs(
             collection_name=collection_name,
+            db_name=db_name,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    async def pin_snapshot_data(
+        self,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+        ttl_seconds: int = 0,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> int:
+        """Pin snapshot data to prevent GC during backup/copy (async).
+
+        Returns:
+            int: The pin_id. Pass to ``unpin_snapshot_data`` to release.
+        """
+        conn = await self._get_connection()
+        return await conn.pin_snapshot_data(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+            ttl_seconds=ttl_seconds,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    async def unpin_snapshot_data(
+        self,
+        pin_id: int,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> None:
+        """Release a pin created by ``pin_snapshot_data`` (async)."""
+        conn = await self._get_connection()
+        await conn.unpin_snapshot_data(
+            pin_id=pin_id,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2592,6 +2592,8 @@ class MilvusClient(BaseMilvusClient):
         collection_name: str,
         snapshot_name: str,
         description: str = "",
+        db_name: str = "",
+        compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -2601,6 +2603,10 @@ class MilvusClient(BaseMilvusClient):
             collection_name (str): The name of the collection to snapshot.
             snapshot_name (str): The name of the snapshot. Must be unique.
             description (str): Optional description for the snapshot.
+            db_name (str): Optional database name (defaults to active db).
+            compaction_protection_seconds (int): Duration in seconds during which the
+                segments referenced by this snapshot are protected from compaction.
+                0 = no protection (default). Max 7 days (604800).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2615,7 +2621,8 @@ class MilvusClient(BaseMilvusClient):
             >>> client.create_snapshot(
             ...     collection_name="my_collection",
             ...     snapshot_name="backup_20240101",
-            ...     description="Daily backup"
+            ...     description="Daily backup",
+            ...     compaction_protection_seconds=3600,
             ... )
         """
         conn = self._get_connection()
@@ -2623,6 +2630,8 @@ class MilvusClient(BaseMilvusClient):
             snapshot_name=snapshot_name,
             collection_name=collection_name,
             description=description,
+            db_name=db_name,
+            compaction_protection_seconds=compaction_protection_seconds,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2631,6 +2640,8 @@ class MilvusClient(BaseMilvusClient):
     def drop_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str,
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> None:
@@ -2638,6 +2649,9 @@ class MilvusClient(BaseMilvusClient):
 
         Args:
             snapshot_name (str): The name of the snapshot to drop.
+            collection_name (str): The collection the snapshot belongs to
+                (required for collection-level authorization).
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2645,11 +2659,16 @@ class MilvusClient(BaseMilvusClient):
             MilvusException: If the operation fails.
 
         Example:
-            >>> client.drop_snapshot(snapshot_name="backup_20240101")
+            >>> client.drop_snapshot(
+            ...     snapshot_name="backup_20240101",
+            ...     collection_name="my_collection",
+            ... )
         """
         conn = self._get_connection()
         conn.drop_snapshot(
             snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2658,6 +2677,7 @@ class MilvusClient(BaseMilvusClient):
     def list_snapshots(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[str]:
@@ -2666,6 +2686,7 @@ class MilvusClient(BaseMilvusClient):
         Args:
             collection_name (str): Optional collection name to filter snapshots.
                 If empty, lists all snapshots.
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2684,6 +2705,7 @@ class MilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return conn.list_snapshots(
             collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2692,6 +2714,8 @@ class MilvusClient(BaseMilvusClient):
     def describe_snapshot(
         self,
         snapshot_name: str,
+        collection_name: str,
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> SnapshotInfo:
@@ -2699,6 +2723,9 @@ class MilvusClient(BaseMilvusClient):
 
         Args:
             snapshot_name (str): The name of the snapshot to describe.
+            collection_name (str): The collection the snapshot belongs to
+                (required for collection-level authorization).
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2715,7 +2742,10 @@ class MilvusClient(BaseMilvusClient):
             MilvusException: If the operation fails.
 
         Example:
-            >>> info = client.describe_snapshot(snapshot_name="backup_20240101")
+            >>> info = client.describe_snapshot(
+            ...     snapshot_name="backup_20240101",
+            ...     collection_name="my_collection",
+            ... )
             >>> print(f"Snapshot: {info.name}")
             >>> print(f"Collection: {info.collection_name}")
             >>> print(f"Created: {info.create_ts}")
@@ -2723,6 +2753,8 @@ class MilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return conn.describe_snapshot(
             snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2731,18 +2763,28 @@ class MilvusClient(BaseMilvusClient):
     def restore_snapshot(
         self,
         snapshot_name: str,
-        collection_name: str,
+        target_collection_name: str,
+        source_collection_name: str = "",
+        target_db_name: str = "",
+        source_db_name: str = "",
+        rewrite_data: bool = False,
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
-        """Restore a snapshot to a new collection.
+        """Restore a snapshot to a new (possibly cross-db / cross-collection) collection.
 
         This operation is asynchronous and returns a job ID for tracking progress.
         Use get_restore_snapshot_state() to monitor the restore progress.
 
         Args:
             snapshot_name (str): The name of the snapshot to restore.
-            collection_name (str): The name of the target collection to create.
+            target_collection_name (str): The collection the snapshot will be restored into.
+                Validated server-side; an existing collection causes the restore job to fail.
+            source_collection_name (str): The collection the snapshot belongs to.
+                If empty, the server resolves it from the snapshot metadata.
+            target_db_name (str): Target database name (defaults to active db).
+            source_db_name (str): Source database name (defaults to active db).
+            rewrite_data (bool): If True, use import to rewrite data to the target collection.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2755,27 +2797,19 @@ class MilvusClient(BaseMilvusClient):
         Example:
             >>> job_id = client.restore_snapshot(
             ...     snapshot_name="backup_20240101",
-            ...     collection_name="restored_collection"
+            ...     target_collection_name="restored_collection",
+            ...     source_collection_name="my_collection",
             ... )
             >>> print(f"Restore job ID: {job_id}")
-            >>> # Monitor progress
-            >>> import time
-            >>> while True:
-            ...     state = client.get_restore_snapshot_state(job_id=job_id)
-            ...     if state.state == "RestoreSnapshotCompleted":
-            ...         print("Restore completed!")
-            ...         break
-            ...     elif state.state == "RestoreSnapshotFailed":
-            ...         print(f"Restore failed: {state.reason}")
-            ...         break
-            ...     print(f"Progress: {state.progress}%")
-            ...     time.sleep(1)
         """
         conn = self._get_connection()
         return conn.restore_snapshot(
             snapshot_name=snapshot_name,
-            collection_name=collection_name,
-            rewrite_data=False,
+            target_collection_name=target_collection_name,
+            source_collection_name=source_collection_name,
+            target_db_name=target_db_name,
+            source_db_name=source_db_name,
+            rewrite_data=rewrite_data,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2831,6 +2865,7 @@ class MilvusClient(BaseMilvusClient):
     def list_restore_snapshot_jobs(
         self,
         collection_name: str = "",
+        db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> List[RestoreSnapshotJobInfo]:
@@ -2839,6 +2874,7 @@ class MilvusClient(BaseMilvusClient):
         Args:
             collection_name (str): Optional collection name to filter jobs.
                 If empty, lists all restore jobs.
+            db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2858,6 +2894,70 @@ class MilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         return conn.list_restore_snapshot_jobs(
             collection_name=collection_name,
+            db_name=db_name,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    def pin_snapshot_data(
+        self,
+        snapshot_name: str,
+        collection_name: str = "",
+        db_name: str = "",
+        ttl_seconds: int = 0,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> int:
+        """Pin snapshot data to prevent GC while copying out (e.g. during backup).
+
+        Args:
+            snapshot_name (str): The name of the snapshot to pin.
+            collection_name (str): The collection the snapshot belongs to.
+            db_name (str): Optional database name.
+            ttl_seconds (int): Pin TTL in seconds. 0 uses the server default.
+            timeout (Optional[float]): Optional RPC timeout in seconds.
+            **kwargs: Additional arguments.
+
+        Returns:
+            int: The pin_id. Pass this to ``unpin_snapshot_data`` to release the pin.
+
+        Example:
+            >>> pin_id = client.pin_snapshot_data(
+            ...     snapshot_name="backup_20240101",
+            ...     collection_name="my_collection",
+            ...     ttl_seconds=3600,
+            ... )
+            >>> # ... copy snapshot data out ...
+            >>> client.unpin_snapshot_data(pin_id=pin_id)
+        """
+        conn = self._get_connection()
+        return conn.pin_snapshot_data(
+            snapshot_name=snapshot_name,
+            collection_name=collection_name,
+            db_name=db_name,
+            ttl_seconds=ttl_seconds,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    def unpin_snapshot_data(
+        self,
+        pin_id: int,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> None:
+        """Release a pin created by ``pin_snapshot_data``.
+
+        Args:
+            pin_id (int): The pin_id returned by ``pin_snapshot_data``.
+            timeout (Optional[float]): Optional RPC timeout in seconds.
+            **kwargs: Additional arguments.
+        """
+        conn = self._get_connection()
+        conn.unpin_snapshot_data(
+            pin_id=pin_id,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/tests/async_grpc_handler/test_async_snapshot.py
+++ b/tests/async_grpc_handler/test_async_snapshot.py
@@ -51,6 +51,8 @@ class TestAsyncGrpcHandlerSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="test_collection",
                 description="test description",
+                db_name="",
+                compaction_protection_seconds=0,
             )
 
     @pytest.mark.asyncio
@@ -79,9 +81,17 @@ class TestAsyncGrpcHandlerSnapshot:
             mock_request = MagicMock()
             mock_prepare.drop_snapshot_req.return_value = mock_request
 
-            await handler.drop_snapshot(snapshot_name="test_snapshot", timeout=30)
+            await handler.drop_snapshot(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                timeout=30,
+            )
 
-            mock_prepare.drop_snapshot_req.assert_called_once_with("test_snapshot")
+            mock_prepare.drop_snapshot_req.assert_called_once_with(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                db_name="",
+            )
 
     @pytest.mark.asyncio
     async def test_list_snapshots(self) -> None:
@@ -118,7 +128,7 @@ class TestAsyncGrpcHandlerSnapshot:
             result = await handler.list_snapshots(collection_name="test_collection", timeout=30)
 
             mock_prepare.list_snapshots_req.assert_called_once_with(
-                collection_name="test_collection"
+                collection_name="test_collection", db_name=""
             )
             assert len(result) == 2
 
@@ -156,9 +166,17 @@ class TestAsyncGrpcHandlerSnapshot:
             mock_request = MagicMock()
             mock_prepare.describe_snapshot_req.return_value = mock_request
 
-            result = await handler.describe_snapshot(snapshot_name="test_snapshot", timeout=30)
+            result = await handler.describe_snapshot(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                timeout=30,
+            )
 
-            mock_prepare.describe_snapshot_req.assert_called_once_with("test_snapshot")
+            mock_prepare.describe_snapshot_req.assert_called_once_with(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                db_name="",
+            )
             assert result.name == "test_snapshot"
             assert result.description == "test description"
             assert result.collection_name == "test_collection"
@@ -194,13 +212,19 @@ class TestAsyncGrpcHandlerSnapshot:
 
             job_id = await handler.restore_snapshot(
                 snapshot_name="test_snapshot",
-                collection_name="new_collection",
+                target_collection_name="new_collection",
+                source_collection_name="source_collection",
                 rewrite_data=False,
                 timeout=30,
             )
 
             mock_prepare.restore_snapshot_req.assert_called_once_with(
-                snapshot_name="test_snapshot", collection_name="new_collection", rewrite_data=False
+                snapshot_name="test_snapshot",
+                target_collection_name="new_collection",
+                source_collection_name="source_collection",
+                target_db_name="",
+                source_db_name="",
+                rewrite_data=False,
             )
             assert job_id == 12345
 
@@ -314,8 +338,80 @@ class TestAsyncGrpcHandlerSnapshot:
             )
 
             mock_prepare.list_restore_snapshot_jobs_req.assert_called_once_with(
-                collection_name="test_collection"
+                collection_name="test_collection", db_name=""
             )
             assert len(result) == 2
             assert result[0].job_id == 1
             assert result[1].job_id == 2
+
+    @pytest.mark.asyncio
+    async def test_pin_snapshot_data(self) -> None:
+        """Test pin_snapshot_data async API"""
+        mock_channel = MagicMock()
+        mock_channel.channel_ready = AsyncMock()
+        mock_channel.close = AsyncMock()
+        mock_channel._unary_unary_interceptors = []
+
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+
+        mock_stub = AsyncMock()
+        handler._async_stub = mock_stub
+
+        mock_response = MagicMock()
+        mock_status = MagicMock()
+        mock_status.code = 0
+        mock_status.error_code = 0
+        mock_status.reason = ""
+        mock_response.status = mock_status
+        mock_response.pin_id = 42
+        mock_stub.PinSnapshotData = AsyncMock(return_value=mock_response)
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_status"
+        ):
+            mock_prepare.pin_snapshot_data_req.return_value = MagicMock()
+
+            pin_id = await handler.pin_snapshot_data(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                ttl_seconds=60,
+                timeout=30,
+            )
+
+            mock_prepare.pin_snapshot_data_req.assert_called_once_with(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                db_name="",
+                ttl_seconds=60,
+            )
+            assert pin_id == 42
+
+    @pytest.mark.asyncio
+    async def test_unpin_snapshot_data(self) -> None:
+        """Test unpin_snapshot_data async API"""
+        mock_channel = MagicMock()
+        mock_channel.channel_ready = AsyncMock()
+        mock_channel.close = AsyncMock()
+        mock_channel._unary_unary_interceptors = []
+
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+
+        mock_stub = AsyncMock()
+        handler._async_stub = mock_stub
+
+        mock_status = MagicMock()
+        mock_status.code = 0
+        mock_status.error_code = 0
+        mock_status.reason = ""
+        mock_stub.UnpinSnapshotData = AsyncMock(return_value=mock_status)
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_status"
+        ):
+            mock_prepare.unpin_snapshot_data_req.return_value = MagicMock()
+
+            await handler.unpin_snapshot_data(pin_id=42, timeout=30)
+
+            mock_prepare.unpin_snapshot_data_req.assert_called_once_with(pin_id=42)

--- a/tests/grpc_handler/test_snapshot.py
+++ b/tests/grpc_handler/test_snapshot.py
@@ -10,13 +10,26 @@ class TestGrpcHandlerSnapshotOps:
 
     def test_create_snapshot(self, handler):
         handler._stub.CreateSnapshot.return_value = make_status()
-        handler.create_snapshot("snap", "coll", "desc")
+        handler.create_snapshot("coll", "snap", "desc")
         handler._stub.CreateSnapshot.assert_called_once()
+        req = handler._stub.CreateSnapshot.call_args[0][0]
+        assert req.collection_name == "coll"
+        assert req.name == "snap"
+        assert req.compaction_protection_seconds == 0
+
+    def test_create_snapshot_with_compaction_protection(self, handler):
+        handler._stub.CreateSnapshot.return_value = make_status()
+        handler.create_snapshot("coll", "snap", "desc", compaction_protection_seconds=3600)
+        req = handler._stub.CreateSnapshot.call_args[0][0]
+        assert req.compaction_protection_seconds == 3600
 
     def test_drop_snapshot(self, handler):
         handler._stub.DropSnapshot.return_value = make_status()
-        handler.drop_snapshot("snap")
+        handler.drop_snapshot("snap", collection_name="coll")
         handler._stub.DropSnapshot.assert_called_once()
+        req = handler._stub.DropSnapshot.call_args[0][0]
+        assert req.name == "snap"
+        assert req.collection_name == "coll"
 
     def test_list_snapshots(self, handler):
         mock_snap = MagicMock(name="snap1")
@@ -36,13 +49,38 @@ class TestGrpcHandlerSnapshotOps:
         mock_resp.create_ts = 123
         mock_resp.s3_location = "s3://bucket"
         handler._stub.DescribeSnapshot.return_value = mock_resp
-        result = handler.describe_snapshot("snap")
+        result = handler.describe_snapshot("snap", collection_name="coll")
         assert result is not None
+        req = handler._stub.DescribeSnapshot.call_args[0][0]
+        assert req.name == "snap"
+        assert req.collection_name == "coll"
 
     def test_restore_snapshot(self, handler):
         handler._stub.RestoreSnapshot.return_value = make_response(job_id=123)
-        result = handler.restore_snapshot("snap", "coll")
+        result = handler.restore_snapshot(
+            snapshot_name="snap",
+            target_collection_name="new_coll",
+            source_collection_name="src_coll",
+        )
         assert result == 123
+        req = handler._stub.RestoreSnapshot.call_args[0][0]
+        assert req.name == "snap"
+        assert req.target_collection_name == "new_coll"
+        assert req.collection_name == "src_coll"
+
+    def test_pin_snapshot_data(self, handler):
+        handler._stub.PinSnapshotData.return_value = make_response(pin_id=42)
+        pin_id = handler.pin_snapshot_data("snap", collection_name="coll", ttl_seconds=60)
+        assert pin_id == 42
+        req = handler._stub.PinSnapshotData.call_args[0][0]
+        assert req.name == "snap"
+        assert req.ttl_seconds == 60
+
+    def test_unpin_snapshot_data(self, handler):
+        handler._stub.UnpinSnapshotData.return_value = make_status()
+        handler.unpin_snapshot_data(pin_id=42)
+        req = handler._stub.UnpinSnapshotData.call_args[0][0]
+        assert req.pin_id == 42
 
     def test_get_restore_snapshot_state(self, handler):
         mock_resp = MagicMock()
@@ -76,5 +114,5 @@ class TestGrpcHandlerSnapshotOps:
 
     def test_create_snapshot_with_partitions(self, handler):
         handler._stub.CreateSnapshot.return_value = make_status()
-        handler.create_snapshot("snap", "coll", "desc", partition_names=["p1", "p2"])
+        handler.create_snapshot("coll", "snap", "desc", partition_names=["p1", "p2"])
         handler._stub.CreateSnapshot.assert_called_once()

--- a/tests/prepare/test_coverage_gaps.py
+++ b/tests/prepare/test_coverage_gaps.py
@@ -304,10 +304,13 @@ class TestSnapshotRequests:
 
     def test_create_snapshot(self):
         """Test create snapshot request."""
-        req = Prepare.create_snapshot_req("snap1", "test_coll", "description")
+        req = Prepare.create_snapshot_req(
+            "snap1", "test_coll", "description", compaction_protection_seconds=3600
+        )
         assert req.name == "snap1"
         assert req.collection_name == "test_coll"
         assert req.description == "description"
+        assert req.compaction_protection_seconds == 3600
 
     def test_create_snapshot_invalid_name(self):
         """Test create snapshot with invalid name."""
@@ -319,15 +322,26 @@ class TestSnapshotRequests:
         with pytest.raises(ParamError):
             Prepare.create_snapshot_req("snap1", "")
 
+    def test_create_snapshot_invalid_compaction_seconds(self):
+        """Test create snapshot with negative compaction_protection_seconds."""
+        with pytest.raises(ParamError):
+            Prepare.create_snapshot_req("snap1", "test_coll", compaction_protection_seconds=-1)
+
     def test_drop_snapshot(self):
         """Test drop snapshot request."""
-        req = Prepare.drop_snapshot_req("snap1")
+        req = Prepare.drop_snapshot_req("snap1", collection_name="test_coll")
         assert req.name == "snap1"
+        assert req.collection_name == "test_coll"
 
     def test_drop_snapshot_invalid_name(self):
         """Test drop snapshot with invalid name."""
         with pytest.raises(ParamError):
-            Prepare.drop_snapshot_req("")
+            Prepare.drop_snapshot_req("", collection_name="test_coll")
+
+    def test_drop_snapshot_invalid_collection(self):
+        """Test drop snapshot with missing collection."""
+        with pytest.raises(ParamError):
+            Prepare.drop_snapshot_req("snap1", collection_name="")
 
     def test_list_snapshots(self):
         """Test list snapshots request."""
@@ -336,30 +350,46 @@ class TestSnapshotRequests:
 
     def test_describe_snapshot(self):
         """Test describe snapshot request."""
-        req = Prepare.describe_snapshot_req("snap1")
+        req = Prepare.describe_snapshot_req("snap1", collection_name="test_coll")
         assert req.name == "snap1"
+        assert req.collection_name == "test_coll"
 
     def test_describe_snapshot_invalid_name(self):
         """Test describe snapshot with invalid name."""
         with pytest.raises(ParamError):
-            Prepare.describe_snapshot_req("")
+            Prepare.describe_snapshot_req("", collection_name="test_coll")
+
+    def test_describe_snapshot_invalid_collection(self):
+        """Test describe snapshot with missing collection."""
+        with pytest.raises(ParamError):
+            Prepare.describe_snapshot_req("snap1", collection_name="")
 
     def test_restore_snapshot(self):
-        """Test restore snapshot request."""
-        req = Prepare.restore_snapshot_req("snap1", "test_coll", rewrite_data=True)
+        """Test restore snapshot request with full cross-collection parameters."""
+        req = Prepare.restore_snapshot_req(
+            snapshot_name="snap1",
+            target_collection_name="new_coll",
+            source_collection_name="src_coll",
+            target_db_name="tgt_db",
+            source_db_name="src_db",
+            rewrite_data=True,
+        )
         assert req.name == "snap1"
-        assert req.collection_name == "test_coll"
+        assert req.target_collection_name == "new_coll"
+        assert req.collection_name == "src_coll"
+        assert req.target_db_name == "tgt_db"
+        assert req.db_name == "src_db"
         assert req.rewrite_data is True
 
     def test_restore_snapshot_invalid_name(self):
         """Test restore snapshot with invalid name."""
         with pytest.raises(ParamError):
-            Prepare.restore_snapshot_req("", "test_coll")
+            Prepare.restore_snapshot_req("", target_collection_name="test_coll")
 
-    def test_restore_snapshot_invalid_collection(self):
-        """Test restore snapshot with invalid collection."""
+    def test_restore_snapshot_invalid_target_collection(self):
+        """Test restore snapshot with missing target collection."""
         with pytest.raises(ParamError):
-            Prepare.restore_snapshot_req("snap1", "")
+            Prepare.restore_snapshot_req("snap1", target_collection_name="")
 
     def test_get_restore_snapshot_state(self):
         """Test get restore snapshot state."""
@@ -375,6 +405,37 @@ class TestSnapshotRequests:
         """Test list restore snapshot jobs."""
         req = Prepare.list_restore_snapshot_jobs_req("test_coll")
         assert req.collection_name == "test_coll"
+
+    def test_pin_snapshot_data(self):
+        """Test pin snapshot data request."""
+        req = Prepare.pin_snapshot_data_req(
+            snapshot_name="snap1",
+            collection_name="test_coll",
+            ttl_seconds=60,
+        )
+        assert req.name == "snap1"
+        assert req.collection_name == "test_coll"
+        assert req.ttl_seconds == 60
+
+    def test_pin_snapshot_data_invalid_ttl(self):
+        """Test pin snapshot data with negative ttl."""
+        with pytest.raises(ParamError):
+            Prepare.pin_snapshot_data_req(snapshot_name="snap1", ttl_seconds=-1)
+
+    def test_unpin_snapshot_data(self):
+        """Test unpin snapshot data request."""
+        req = Prepare.unpin_snapshot_data_req(pin_id=42)
+        assert req.pin_id == 42
+
+    def test_unpin_snapshot_data_zero(self):
+        """pin_id=0 is a valid integer; server decides semantics."""
+        req = Prepare.unpin_snapshot_data_req(pin_id=0)
+        assert req.pin_id == 0
+
+    def test_unpin_snapshot_data_invalid(self):
+        """Test unpin snapshot data with non-int pin_id."""
+        with pytest.raises(ParamError):
+            Prepare.unpin_snapshot_data_req(pin_id="42")
 
 
 class TestExternalCollectionRequests:

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -918,6 +918,42 @@ class TestAsyncMilvusClientSnapshot:
         if return_value is not None:
             assert result == return_value
 
+    @pytest.mark.asyncio
+    async def test_pin_snapshot_data(self, client_and_handler):
+        """Test async pin_snapshot_data passes context."""
+        client, mock_handler = client_and_handler
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler.pin_snapshot_data = AsyncMock(return_value=42)
+
+        pin_id = await client.pin_snapshot_data(
+            snapshot_name="test_snapshot",
+            collection_name="test_collection",
+            ttl_seconds=60,
+        )
+
+        assert pin_id == 42
+        mock_handler.pin_snapshot_data.assert_called_once_with(
+            snapshot_name="test_snapshot",
+            collection_name="test_collection",
+            db_name="",
+            ttl_seconds=60,
+            timeout=None,
+            context=ANY,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unpin_snapshot_data(self, client_and_handler):
+        """Test async unpin_snapshot_data passes context."""
+        client, mock_handler = client_and_handler
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler.unpin_snapshot_data = AsyncMock(return_value=None)
+
+        await client.unpin_snapshot_data(pin_id=42)
+
+        mock_handler.unpin_snapshot_data.assert_called_once_with(
+            pin_id=42, timeout=None, context=ANY
+        )
+
 
 class TestAsyncFileResourceMethods:
     """Tests for async file_resource API methods with context passing."""

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -684,6 +684,8 @@ _SNAPSHOT_CASES = [
             "snapshot_name": "test_snapshot",
             "collection_name": "test_collection",
             "description": "Test description",
+            "db_name": "",
+            "compaction_protection_seconds": 0,
             "timeout": None,
             "context": ANY,
         },
@@ -692,24 +694,42 @@ _SNAPSHOT_CASES = [
     ),
     (
         "drop_snapshot",
-        {"snapshot_name": "test_snapshot"},
-        {"snapshot_name": "test_snapshot", "timeout": None, "context": ANY},
+        {"snapshot_name": "test_snapshot", "collection_name": "test_collection"},
+        {
+            "snapshot_name": "test_snapshot",
+            "collection_name": "test_collection",
+            "db_name": "",
+            "timeout": None,
+            "context": ANY,
+        },
         None,
         None,
     ),
     (
         "list_snapshots",
         {"collection_name": "test_collection"},
-        {"collection_name": "test_collection", "timeout": None, "context": ANY},
+        {
+            "collection_name": "test_collection",
+            "db_name": "",
+            "timeout": None,
+            "context": ANY,
+        },
         ["snapshot1", "snapshot2"],
         None,
     ),
     (
         "restore_snapshot",
-        {"snapshot_name": "test_snapshot", "collection_name": "restored_collection"},
         {
             "snapshot_name": "test_snapshot",
-            "collection_name": "restored_collection",
+            "target_collection_name": "restored_collection",
+            "source_collection_name": "test_collection",
+        },
+        {
+            "snapshot_name": "test_snapshot",
+            "target_collection_name": "restored_collection",
+            "source_collection_name": "test_collection",
+            "target_db_name": "",
+            "source_db_name": "",
             "rewrite_data": False,
             "timeout": None,
             "context": ANY,
@@ -727,7 +747,12 @@ _SNAPSHOT_CASES = [
     (
         "list_restore_snapshot_jobs",
         {"collection_name": "test_collection"},
-        {"collection_name": "test_collection", "timeout": None, "context": ANY},
+        {
+            "collection_name": "test_collection",
+            "db_name": "",
+            "timeout": None,
+            "context": ANY,
+        },
         [],
         None,
     ),
@@ -752,11 +777,17 @@ class TestAsyncMilvusClientSnapshot:
         mock_handler.get_server_type.return_value = "milvus"
         mock_handler.describe_snapshot = AsyncMock(return_value=mock_info)
 
-        info = await client.describe_snapshot(snapshot_name="test_snapshot")
+        info = await client.describe_snapshot(
+            snapshot_name="test_snapshot", collection_name="test_collection"
+        )
 
         assert info.name == "test_snapshot"
         mock_handler.describe_snapshot.assert_called_once_with(
-            snapshot_name="test_snapshot", timeout=None, context=ANY
+            snapshot_name="test_snapshot",
+            collection_name="test_collection",
+            db_name="",
+            timeout=None,
+            context=ANY,
         )
 
     @pytest.mark.asyncio
@@ -799,6 +830,8 @@ class TestAsyncMilvusClientSnapshot:
                     "snapshot_name": "test_snapshot",
                     "collection_name": "test_collection",
                     "description": "Test description",
+                    "db_name": "",
+                    "compaction_protection_seconds": 0,
                     "timeout": None,
                     "context": ANY,
                 },
@@ -806,22 +839,40 @@ class TestAsyncMilvusClientSnapshot:
             ),
             (
                 "drop_snapshot",
-                {"snapshot_name": "test_snapshot"},
-                {"snapshot_name": "test_snapshot", "timeout": None, "context": ANY},
+                {"snapshot_name": "test_snapshot", "collection_name": "test_collection"},
+                {
+                    "snapshot_name": "test_snapshot",
+                    "collection_name": "test_collection",
+                    "db_name": "",
+                    "timeout": None,
+                    "context": ANY,
+                },
                 None,
             ),
             (
                 "list_snapshots",
                 {"collection_name": "test_collection"},
-                {"collection_name": "test_collection", "timeout": None, "context": ANY},
+                {
+                    "collection_name": "test_collection",
+                    "db_name": "",
+                    "timeout": None,
+                    "context": ANY,
+                },
                 ["snapshot1", "snapshot2"],
             ),
             (
                 "restore_snapshot",
-                {"snapshot_name": "test_snapshot", "collection_name": "restored_collection"},
                 {
                     "snapshot_name": "test_snapshot",
-                    "collection_name": "restored_collection",
+                    "target_collection_name": "restored_collection",
+                    "source_collection_name": "test_collection",
+                },
+                {
+                    "snapshot_name": "test_snapshot",
+                    "target_collection_name": "restored_collection",
+                    "source_collection_name": "test_collection",
+                    "target_db_name": "",
+                    "source_db_name": "",
                     "rewrite_data": False,
                     "timeout": None,
                     "context": ANY,
@@ -831,7 +882,12 @@ class TestAsyncMilvusClientSnapshot:
             (
                 "list_restore_snapshot_jobs",
                 {"collection_name": "test_collection"},
-                {"collection_name": "test_collection", "timeout": None, "context": ANY},
+                {
+                    "collection_name": "test_collection",
+                    "db_name": "",
+                    "timeout": None,
+                    "context": ANY,
+                },
                 [],
             ),
         ],

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -226,6 +226,8 @@ class TestMilvusClientSnapshot:
                 snapshot_name="test_snapshot",
                 collection_name="test_collection",
                 description="Test description",
+                db_name="",
+                compaction_protection_seconds=0,
                 timeout=None,
                 context=ANY,
             )
@@ -258,10 +260,14 @@ class TestMilvusClientSnapshot:
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
             client = MilvusClient()
 
-            client.drop_snapshot(snapshot_name="test_snapshot")
+            client.drop_snapshot(snapshot_name="test_snapshot", collection_name="test_collection")
 
             mock_handler.drop_snapshot.assert_called_once_with(
-                snapshot_name="test_snapshot", timeout=None, context=ANY
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                db_name="",
+                timeout=None,
+                context=ANY,
             )
 
     def test_list_snapshots(self):
@@ -278,7 +284,7 @@ class TestMilvusClientSnapshot:
 
             assert snapshots == ["snapshot1", "snapshot2"]
             mock_handler.list_snapshots.assert_called_once_with(
-                collection_name="test_collection", timeout=None, context=ANY
+                collection_name="test_collection", db_name="", timeout=None, context=ANY
             )
 
     def test_list_snapshots_all(self):
@@ -315,7 +321,9 @@ class TestMilvusClientSnapshot:
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
             client = MilvusClient()
 
-            info = client.describe_snapshot(snapshot_name="test_snapshot")
+            info = client.describe_snapshot(
+                snapshot_name="test_snapshot", collection_name="test_collection"
+            )
 
             assert info.name == "test_snapshot"
             assert info.description == "Test description"
@@ -325,7 +333,11 @@ class TestMilvusClientSnapshot:
             assert info.s3_location == "s3://bucket/path"
 
             mock_handler.describe_snapshot.assert_called_once_with(
-                snapshot_name="test_snapshot", timeout=None, context=ANY
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                db_name="",
+                timeout=None,
+                context=ANY,
             )
 
     def test_restore_snapshot(self):
@@ -339,13 +351,18 @@ class TestMilvusClientSnapshot:
             client = MilvusClient()
 
             job_id = client.restore_snapshot(
-                snapshot_name="test_snapshot", collection_name="restored_collection"
+                snapshot_name="test_snapshot",
+                target_collection_name="restored_collection",
+                source_collection_name="test_collection",
             )
 
             assert job_id == 12345
             mock_handler.restore_snapshot.assert_called_once_with(
                 snapshot_name="test_snapshot",
-                collection_name="restored_collection",
+                target_collection_name="restored_collection",
+                source_collection_name="test_collection",
+                target_db_name="",
+                source_db_name="",
                 rewrite_data=False,
                 timeout=None,
                 context=ANY,
@@ -426,7 +443,7 @@ class TestMilvusClientSnapshot:
             assert jobs[1].progress == 50
 
             mock_handler.list_restore_snapshot_jobs.assert_called_once_with(
-                collection_name="test_collection", timeout=None, context=ANY
+                collection_name="test_collection", db_name="", timeout=None, context=ANY
             )
 
     def test_list_restore_snapshot_jobs_all(self):

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -463,6 +463,48 @@ class TestMilvusClientSnapshot:
             call_kwargs = mock_handler.list_restore_snapshot_jobs.call_args[1]
             assert call_kwargs["collection_name"] == ""
 
+    def test_pin_snapshot_data(self):
+        """Test pin_snapshot_data method."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.pin_snapshot_data.return_value = 42
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+
+            pin_id = client.pin_snapshot_data(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                ttl_seconds=60,
+            )
+
+            assert pin_id == 42
+            mock_handler.pin_snapshot_data.assert_called_once_with(
+                snapshot_name="test_snapshot",
+                collection_name="test_collection",
+                db_name="",
+                ttl_seconds=60,
+                timeout=None,
+                context=ANY,
+            )
+
+    def test_unpin_snapshot_data(self):
+        """Test unpin_snapshot_data method."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_handler.unpin_snapshot_data.return_value = None
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
+            client = MilvusClient()
+
+            client.unpin_snapshot_data(pin_id=42)
+
+            mock_handler.unpin_snapshot_data.assert_called_once_with(
+                pin_id=42, timeout=None, context=ANY
+            )
+
     def test_client_db_isolation(self):
         """
         Test that two clients sharing the same connection but using different databases


### PR DESCRIPTION
## Summary

Align pymilvus snapshot APIs with recent milvus-proto changes:

- **[milvus-proto#573](https://github.com/milvus-io/milvus-proto/pull/573)** — snapshots are now collection-scoped
  - `drop_snapshot` / `describe_snapshot` require `collection_name`
  - `restore_snapshot` splits source vs target collection/db, supports cross-collection and cross-db restore
  - `list_snapshots` / `list_restore_snapshot_jobs` accept `db_name`
- **[milvus-proto#574](https://github.com/milvus-io/milvus-proto/pull/574)** — `create_snapshot` accepts `compaction_protection_seconds`
- **[milvus-proto#576](https://github.com/milvus-io/milvus-proto/pull/576)** — new `pin_snapshot_data` / `unpin_snapshot_data` APIs wired through Prepare, GrpcHandler (sync + async), and MilvusClient layers

## Test plan

- [x] `tests/prepare/test_coverage_gaps.py::TestSnapshotRequests` — Prepare request builders cover new fields and error paths
- [x] `tests/grpc_handler/test_snapshot.py` + `tests/async_grpc_handler/test_async_snapshot.py` — handler signatures, pin/unpin
- [x] `tests/test_milvus_client.py::TestMilvusClientSnapshot` + async equivalent — user-facing API wiring
- [x] Full suite: `3627 passed, 3 skipped, 1 xpassed`