### PR TITLE
[Backport 2.6] fix: MilvusClient hangs on unreachable URI when timeout=None (#3428)

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -214,16 +214,21 @@ class GrpcHandler:
     def __exit__(self: object, exc_type: object, exc_val: object, exc_tb: object):
         pass
 
-    def _wait_for_channel_ready(self, timeout: float = 10):
+    def _wait_for_channel_ready(self, timeout: Optional[float] = 10):
         if self._channel is None:
             raise MilvusException(
                 code=Status.CONNECT_FAILED,
                 message="No channel in handler, please setup grpc channel first",
             )
 
+        # grpc.Future.result(timeout=None) blocks indefinitely.  Normalise None
+        # to the default 10 s so that an unreachable URI raises MilvusException
+        # instead of hanging forever (mirrors async ensure_channel_ready behaviour).
+        effective_timeout = timeout if timeout is not None else 10
+
         try:
-            grpc.channel_ready_future(self._channel).result(timeout=timeout)
-            self._setup_identifier_interceptor(self._user, timeout=timeout)
+            grpc.channel_ready_future(self._channel).result(timeout=effective_timeout)
+            self._setup_identifier_interceptor(self._user, timeout=effective_timeout)
         except grpc.FutureTimeoutError as e:
             self.close()
             raise MilvusException(

--- a/tests/grpc_handler/test_init.py
+++ b/tests/grpc_handler/test_init.py
@@ -141,3 +141,34 @@ class TestGrpcHandlerConnectionMgmt:
             mock_ready.return_value.result.side_effect = RuntimeError("unexpected error")
             with pytest.raises(RuntimeError, match="unexpected error"):
                 handler._wait_for_channel_ready(timeout=1.0)
+
+    def test_wait_for_channel_ready_none_timeout_uses_default(self):
+        """_wait_for_channel_ready(timeout=None) must use a finite default, not block forever.
+
+        When MilvusClient is constructed with the default timeout=None and the URI is
+        unreachable, the call should raise MilvusException instead of hanging indefinitely.
+        The root cause is that grpc.Future.result(timeout=None) blocks forever; this test
+        ensures the implementation substitutes a finite timeout before calling .result().
+        """
+        handler = GrpcHandler(channel=MagicMock())
+        with patch("pymilvus.client.grpc_handler.grpc.channel_ready_future") as mock_ready:
+            mock_ready.return_value.result.side_effect = grpc.FutureTimeoutError()
+            with pytest.raises(MilvusException, match="Fail connecting"):
+                handler._wait_for_channel_ready(timeout=None)
+            # The key assertion: result() must have been called with a finite timeout, not None.
+            call_kwargs = mock_ready.return_value.result.call_args
+            passed_timeout = call_kwargs.kwargs.get("timeout") or (
+                call_kwargs.args[0] if call_kwargs.args else None
+            )
+            assert passed_timeout is not None, (
+                "_wait_for_channel_ready(timeout=None) passed timeout=None to grpc Future.result(), "
+                "which blocks indefinitely on unreachable URIs"
+            )
+
+    def test_wait_for_channel_ready_success(self):
+        handler = GrpcHandler(channel=MagicMock())
+        with patch("pymilvus.client.grpc_handler.grpc.channel_ready_future") as mock_ready:
+            mock_ready.return_value.result.return_value = None
+            with patch.object(handler, "_setup_identifier_interceptor") as mock_setup:
+                handler._wait_for_channel_ready(timeout=None)
+                mock_setup.assert_called_once_with(handler._user, timeout=10)


### PR DESCRIPTION
## Problem

`MilvusClient(uri="http://random-invalid-host:19530")` hangs
indefinitely instead of raising a `MilvusException`.

Reported by tonyq116 in #3317 (follow-up to the original dns:/// bug
fixed in 2.6.11).

## Root cause

`GrpcHandler._wait_for_channel_ready()` passes the caller-supplied
`timeout` directly to `grpc.Future.result(timeout=...)`. Per gRPC's
contract, `result(timeout=None)` blocks forever. Since
`MilvusClient.__init__` defaults to `timeout=None`, any unreachable URI
triggers an infinite hang.

The async path (`AsyncGrpcHandler.ensure_channel_ready`) already handles
this correctly with `wait_timeout = timeout if timeout is not None else
10`. The sync path was missing the same guard.

## Fix

Normalise `None` to 10 s (the existing default) before calling
`.result()`:

```python
# Before (hangs when timeout=None):
grpc.channel_ready_future(self._channel).result(timeout=timeout)

# After (raises MilvusException after 10 s):
effective_timeout = timeout if timeout is not None else 10
grpc.channel_ready_future(self._channel).result(timeout=effective_timeout)
```

## Test

Added `test_wait_for_channel_ready_none_timeout_uses_default` in
`tests/grpc_handler/test_init.py`:
- Confirms that calling `_wait_for_channel_ready(timeout=None)` raises
`MilvusException` (not hang).
- Asserts that `grpc.Future.result()` is never called with
`timeout=None`.

See also: #3428

Co-authored-by: pymilvus-bot <pymilvus@zilliz.com>
Signed-off-by: pymilvus-bot <pymilvus@zilliz.com>