### PR TITLE
enhance: align snapshot APIs with latest milvus-proto

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -2495,10 +2495,10 @@ class AsyncGrpcHandler:
     @retry_on_rpc_failure()
     async def create_snapshot(
         self,
-        collection_name: str,
         snapshot_name: str,
-        description: str = "",
+        collection_name: str,
         db_name: str = "",
+        description: str = "",
         compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -2520,7 +2520,7 @@ class AsyncGrpcHandler:
     async def drop_snapshot(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -2552,13 +2552,13 @@ class AsyncGrpcHandler:
         check_status(response.status)
 
         # Return list of snapshot names
-        return response.snapshots
+        return list(response.snapshots)
 
     @retry_on_rpc_failure()
     async def describe_snapshot(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -2587,11 +2587,10 @@ class AsyncGrpcHandler:
     async def restore_snapshot(
         self,
         snapshot_name: str,
+        source_collection_name: str,
         target_collection_name: str,
-        source_collection_name: str = "",
-        target_db_name: str = "",
         source_db_name: str = "",
-        rewrite_data: bool = False,
+        target_db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -2602,7 +2601,6 @@ class AsyncGrpcHandler:
             source_collection_name=source_collection_name,
             target_db_name=target_db_name,
             source_db_name=source_db_name,
-            rewrite_data=rewrite_data,
         )
         response = await self._async_stub.RestoreSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -2673,7 +2671,7 @@ class AsyncGrpcHandler:
     async def pin_snapshot_data(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         ttl_seconds: int = 0,
         timeout: Optional[float] = None,

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -3208,10 +3208,10 @@ class GrpcHandler:
     @retry_on_rpc_failure()
     def create_snapshot(
         self,
-        collection_name: str,
         snapshot_name: str,
-        description: str = "",
+        collection_name: str,
         db_name: str = "",
+        description: str = "",
         compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -3233,7 +3233,7 @@ class GrpcHandler:
     def drop_snapshot(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -3263,13 +3263,13 @@ class GrpcHandler:
         check_status(response.status)
 
         # Return list of snapshot names
-        return response.snapshots
+        return list(response.snapshots)
 
     @retry_on_rpc_failure()
     def describe_snapshot(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
@@ -3298,11 +3298,10 @@ class GrpcHandler:
     def restore_snapshot(
         self,
         snapshot_name: str,
+        source_collection_name: str,
         target_collection_name: str,
-        source_collection_name: str = "",
-        target_db_name: str = "",
         source_db_name: str = "",
-        rewrite_data: bool = False,
+        target_db_name: str = "",
         timeout: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
@@ -3313,7 +3312,6 @@ class GrpcHandler:
             source_collection_name=source_collection_name,
             target_db_name=target_db_name,
             source_db_name=source_db_name,
-            rewrite_data=rewrite_data,
         )
         response = self._stub.RestoreSnapshot(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -3386,7 +3384,7 @@ class GrpcHandler:
     def pin_snapshot_data(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         ttl_seconds: int = 0,
         timeout: Optional[float] = None,

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2658,9 +2658,9 @@ class Prepare:
     def create_snapshot_req(
         cls,
         snapshot_name: str,
-        collection_name: str = "",
-        description: str = "",
+        collection_name: str,
         db_name: str = "",
+        description: str = "",
         compaction_protection_seconds: int = 0,
     ):
         if not validate_str(snapshot_name):
@@ -2669,7 +2669,11 @@ class Prepare:
         if not validate_str(collection_name):
             msg = "collection_name must be a non-empty string"
             raise ParamError(message=msg)
-        if not isinstance(compaction_protection_seconds, int) or compaction_protection_seconds < 0:
+        if (
+            not isinstance(compaction_protection_seconds, int)
+            or isinstance(compaction_protection_seconds, bool)
+            or compaction_protection_seconds < 0
+        ):
             msg = "compaction_protection_seconds must be a non-negative integer"
             raise ParamError(message=msg)
         return milvus_types.CreateSnapshotRequest(
@@ -2684,7 +2688,7 @@ class Prepare:
     def drop_snapshot_req(
         cls,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
     ):
         if not validate_str(snapshot_name):
@@ -2710,7 +2714,7 @@ class Prepare:
     def describe_snapshot_req(
         cls,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
     ):
         if not validate_str(snapshot_name):
@@ -2729,11 +2733,10 @@ class Prepare:
     def restore_snapshot_req(
         cls,
         snapshot_name: str,
+        source_collection_name: str,
         target_collection_name: str,
-        source_collection_name: str = "",
-        target_db_name: str = "",
         source_db_name: str = "",
-        rewrite_data: bool = False,
+        target_db_name: str = "",
     ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
@@ -2741,11 +2744,13 @@ class Prepare:
         if not validate_str(target_collection_name):
             msg = "target_collection_name must be a non-empty string"
             raise ParamError(message=msg)
+        if not validate_str(source_collection_name):
+            msg = "source_collection_name must be a non-empty string"
+            raise ParamError(message=msg)
         return milvus_types.RestoreSnapshotRequest(
             name=snapshot_name,
             db_name=source_db_name,
             collection_name=source_collection_name,
-            rewrite_data=rewrite_data,
             target_db_name=target_db_name,
             target_collection_name=target_collection_name,
         )
@@ -2768,14 +2773,17 @@ class Prepare:
     def pin_snapshot_data_req(
         cls,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         ttl_seconds: int = 0,
     ):
         if not validate_str(snapshot_name):
             msg = "snapshot_name must be a non-empty string"
             raise ParamError(message=msg)
-        if not isinstance(ttl_seconds, int) or ttl_seconds < 0:
+        if not validate_str(collection_name):
+            msg = "collection_name must be a non-empty string"
+            raise ParamError(message=msg)
+        if not isinstance(ttl_seconds, int) or isinstance(ttl_seconds, bool) or ttl_seconds < 0:
             msg = "ttl_seconds must be a non-negative integer"
             raise ParamError(message=msg)
         return milvus_types.PinSnapshotDataRequest(
@@ -2787,8 +2795,8 @@ class Prepare:
 
     @classmethod
     def unpin_snapshot_data_req(cls, pin_id: int):
-        if not isinstance(pin_id, int) or isinstance(pin_id, bool):
-            msg = "pin_id must be an integer"
+        if not isinstance(pin_id, int) or isinstance(pin_id, bool) or pin_id <= 0:
+            msg = "pin_id must be a positive integer"
             raise ParamError(message=msg)
         return milvus_types.UnpinSnapshotDataRequest(pin_id=pin_id)
 

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1967,10 +1967,10 @@ class AsyncMilvusClient(BaseMilvusClient):
 
     async def create_snapshot(
         self,
-        collection_name: str,
         snapshot_name: str,
-        description: str = "",
+        collection_name: str,
         db_name: str = "",
+        description: str = "",
         compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         **kwargs,
@@ -1978,13 +1978,13 @@ class AsyncMilvusClient(BaseMilvusClient):
         """Create a snapshot for a collection (async).
 
         Args:
-            collection_name (str): The name of the collection to snapshot.
             snapshot_name (str): The name of the snapshot. Must be unique.
+            collection_name (str): The name of the collection to snapshot.
             description (str): Optional description for the snapshot.
             db_name (str): Optional database name (defaults to active db).
             compaction_protection_seconds (int): Duration in seconds during which the
                 snapshot-referenced segments are protected from compaction.
-                0 = no protection (default). Max 7 days (604800).
+                0 = no protection (default).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -1992,8 +1992,8 @@ class AsyncMilvusClient(BaseMilvusClient):
             >>> client = AsyncMilvusClient(uri="http://localhost:19530")
             >>> await client.flush(collection_name="my_collection")
             >>> await client.create_snapshot(
-            ...     collection_name="my_collection",
             ...     snapshot_name="backup_20240101",
+            ...     collection_name="my_collection",
             ...     description="Daily backup",
             ...     compaction_protection_seconds=3600,
             ... )
@@ -2099,11 +2099,10 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def restore_snapshot(
         self,
         snapshot_name: str,
+        source_collection_name: str,
         target_collection_name: str,
-        source_collection_name: str = "",
-        target_db_name: str = "",
         source_db_name: str = "",
-        rewrite_data: bool = False,
+        target_db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
@@ -2114,10 +2113,10 @@ class AsyncMilvusClient(BaseMilvusClient):
             target_collection_name (str): The collection the snapshot will be restored into.
                 Validated server-side; an existing collection causes the restore job to fail.
             source_collection_name (str): The collection the snapshot belongs to.
-                If empty, resolved from snapshot metadata server-side.
+                Required to uniquely identify the snapshot, since snapshot names are only
+                unique within a collection and multiple collections may share the same name.
             target_db_name (str): Target database name (defaults to active db).
             source_db_name (str): Source database name (defaults to active db).
-            rewrite_data (bool): If True, use import to rewrite data to the target collection.
             timeout (Optional[float]): Optional RPC timeout in seconds.
             **kwargs: Additional arguments.
 
@@ -2131,7 +2130,6 @@ class AsyncMilvusClient(BaseMilvusClient):
             source_collection_name=source_collection_name,
             target_db_name=target_db_name,
             source_db_name=source_db_name,
-            rewrite_data=rewrite_data,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2171,7 +2169,9 @@ class AsyncMilvusClient(BaseMilvusClient):
         """List all restore snapshot jobs (async).
 
         Args:
-            collection_name (str): Optional collection name to filter jobs.
+            collection_name (str): Optional target collection name to filter jobs.
+                Pass the name of the collection that was restored into (the target collection).
+                If empty, lists all restore jobs.
             db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
@@ -2191,7 +2191,7 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def pin_snapshot_data(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         ttl_seconds: int = 0,
         timeout: Optional[float] = None,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2589,10 +2589,10 @@ class MilvusClient(BaseMilvusClient):
 
     def create_snapshot(
         self,
-        collection_name: str,
         snapshot_name: str,
-        description: str = "",
+        collection_name: str,
         db_name: str = "",
+        description: str = "",
         compaction_protection_seconds: int = 0,
         timeout: Optional[float] = None,
         **kwargs,
@@ -2600,13 +2600,13 @@ class MilvusClient(BaseMilvusClient):
         """Create a snapshot for a collection.
 
         Args:
-            collection_name (str): The name of the collection to snapshot.
             snapshot_name (str): The name of the snapshot. Must be unique.
+            collection_name (str): The name of the collection to snapshot.
             description (str): Optional description for the snapshot.
             db_name (str): Optional database name (defaults to active db).
             compaction_protection_seconds (int): Duration in seconds during which the
                 segments referenced by this snapshot are protected from compaction.
-                0 = no protection (default). Max 7 days (604800).
+                0 = no protection (default).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2619,8 +2619,8 @@ class MilvusClient(BaseMilvusClient):
             >>> # Recommended: flush before creating snapshot
             >>> client.flush(collection_name="my_collection")
             >>> client.create_snapshot(
-            ...     collection_name="my_collection",
             ...     snapshot_name="backup_20240101",
+            ...     collection_name="my_collection",
             ...     description="Daily backup",
             ...     compaction_protection_seconds=3600,
             ... )
@@ -2763,11 +2763,10 @@ class MilvusClient(BaseMilvusClient):
     def restore_snapshot(
         self,
         snapshot_name: str,
+        source_collection_name: str,
         target_collection_name: str,
-        source_collection_name: str = "",
-        target_db_name: str = "",
         source_db_name: str = "",
-        rewrite_data: bool = False,
+        target_db_name: str = "",
         timeout: Optional[float] = None,
         **kwargs,
     ) -> int:
@@ -2781,10 +2780,10 @@ class MilvusClient(BaseMilvusClient):
             target_collection_name (str): The collection the snapshot will be restored into.
                 Validated server-side; an existing collection causes the restore job to fail.
             source_collection_name (str): The collection the snapshot belongs to.
-                If empty, the server resolves it from the snapshot metadata.
+                Required to uniquely identify the snapshot, since snapshot names are only
+                unique within a collection and multiple collections may share the same name.
             target_db_name (str): Target database name (defaults to active db).
             source_db_name (str): Source database name (defaults to active db).
-            rewrite_data (bool): If True, use import to rewrite data to the target collection.
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
             **kwargs: Additional arguments.
 
@@ -2809,7 +2808,6 @@ class MilvusClient(BaseMilvusClient):
             source_collection_name=source_collection_name,
             target_db_name=target_db_name,
             source_db_name=source_db_name,
-            rewrite_data=rewrite_data,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,
@@ -2872,7 +2870,8 @@ class MilvusClient(BaseMilvusClient):
         """List all restore snapshot jobs.
 
         Args:
-            collection_name (str): Optional collection name to filter jobs.
+            collection_name (str): Optional target collection name to filter jobs.
+                Pass the name of the collection that was restored into (the target collection).
                 If empty, lists all restore jobs.
             db_name (str): Optional database name (defaults to active db).
             timeout (Optional[float]): An optional duration of time in seconds to allow for the RPC.
@@ -2888,7 +2887,7 @@ class MilvusClient(BaseMilvusClient):
             >>> for job in jobs:
             ...     print(f"Job {job.job_id}: {job.snapshot_name} - {job.progress}%")
             >>>
-            >>> # List restore jobs for a specific collection
+            >>> # List restore jobs involving a specific collection (as source or target)
             >>> jobs = client.list_restore_snapshot_jobs(collection_name="my_collection")
         """
         conn = self._get_connection()
@@ -2903,7 +2902,7 @@ class MilvusClient(BaseMilvusClient):
     def pin_snapshot_data(
         self,
         snapshot_name: str,
-        collection_name: str = "",
+        collection_name: str,
         db_name: str = "",
         ttl_seconds: int = 0,
         timeout: Optional[float] = None,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2887,7 +2887,7 @@ class MilvusClient(BaseMilvusClient):
             >>> for job in jobs:
             ...     print(f"Job {job.job_id}: {job.snapshot_name} - {job.progress}%")
             >>>
-            >>> # List restore jobs involving a specific collection (as source or target)
+            >>> # List restore jobs for a specific target collection
             >>> jobs = client.list_restore_snapshot_jobs(collection_name="my_collection")
         """
         conn = self._get_connection()

--- a/tests/async_grpc_handler/test_async_snapshot.py
+++ b/tests/async_grpc_handler/test_async_snapshot.py
@@ -214,7 +214,6 @@ class TestAsyncGrpcHandlerSnapshot:
                 snapshot_name="test_snapshot",
                 target_collection_name="new_collection",
                 source_collection_name="source_collection",
-                rewrite_data=False,
                 timeout=30,
             )
 
@@ -224,7 +223,6 @@ class TestAsyncGrpcHandlerSnapshot:
                 source_collection_name="source_collection",
                 target_db_name="",
                 source_db_name="",
-                rewrite_data=False,
             )
             assert job_id == 12345
 

--- a/tests/grpc_handler/test_snapshot.py
+++ b/tests/grpc_handler/test_snapshot.py
@@ -19,7 +19,9 @@ class TestGrpcHandlerSnapshotOps:
 
     def test_create_snapshot_with_compaction_protection(self, handler):
         handler._stub.CreateSnapshot.return_value = make_status()
-        handler.create_snapshot("snap", "coll", description="desc", compaction_protection_seconds=3600)
+        handler.create_snapshot(
+            "snap", "coll", description="desc", compaction_protection_seconds=3600
+        )
         req = handler._stub.CreateSnapshot.call_args[0][0]
         assert req.compaction_protection_seconds == 3600
 

--- a/tests/grpc_handler/test_snapshot.py
+++ b/tests/grpc_handler/test_snapshot.py
@@ -10,7 +10,7 @@ class TestGrpcHandlerSnapshotOps:
 
     def test_create_snapshot(self, handler):
         handler._stub.CreateSnapshot.return_value = make_status()
-        handler.create_snapshot("coll", "snap", "desc")
+        handler.create_snapshot("snap", "coll", description="desc")
         handler._stub.CreateSnapshot.assert_called_once()
         req = handler._stub.CreateSnapshot.call_args[0][0]
         assert req.collection_name == "coll"
@@ -19,7 +19,7 @@ class TestGrpcHandlerSnapshotOps:
 
     def test_create_snapshot_with_compaction_protection(self, handler):
         handler._stub.CreateSnapshot.return_value = make_status()
-        handler.create_snapshot("coll", "snap", "desc", compaction_protection_seconds=3600)
+        handler.create_snapshot("snap", "coll", description="desc", compaction_protection_seconds=3600)
         req = handler._stub.CreateSnapshot.call_args[0][0]
         assert req.compaction_protection_seconds == 3600
 
@@ -114,5 +114,5 @@ class TestGrpcHandlerSnapshotOps:
 
     def test_create_snapshot_with_partitions(self, handler):
         handler._stub.CreateSnapshot.return_value = make_status()
-        handler.create_snapshot("coll", "snap", "desc", partition_names=["p1", "p2"])
+        handler.create_snapshot("snap", "coll", description="desc", partition_names=["p1", "p2"])
         handler._stub.CreateSnapshot.assert_called_once()

--- a/tests/prepare/test_coverage_gaps.py
+++ b/tests/prepare/test_coverage_gaps.py
@@ -440,7 +440,7 @@ class TestSnapshotRequests:
 
     def test_pin_snapshot_data_missing_collection(self):
         """Test pin snapshot data without collection_name raises TypeError."""
-        with pytest.raises((ParamError, TypeError)):
+        with pytest.raises(TypeError):
             Prepare.pin_snapshot_data_req(snapshot_name="snap1")
 
     def test_unpin_snapshot_data(self):

--- a/tests/prepare/test_coverage_gaps.py
+++ b/tests/prepare/test_coverage_gaps.py
@@ -305,7 +305,7 @@ class TestSnapshotRequests:
     def test_create_snapshot(self):
         """Test create snapshot request."""
         req = Prepare.create_snapshot_req(
-            "snap1", "test_coll", "description", compaction_protection_seconds=3600
+            "snap1", "test_coll", description="description", compaction_protection_seconds=3600
         )
         assert req.name == "snap1"
         assert req.collection_name == "test_coll"
@@ -372,24 +372,33 @@ class TestSnapshotRequests:
             source_collection_name="src_coll",
             target_db_name="tgt_db",
             source_db_name="src_db",
-            rewrite_data=True,
         )
         assert req.name == "snap1"
         assert req.target_collection_name == "new_coll"
         assert req.collection_name == "src_coll"
         assert req.target_db_name == "tgt_db"
         assert req.db_name == "src_db"
-        assert req.rewrite_data is True
 
     def test_restore_snapshot_invalid_name(self):
         """Test restore snapshot with invalid name."""
         with pytest.raises(ParamError):
-            Prepare.restore_snapshot_req("", target_collection_name="test_coll")
+            Prepare.restore_snapshot_req(
+                "", target_collection_name="test_coll", source_collection_name="src_coll"
+            )
 
     def test_restore_snapshot_invalid_target_collection(self):
         """Test restore snapshot with missing target collection."""
         with pytest.raises(ParamError):
-            Prepare.restore_snapshot_req("snap1", target_collection_name="")
+            Prepare.restore_snapshot_req(
+                "snap1", target_collection_name="", source_collection_name="src_coll"
+            )
+
+    def test_restore_snapshot_invalid_source_collection(self):
+        """Test restore snapshot with missing source collection."""
+        with pytest.raises(ParamError):
+            Prepare.restore_snapshot_req(
+                "snap1", target_collection_name="new_coll", source_collection_name=""
+            )
 
     def test_get_restore_snapshot_state(self):
         """Test get restore snapshot state."""
@@ -420,7 +429,19 @@ class TestSnapshotRequests:
     def test_pin_snapshot_data_invalid_ttl(self):
         """Test pin snapshot data with negative ttl."""
         with pytest.raises(ParamError):
-            Prepare.pin_snapshot_data_req(snapshot_name="snap1", ttl_seconds=-1)
+            Prepare.pin_snapshot_data_req(
+                snapshot_name="snap1", collection_name="test_coll", ttl_seconds=-1
+            )
+
+    def test_pin_snapshot_data_empty_collection(self):
+        """Test pin snapshot data with empty collection_name raises ParamError."""
+        with pytest.raises(ParamError):
+            Prepare.pin_snapshot_data_req(snapshot_name="snap1", collection_name="")
+
+    def test_pin_snapshot_data_missing_collection(self):
+        """Test pin snapshot data without collection_name raises TypeError."""
+        with pytest.raises((ParamError, TypeError)):
+            Prepare.pin_snapshot_data_req(snapshot_name="snap1")
 
     def test_unpin_snapshot_data(self):
         """Test unpin snapshot data request."""
@@ -428,9 +449,14 @@ class TestSnapshotRequests:
         assert req.pin_id == 42
 
     def test_unpin_snapshot_data_zero(self):
-        """pin_id=0 is a valid integer; server decides semantics."""
-        req = Prepare.unpin_snapshot_data_req(pin_id=0)
-        assert req.pin_id == 0
+        """pin_id=0 is invalid — server assigns positive pin_ids only."""
+        with pytest.raises(ParamError):
+            Prepare.unpin_snapshot_data_req(pin_id=0)
+
+    def test_unpin_snapshot_data_negative(self):
+        """Negative pin_id is invalid."""
+        with pytest.raises(ParamError):
+            Prepare.unpin_snapshot_data_req(pin_id=-1)
 
     def test_unpin_snapshot_data_invalid(self):
         """Test unpin snapshot data with non-int pin_id."""

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -676,8 +676,8 @@ _SNAPSHOT_CASES = [
     (
         "create_snapshot",
         {
-            "collection_name": "test_collection",
             "snapshot_name": "test_snapshot",
+            "collection_name": "test_collection",
             "description": "Test description",
         },
         {
@@ -730,7 +730,6 @@ _SNAPSHOT_CASES = [
             "source_collection_name": "test_collection",
             "target_db_name": "",
             "source_db_name": "",
-            "rewrite_data": False,
             "timeout": None,
             "context": ANY,
         },
@@ -822,8 +821,8 @@ class TestAsyncMilvusClientSnapshot:
             (
                 "create_snapshot",
                 {
-                    "collection_name": "test_collection",
                     "snapshot_name": "test_snapshot",
+                    "collection_name": "test_collection",
                     "description": "Test description",
                 },
                 {
@@ -873,7 +872,6 @@ class TestAsyncMilvusClientSnapshot:
                     "source_collection_name": "test_collection",
                     "target_db_name": "",
                     "source_db_name": "",
-                    "rewrite_data": False,
                     "timeout": None,
                     "context": ANY,
                 },

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -217,8 +217,8 @@ class TestMilvusClientSnapshot:
             client = MilvusClient()
 
             client.create_snapshot(
-                collection_name="test_collection",
                 snapshot_name="test_snapshot",
+                collection_name="test_collection",
                 description="Test description",
             )
 
@@ -242,7 +242,7 @@ class TestMilvusClientSnapshot:
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler):
             client = MilvusClient()
 
-            client.create_snapshot(collection_name="test_collection", snapshot_name="test_snapshot")
+            client.create_snapshot(snapshot_name="test_snapshot", collection_name="test_collection")
 
             mock_handler.create_snapshot.assert_called_once()
             call_kwargs = mock_handler.create_snapshot.call_args[1]
@@ -363,7 +363,6 @@ class TestMilvusClientSnapshot:
                 source_collection_name="test_collection",
                 target_db_name="",
                 source_db_name="",
-                rewrite_data=False,
                 timeout=None,
                 context=ANY,
             )


### PR DESCRIPTION
## Summary

- Make `collection_name` a required positional parameter for `create_snapshot`, `drop_snapshot`, `describe_snapshot`, `list_snapshots`, and `pin_snapshot_data` — removes the silent empty-string default that caused server-side `InvalidArgument` errors
- Reorder `restore_snapshot` signature: `source_collection_name` before `target_collection_name`; remove `rewrite_data` (field dropped from latest proto)
- Fix `list_restore_snapshot_jobs` docstring: the `collection_name` filter matches the **target** collection, not the source
- Tighten client-side input validation: reject `bool` passed as `int`, enforce `pin_id > 0`, add `collection_name` validation in `pin_snapshot_data`
- Update all affected unit tests to match new signatures

## Test plan

- [ ] All existing unit tests pass: `pytest tests/ -v --ignore=tests/test_snapshot_integration.py`
- [ ] No regressions in snapshot-related test files (`test_snapshot.py`, `test_async_snapshot.py`, `test_coverage_gaps.py`, `test_milvus_client.py`, `test_async_milvus_client.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)