### PR TITLE
fix: validate params type in IndexParam to handle None and reject invalid types

### DIFF
--- a/pymilvus/milvus_client/index.py
+++ b/pymilvus/milvus_client/index.py
@@ -1,5 +1,7 @@
 from typing import Dict
 
+from pymilvus.exceptions import ParamError
+
 
 class IndexParam:
     def __init__(self, field_name: str, index_type: str, index_name: str, **kwargs):
@@ -21,9 +23,15 @@ class IndexParam:
 
         # index configs are unique to each index,
         # if params={} is passed in, it will be flattened and merged
-        # with other configs.
+        # with other configs. None is treated as an empty dict so callers
+        # can omit the value explicitly.
+        params = kwargs.pop("params", None) or {}
+        if not isinstance(params, dict):
+            msg = f"params must be a dict or None, got {type(params).__name__}: {params!r}"
+            raise ParamError(message=msg)
+
         self._configs = {}
-        self._configs.update(kwargs.pop("params", {}))
+        self._configs.update(params)
         self._configs.update(kwargs)
 
     @property

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -68,6 +68,61 @@ class TestMilvusClient:
         for index in index_params:
             log.info(index)
 
+    def test_add_index_params_none_is_normalized(self):
+        """Regression for #2789: passing params=None should not crash."""
+        index_params = MilvusClient.prepare_index_params()
+        index_params.add_index(
+            field_name="vector",
+            metric_type="IP",
+            index_type="HNSW",
+            params=None,
+        )
+        assert len(index_params) == 1
+        configs = index_params[0].get_index_configs()
+        assert configs["index_type"] == "HNSW"
+        assert configs["metric_type"] == "IP"
+
+    def test_add_index_params_empty_dict(self):
+        """params={} keeps working (no inner params to flatten)."""
+        index_params = MilvusClient.prepare_index_params()
+        index_params.add_index(
+            field_name="vector",
+            metric_type="L2",
+            index_type="FLAT",
+            params={},
+        )
+        assert len(index_params) == 1
+        configs = index_params[0].get_index_configs()
+        assert configs["index_type"] == "FLAT"
+        assert configs["metric_type"] == "L2"
+
+    def test_add_index_params_dict_is_flattened(self):
+        """params={"nlist": 128} is flattened into the index configs."""
+        index_params = MilvusClient.prepare_index_params()
+        index_params.add_index(
+            field_name="vector",
+            metric_type="L2",
+            index_type="IVF_FLAT",
+            params={"nlist": 128},
+        )
+        assert len(index_params) == 1
+        configs = index_params[0].get_index_configs()
+        assert configs["nlist"] == 128
+        assert configs["index_type"] == "IVF_FLAT"
+        assert configs["metric_type"] == "L2"
+
+    @pytest.mark.parametrize("bad_params", ["nlist=128", 123, [("nlist", 128)], 0.5])
+    def test_add_index_params_invalid_type_raises(self, bad_params):
+        """Non-dict, non-None params should raise ParamError with a clear message."""
+        index_params = MilvusClient.prepare_index_params()
+        with pytest.raises(ParamError, match=r"params must be a dict or None"):
+            index_params.add_index(
+                field_name="vector",
+                metric_type="L2",
+                index_type="HNSW",
+                params=bad_params,
+            )
+
     def test_connection_reuse(self):
         """Test that connections with same config share handler, different configs get different handlers."""
         mock_handler1 = MagicMock()


### PR DESCRIPTION
When callers pass `params=None` to `IndexParams.add_index` (e.g.,
`add_index(field_name=..., metric_type="IP", index_type=..., params=None)`),
`IndexParam` previously crashed with a confusing `TypeError`:

```
self._configs.update(kwargs.pop("params", {}))
TypeError: 'NoneType' object is not iterable
```

The default to `{}` only fires when the key is absent, not when its value
is `None`. Other non-dict values (str, int, list of tuples, etc.) failed
similarly with cryptic errors from `dict.update`.

Normalize `None` to an empty dict so explicitly omitting `params` works,
and raise `ParamError` with a clear message when `params` is any other
non-dict type. Added regression tests covering `None`, `{}`, populated
dict, and four invalid types.

Fixes #2789
