### PR TITLE
refactor: simplify Union[float] type hints to float

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -220,7 +220,7 @@ class GrpcHandler:
     def __exit__(self: object, exc_type: object, exc_val: object, exc_tb: object):
         pass
 
-    def _wait_for_channel_ready(self, timeout: Union[float] = 10):
+    def _wait_for_channel_ready(self, timeout: float = 10):
         if self._channel is None:
             raise MilvusException(
                 code=Status.CONNECT_FAILED,

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -93,7 +93,7 @@ def hybridts_to_unixtime(ts: int):
 
 def mkts_from_hybridts(
     hybridts: int,
-    milliseconds: Union[float] = 0.0,
+    milliseconds: float = 0.0,
     delta: Optional[timedelta] = None,
 ) -> int:
     if not isinstance(milliseconds, (int, float)):
@@ -114,8 +114,8 @@ def mkts_from_hybridts(
 
 
 def mkts_from_unixtime(
-    epoch: Union[float],
-    milliseconds: Union[float] = 0.0,
+    epoch: float,
+    milliseconds: float = 0.0,
     delta: Optional[timedelta] = None,
 ) -> int:
     if not isinstance(epoch, (int, float)):
@@ -136,7 +136,7 @@ def mkts_from_unixtime(
 
 def mkts_from_datetime(
     d_time: datetime.datetime,
-    milliseconds: Union[float] = 0.0,
+    milliseconds: float = 0.0,
     delta: Optional[timedelta] = None,
 ) -> int:
     if not isinstance(d_time, datetime.datetime):


### PR DESCRIPTION
## Summary

`Union[X]` with a single argument is equivalent to `X` itself. The Union wrapper adds no information and is collapsed by the typing system at runtime — `Union[float]` is exactly `float`.

This PR replaces these no-op `Union[float]` annotations with plain `float` in:

- `pymilvus/client/utils.py`: `mkts_from_hybridts`, `mkts_from_unixtime`, `mkts_from_datetime`
- `pymilvus/client/grpc_handler.py`: `_wait_for_channel_ready`

Pure type-annotation cleanup, no behavior change.