### PR TITLE
feat: add get replicate configuration client API

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -2505,6 +2505,30 @@ class AsyncGrpcHandler:
         return [AnalyzeResult(result, with_hash, with_detail) for result in resp.results]
 
     @retry_on_rpc_failure()
+    async def get_replicate_configuration(
+        self,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """
+        Get replication configuration from Milvus.
+
+        Args:
+            timeout: An optional duration of time in seconds to allow for the RPC
+            **kwargs: Additional arguments
+
+        Returns:
+            ReplicateConfiguration: The current replication configuration
+        """
+        request = milvus_types.GetReplicateConfigurationRequest()
+        response = await self._async_stub.GetReplicateConfiguration(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return response.configuration
+
+    @retry_on_rpc_failure()
     async def create_snapshot(
         self,
         snapshot_name: str,

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -3220,6 +3220,30 @@ class GrpcHandler:
         return status
 
     @retry_on_rpc_failure()
+    def get_replicate_configuration(
+        self,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """
+        Get replication configuration from Milvus.
+
+        Args:
+            timeout: An optional duration of time in seconds to allow for the RPC
+            **kwargs: Additional arguments
+
+        Returns:
+            ReplicateConfiguration: The current replication configuration
+        """
+        request = milvus_types.GetReplicateConfigurationRequest()
+        response = self._stub.GetReplicateConfiguration(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.status)
+        return response.configuration
+
+    @retry_on_rpc_failure()
     def create_snapshot(
         self,
         snapshot_name: str,

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1767,6 +1767,31 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    async def get_replicate_configuration(
+        self,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Get replication configuration from Milvus.
+
+        Args:
+            timeout (float, optional): An optional duration of time in seconds to allow for the RPC
+            **kwargs: Additional arguments
+
+        Returns:
+            ReplicateConfiguration: The current replication configuration
+
+        Raises:
+            MilvusException: If the operation fails
+        """
+        conn = await self._get_connection()
+        return await conn.get_replicate_configuration(
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     async def _is_collection_loaded(
         self, collection_name: str, timeout: Optional[float] = None
     ) -> bool:

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2259,6 +2259,30 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    def get_replicate_configuration(
+        self,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Get replication configuration from Milvus.
+
+        Args:
+            timeout (float, optional): An optional duration of time in seconds to allow for the RPC
+            **kwargs: Additional arguments
+
+        Returns:
+            ReplicateConfiguration: The current replication configuration
+
+        Raises:
+            MilvusException: If the operation fails
+        """
+        return self._get_connection().get_replicate_configuration(
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     def flush_all(self, timeout: Optional[float] = None, **kwargs) -> None:
         """Flush all collections.
 

--- a/tests/async_grpc_handler/test_async_utility.py
+++ b/tests/async_grpc_handler/test_async_utility.py
@@ -36,6 +36,31 @@ class TestAsyncGrpcHandlerUtility:
             assert result == "v2.4.0"
 
     @pytest.mark.asyncio
+    async def test_get_replicate_configuration(self) -> None:
+        """Test get_replicate_configuration async API"""
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+
+        mock_stub = AsyncMock()
+        mock_config = MagicMock()
+        mock_response = MagicMock()
+        mock_response.status.code = 0
+        mock_response.status.error_code = 0
+        mock_response.status.reason = ""
+        mock_response.configuration = mock_config
+        mock_stub.GetReplicateConfiguration = AsyncMock(return_value=mock_response)
+        handler._async_stub = mock_stub
+
+        with patch("pymilvus.client.async_grpc_handler.check_status"):
+            result = await handler.get_replicate_configuration(timeout=10)
+
+        assert result == mock_config
+        mock_stub.GetReplicateConfiguration.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_get_server_version_with_detail(self) -> None:
         """Test get_server_version returns server info dict when detail=True"""
         mock_channel = MagicMock()

--- a/tests/grpc_handler/test_utility.py
+++ b/tests/grpc_handler/test_utility.py
@@ -8,6 +8,7 @@ from pymilvus import AnnSearchRequest, RRFRanker
 from pymilvus.client.cache import GlobalCache
 from pymilvus.exceptions import AmbiguousIndexName, MilvusException
 from pymilvus.grpc_gen import common_pb2
+from pymilvus.grpc_gen import milvus_pb2 as milvus_types
 
 from .conftest import make_response
 
@@ -61,6 +62,20 @@ class TestGrpcHandlerUtilityOps:
     def test_get_server_version(self, handler):
         handler._stub.GetVersion.return_value = make_response(version="v2.4.0")
         assert handler.get_server_version() == "v2.4.0"
+
+    def test_get_replicate_configuration(self, handler):
+        mock_config = MagicMock()
+        handler._stub.GetReplicateConfiguration.return_value = make_response(
+            configuration=mock_config
+        )
+
+        result = handler.get_replicate_configuration(timeout=10)
+
+        assert result == mock_config
+        handler._stub.GetReplicateConfiguration.assert_called_once()
+        args, kwargs = handler._stub.GetReplicateConfiguration.call_args
+        assert isinstance(args[0], milvus_types.GetReplicateConfigurationRequest)
+        assert kwargs["timeout"] == 10
 
     def test_get_server_version_with_detail(self, handler):
         """Test get_server_version returns server info dict when detail=True"""

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -332,6 +332,18 @@ class TestAsyncMilvusClientNewFeatures:
             context=ANY,
         )
 
+    @pytest.mark.asyncio
+    async def test_get_replicate_configuration(self, client_and_handler):
+        """Test get_replicate_configuration method"""
+        client, mock_handler = client_and_handler
+        mock_config = MagicMock()
+        mock_handler.get_replicate_configuration = AsyncMock(return_value=mock_config)
+
+        result = await client.get_replicate_configuration(timeout=10)
+
+        assert result == mock_config
+        mock_handler.get_replicate_configuration.assert_called_once_with(timeout=10, context=ANY)
+
     def test_create_struct_field_schema(self):
         """Test create_struct_field_schema class method"""
         result = AsyncMilvusClient.create_struct_field_schema()

--- a/tests/test_async_milvus_client_ops.py
+++ b/tests/test_async_milvus_client_ops.py
@@ -133,6 +133,7 @@ _SIMPLE_ASYNC_DELEGATION_CASES = [
     ("refresh_load", ("col",), {}, "refresh_load"),
     ("run_analyzer", ("hello world",), {}, "run_analyzer"),
     ("update_replicate_configuration", (), {"clusters": []}, "update_replicate_configuration"),
+    ("get_replicate_configuration", (), {}, "get_replicate_configuration"),
     ("get_server_version", (), {}, "get_server_version"),
     ("describe_replica", ("col",), {}, "describe_replica"),
     ("describe_resource_group", ("rg1",), {}, "describe_resource_group"),

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1214,6 +1214,7 @@ _SIMPLE_DELEGATION_CASES = [
     ("get_compaction_plans", (42,), {}, "get_compaction_plans"),
     ("run_analyzer", ("hello world",), {}, "run_analyzer"),
     ("update_replicate_configuration", (), {"clusters": []}, "update_replicate_configuration"),
+    ("get_replicate_configuration", (), {}, "get_replicate_configuration"),
     ("alter_database_properties", ("mydb", {"key": "val"}), {}, "alter_database"),
     ("describe_alias", ("alias1",), {}, "describe_alias"),
     ("describe_resource_group", ("rg1",), {}, "describe_resource_group"),


### PR DESCRIPTION
## Summary
- Add sync and async public client wrappers for GetReplicateConfiguration
- Add sync and async gRPC handler wrappers returning the proto ReplicateConfiguration
- Cover handler and public client delegation paths with focused tests

Fixes #2983

## Test Plan
- [x] conda run -n milvus2 pytest tests/grpc_handler/test_utility.py::TestGrpcHandlerUtilityOps::test_get_replicate_configuration tests/async_grpc_handler/test_async_utility.py::TestAsyncGrpcHandlerUtility::test_get_replicate_configuration 'tests/test_milvus_client.py::TestMilvusClientSimpleDelegation::test_delegation[get_replicate_configuration]' 'tests/test_async_milvus_client_ops.py::TestAsyncClientSimpleDelegation::test_delegation[get_replicate_configuration]' tests/test_async_milvus_client.py::TestAsyncMilvusClientNewFeatures::test_get_replicate_configuration -q