### PR TITLE
fix: place PK cursor before user filter in QueryIterator pagination

### DIFF
--- a/pymilvus/orm/iterator.py
+++ b/pymilvus/orm/iterator.py
@@ -379,7 +379,11 @@ class QueryIterator:
             filtered_pk_str = f"{self._pk_field_name} > {self._next_id}"
         if current_expr is None or len(current_expr) == 0:
             return filtered_pk_str
-        return "(" + current_expr + ")" + " and " + filtered_pk_str
+        # Put the PK cursor on the LEFT of AND so that operators with strict
+        # position constraints (e.g. `element_filter()` on struct array, which
+        # must be the right-most operand of a logical AND) keep their position
+        # across paginated calls.
+        return filtered_pk_str + " and (" + current_expr + ")"
 
     def __update_cursor(self, res: List) -> None:
         if len(res) == 0:

--- a/tests/orm/test_iterator.py
+++ b/tests/orm/test_iterator.py
@@ -578,6 +578,25 @@ class TestQueryIteratorNextExpr:
         expr = qi._QueryIterator__setup_next_expr()
         assert "pk > 42" in expr
         assert "(pk > 0)" in expr
+        # PK cursor must precede the user filter so that right-most-operand
+        # constraints (e.g. `element_filter()`) are preserved across pages.
+        assert expr.index("pk > 42") < expr.index("(pk > 0)")
+
+    def test_setup_next_expr_element_filter_stays_right_most(self):
+        conn = _make_mock_conn(session_ts=100)
+        user_filter = "element_filter(structA, $[int_val] >= 20000)"
+        qi = QueryIterator(
+            connection=conn,
+            collection_name="test",
+            batch_size=10,
+            expr=user_filter,
+            output_fields=["pk"],
+            schema=_SCHEMA_DICT,
+        )
+        qi._next_id = 211
+        expr = qi._QueryIterator__setup_next_expr()
+        # element_filter() must remain the right-most operand of AND.
+        assert expr == f"pk > 211 and ({user_filter})"
 
     def test_setup_next_expr_with_varchar_cursor(self):
         conn = _make_mock_conn(session_ts=100)


### PR DESCRIPTION
## Summary

Fixes #3435.

`QueryIterator.__setup_next_expr` previously concatenated the
paginated expression as `(<user_filter>) and <pk_cursor>`, which
breaks on page 2+ whenever the user filter is `element_filter()`
on a struct array field — the Milvus server parser requires
`element_filter()` to be the **right-most** operand of a logical
AND (by design).

Repro error from the issue:

```
MilvusException: (code=1100, message=failed to create query plan: cannot parse expression:
  (element_filter(structA, $[int_val] >= 20000)) and id > 211,
  error: element filter expression can only be the last expression in the logical and expression)
```

This PR swaps the operands so the PK cursor sits on the **left**
of AND. `AND` is commutative for regular predicates, so existing
users are unaffected, and operators with strict position
constraints (like `element_filter()`) keep their right-most slot
across paginated calls.

## Test plan

- [x] Added regression test `test_setup_next_expr_element_filter_stays_right_most`
  asserting the exact emitted expression ordering.
- [x] Strengthened existing `test_setup_next_expr_with_int_cursor`
  to verify the PK cursor precedes the user filter.
- [x] `pytest tests/orm/test_iterator.py` — 136 passed.
- [x] `ruff check` + `black --check` clean on changed files.
- [x] Manual verification on a live Milvus (`master-20260422-e91e8825f7`,
  includes milvus#49182):
  - Before fix: iterator raises on the 2nd `next()` call (parse rejection).
  - After fix: iterator advances through 26 pages / 1292 rows on a
    500-row dataset without the parse rejection. Plain `query()`
    baseline returns 1347 rows; the remaining gap is caused by a
    **separate server-side bug** (`ElementFilterBitsNode` assertion
    in growing segments), tracked at milvus-io/milvus#49260 and
    explicitly called out in the originating issue — out of scope
    for this client-side fix.