### PR TITLE
fix: add DB-Name header to bulk_import and list_import_jobs

### DIFF
--- a/pymilvus/bulk_writer/bulk_import.py
+++ b/pymilvus/bulk_writer/bulk_import.py
@@ -223,7 +223,13 @@ def bulk_import(
         params["options"] = options
 
     resp = _post_request(
-        url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs
+        url=request_url,
+        api_key=api_key,
+        params=params,
+        verify=verify,
+        cert=cert,
+        db_name=db_name,
+        **kwargs,
     )
     _handle_response(request_url, resp.json())
     return resp
@@ -315,7 +321,13 @@ def list_import_jobs(
     }
 
     resp = _post_request(
-        url=request_url, api_key=api_key, params=params, verify=verify, cert=cert, **kwargs
+        url=request_url,
+        api_key=api_key,
+        params=params,
+        verify=verify,
+        cert=cert,
+        db_name=db_name,
+        **kwargs,
     )
     _handle_response(request_url, resp.json())
     return resp

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -6,7 +6,9 @@ import pytest
 from pymilvus.bulk_writer.bulk_import import (
     _http_headers,
     _post_request,
+    bulk_import,
     get_import_progress,
+    list_import_jobs,
 )
 from pymilvus.exceptions import MilvusException
 
@@ -118,3 +120,89 @@ class TestGetImportProgress:
                 api_key="my-key",
                 db_name="my_db",
             )
+
+
+class TestBulkImport:
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_sends_db_name_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0, "data": {}}
+        mock_post.return_value = mock_resp
+
+        resp = bulk_import(
+            url="http://example.com",
+            collection_name="my_collection",
+            api_key="my-key",
+            db_name="my_db",
+            files=[["file1.parquet"]],
+        )
+
+        assert resp is mock_resp
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["url"] == "http://example.com/v2/vectordb/jobs/import/create"
+        assert kwargs["headers"]["DB-Name"] == "my_db"
+        assert kwargs["json"]["dbName"] == "my_db"
+        assert kwargs["json"]["collectionName"] == "my_collection"
+        assert "db_name" not in kwargs
+
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_without_db_name_has_no_db_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0, "data": {}}
+        mock_post.return_value = mock_resp
+
+        bulk_import(
+            url="http://example.com",
+            collection_name="my_collection",
+            api_key="my-key",
+            files=[["file1.parquet"]],
+        )
+
+        _, kwargs = mock_post.call_args
+        assert "DB-Name" not in kwargs["headers"]
+        assert kwargs["json"]["dbName"] == ""
+
+
+class TestListImportJobs:
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_sends_db_name_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0, "data": {}}
+        mock_post.return_value = mock_resp
+
+        resp = list_import_jobs(
+            url="http://example.com",
+            collection_name="my_collection",
+            api_key="my-key",
+            db_name="my_db",
+        )
+
+        assert resp is mock_resp
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["url"] == "http://example.com/v2/vectordb/jobs/import/list"
+        assert kwargs["headers"]["DB-Name"] == "my_db"
+        assert kwargs["json"]["dbName"] == "my_db"
+        assert kwargs["json"]["collectionName"] == "my_collection"
+        assert "db_name" not in kwargs
+
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_without_db_name_has_no_db_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0, "data": {}}
+        mock_post.return_value = mock_resp
+
+        list_import_jobs(
+            url="http://example.com",
+            collection_name="my_collection",
+            api_key="my-key",
+        )
+
+        _, kwargs = mock_post.call_args
+        assert "DB-Name" not in kwargs["headers"]
+        assert kwargs["json"]["dbName"] == ""


### PR DESCRIPTION
Fixes #3439

Follow-up to #3413 / #3415. PR #3415 fixed `get_import_progress` only.

`bulk_import` and `list_import_jobs` still passed `db_name` as a JSON body field without sending the `DB-Name` HTTP header, causing server-side RBAC (`PrivilegeInterceptor`) to return 403 for non-admin users on non-default databases.

### Changes
- Pass `db_name=db_name` to `_post_request` in `bulk_import` and `list_import_jobs`
- Add unit tests mirroring the `TestGetImportProgress` pattern from #3415
  - Assert `DB-Name` header is set when `db_name` is provided
  - Assert header is omitted when `db_name` is empty or not provided

### Testing
All 9 new tests pass locally:
```
pytest tests/test_bulk_import.py -v
```
