### PR TITLE
[Backport 2.6] feat(volume): external volume and describe_volume

### DIFF
--- a/examples/bulk_import/example_volume_manager.py
+++ b/examples/bulk_import/example_volume_manager.py
@@ -16,5 +16,8 @@ if __name__ == "__main__":
     volume_list = volume_manager.list_volumes(PROJECT_ID, 1, 10)
     print(f"\nlistVolumes results: ", volume_list.json()['data'])
 
+    volume_info = volume_manager.describe_volume(VOLUME_NAME)
+    print(f"\ndescribeVolume result: ", volume_info.json()['data'])
+
     volume_manager.delete_volume(VOLUME_NAME)
     print(f"\nVolume {VOLUME_NAME} deleted")

--- a/pymilvus/bulk_writer/__init__.py
+++ b/pymilvus/bulk_writer/__init__.py
@@ -17,11 +17,17 @@ from .bulk_import import (
 from .constants import BulkFileType
 from .local_bulk_writer import LocalBulkWriter
 from .remote_bulk_writer import RemoteBulkWriter
+from .volume_bulk_writer import VolumeBulkWriter
+from .volume_file_manager import VolumeFileManager
+from .volume_manager import VolumeManager
 
 __all__ = [
     "BulkFileType",
     "LocalBulkWriter",
     "RemoteBulkWriter",
+    "VolumeBulkWriter",
+    "VolumeFileManager",
+    "VolumeManager",
     "bulk_import",
     "get_import_progress",
     "list_import_jobs",

--- a/pymilvus/bulk_writer/volume_manager.py
+++ b/pymilvus/bulk_writer/volume_manager.py
@@ -1,6 +1,12 @@
 import logging
+from typing import Optional
 
-from pymilvus.bulk_writer.volume_restful import create_volume, delete_volume, list_volumes
+from pymilvus.bulk_writer.volume_restful import (
+    create_volume,
+    delete_volume,
+    describe_volume,
+    list_volumes,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -18,11 +24,40 @@ class VolumeManager:
         self.cloud_endpoint = cloud_endpoint
         self.api_key = api_key
 
-    def create_volume(self, project_id: str, region_id: str, volume_name: str):
+    def create_volume(
+        self,
+        project_id: str,
+        region_id: str,
+        volume_name: str,
+        volume_type: Optional[str] = None,
+        storage_integration_id: Optional[str] = None,
+        path: Optional[str] = None,
+    ):
         """
         Create a volume under the specified project and regionId.
+
+        Args:
+            project_id (str): id of the project
+            region_id (str): id of the region
+            volume_name (str): name of the volume
+            volume_type (str): volume type, available values:
+                MANAGED or EXTERNAL. Defaults to MANAGED when not set.
+            storage_integration_id (str): Storage Integration ID,
+                required for EXTERNAL type
+            path (str): storage path for EXTERNAL type.
+                If not set, defaults to the storage integration root directory.
+                If set, the path must end with '/'.
         """
-        create_volume(self.cloud_endpoint, self.api_key, project_id, region_id, volume_name)
+        return create_volume(
+            self.cloud_endpoint,
+            self.api_key,
+            project_id,
+            region_id,
+            volume_name,
+            volume_type,
+            storage_integration_id,
+            path,
+        )
 
     def delete_volume(self, volume_name: str):
         """
@@ -30,8 +65,28 @@ class VolumeManager:
         """
         delete_volume(self.cloud_endpoint, self.api_key, volume_name)
 
-    def list_volumes(self, project_id: str, current_page: int = 1, page_size: int = 10):
+    def describe_volume(self, volume_name: str):
+        """
+        Get detailed information about a specific volume.
+        """
+        return describe_volume(self.cloud_endpoint, self.api_key, volume_name)
+
+    def list_volumes(
+        self,
+        project_id: str,
+        current_page: int = 1,
+        page_size: int = 10,
+        volume_type: Optional[str] = None,
+    ):
         """
         Paginated query of the volume list under a specified projectId.
+
+        Args:
+            project_id (str): id of the project
+            current_page (int): the current page
+            page_size (int): the size of each page
+            volume_type (str): filter by volume type, available values: MANAGED or EXTERNAL
         """
-        return list_volumes(self.cloud_endpoint, self.api_key, project_id, current_page, page_size)
+        return list_volumes(
+            self.cloud_endpoint, self.api_key, project_id, current_page, page_size, volume_type
+        )

--- a/pymilvus/bulk_writer/volume_restful.py
+++ b/pymilvus/bulk_writer/volume_restful.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from typing import Optional
 
 import requests
 
@@ -14,6 +15,7 @@ def list_volumes(
     project_id: str,
     current_page: int = 1,
     page_size: int = 10,
+    volume_type: Optional[str] = None,
     **kwargs,
 ) -> requests.Response:
     """call listVolumes restful interface to list volumes of project
@@ -24,6 +26,7 @@ def list_volumes(
         project_id (str): the id of project
         current_page (int): the current page
         page_size (int): the size of each page
+        volume_type (str): filter by volume type, available values: MANAGED or EXTERNAL
 
     Returns:
         response of the restful interface
@@ -31,6 +34,8 @@ def list_volumes(
     request_url = url + "/v2/volumes"
 
     params = {"projectId": project_id, "currentPage": current_page, "pageSize": page_size}
+    if volume_type is not None:
+        params["type"] = volume_type
 
     resp = _get_request(url=request_url, api_key=api_key, params=params, **kwargs)
     _handle_response(request_url, resp.json())
@@ -43,6 +48,9 @@ def create_volume(
     project_id: str,
     region_id: str,
     volume_name: str,
+    volume_type: Optional[str] = None,
+    storage_integration_id: Optional[str] = None,
+    path: Optional[str] = None,
     **kwargs,
 ) -> requests.Response:
     """call createVolume restful interface to create new volume
@@ -53,6 +61,13 @@ def create_volume(
         project_id (str): id of the project
         region_id (str): id of the region
         volume_name (str): name of the volume
+        volume_type (str): volume type, available values:
+            MANAGED or EXTERNAL. Defaults to MANAGED when not set.
+        storage_integration_id (str): Storage Integration ID,
+            required for EXTERNAL type
+        path (str): storage path for EXTERNAL type.
+            If not set, defaults to the storage integration root directory.
+            If set, the path must end with '/'.
 
     Returns:
         response of the restful interface
@@ -64,6 +79,12 @@ def create_volume(
         "regionId": region_id,
         "volumeName": volume_name,
     }
+    if volume_type is not None:
+        params["type"] = volume_type
+    if storage_integration_id is not None:
+        params["storageIntegrationId"] = storage_integration_id
+    if path is not None:
+        params["path"] = path
 
     resp = _post_request(url=request_url, api_key=api_key, params=params, **kwargs)
     _handle_response(request_url, resp.json())
@@ -89,6 +110,29 @@ def delete_volume(
     request_url = url + "/v2/volumes/" + volume_name
 
     resp = _delete_request(url=request_url, api_key=api_key, **kwargs)
+    _handle_response(request_url, resp.json())
+    return resp
+
+
+def describe_volume(
+    url: str,
+    api_key: str,
+    volume_name: str,
+    **kwargs,
+) -> requests.Response:
+    """call describeVolume restful interface to get volume details
+
+    Args:
+        url (str): url of the server
+        api_key (str): API key to authenticate your requests.
+        volume_name (str): name of the volume
+
+    Returns:
+        response of the restful interface
+    """
+    request_url = url + "/v2/volumes/" + volume_name
+
+    resp = _get_request(url=request_url, api_key=api_key, params={}, **kwargs)
     _handle_response(request_url, resp.json())
     return resp
 

--- a/tests/test_bulk_writer_stage.py
+++ b/tests/test_bulk_writer_stage.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import MagicMock, Mock, patch
 
+import pymilvus.bulk_writer as bw
 import pytest
 import requests
 from pymilvus.bulk_writer.constants import BulkFileType, ConnectType
@@ -13,6 +14,7 @@ from pymilvus.bulk_writer.volume_restful import (
     apply_volume,
     create_volume,
     delete_volume,
+    describe_volume,
     list_volumes,
 )
 from pymilvus.client.types import DataType
@@ -129,6 +131,95 @@ class TestVolumeRestful:
         mock_delete.assert_called_once()
 
     @patch("pymilvus.bulk_writer.volume_restful.requests.post")
+    def test_create_external_volume_success(
+        self, mock_post: Mock, mock_response: Mock, api_params: Dict[str, str]
+    ) -> None:
+        mock_post.return_value = mock_response
+        mock_response.json.return_value = {
+            "code": 0,
+            "message": "success",
+            "data": {"volumeName": "ext-volume"},
+        }
+        response = create_volume(
+            **api_params,
+            project_id="test_project",
+            region_id="aws-us-west-2",
+            volume_name="ext-volume",
+            volume_type="EXTERNAL",
+            storage_integration_id="si-xxxx",
+            path="data/",
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_post.call_args
+        body = call_kwargs.kwargs["json"]
+        assert body["type"] == "EXTERNAL"
+        assert body["storageIntegrationId"] == "si-xxxx"
+        assert body["path"] == "data/"
+
+    @patch("pymilvus.bulk_writer.volume_restful.requests.post")
+    def test_create_managed_volume_no_extra_params(
+        self, mock_post: Mock, mock_response: Mock, api_params: Dict[str, str]
+    ) -> None:
+        """Verify that creating a MANAGED volume does not send type/storageIntegrationId/path."""
+        mock_post.return_value = mock_response
+        mock_response.json.return_value = {
+            "code": 0,
+            "message": "success",
+            "data": {"volumeName": "my-volume"},
+        }
+        response = create_volume(
+            **api_params,
+            project_id="test_project",
+            region_id="aws-us-west-2",
+            volume_name="my-volume",
+        )
+        assert response.status_code == 200
+        call_kwargs = mock_post.call_args
+        body = call_kwargs.kwargs["json"]
+        assert "type" not in body
+        assert "storageIntegrationId" not in body
+        assert "path" not in body
+
+    @patch("pymilvus.bulk_writer.volume_restful.requests.get")
+    def test_describe_volume_success(
+        self, mock_get: Mock, mock_response: Mock, api_params: Dict[str, str]
+    ) -> None:
+        mock_get.return_value = mock_response
+        mock_response.json.return_value = {
+            "code": 0,
+            "message": "success",
+            "data": {
+                "volumeName": "ext-volume",
+                "type": "EXTERNAL",
+                "regionId": "aws-us-west-2",
+                "storageIntegrationId": "si-xxxx",
+                "path": "data/",
+                "status": "RUNNING",
+                "createTime": "2024-04-15T12:00:00Z",
+            },
+        }
+        response = describe_volume(**api_params, volume_name="ext-volume")
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["volumeName"] == "ext-volume"
+        assert data["type"] == "EXTERNAL"
+        assert data["status"] == "RUNNING"
+        mock_get.assert_called_once()
+
+    @patch("pymilvus.bulk_writer.volume_restful.requests.get")
+    def test_describe_volume_failure(
+        self, mock_get: Mock, mock_response: Mock, api_params: Dict[str, str]
+    ) -> None:
+        mock_response.json.return_value = {
+            "code": 63242,
+            "message": "The volume is not available in this region.",
+            "data": {},
+        }
+        mock_get.return_value = mock_response
+        with pytest.raises(MilvusException, match="The volume is not available"):
+            describe_volume(**api_params, volume_name="nonexistent")
+
+    @patch("pymilvus.bulk_writer.volume_restful.requests.post")
     def test_apply_volume_success(
         self, mock_post: Mock, mock_response: Mock, api_params: Dict[str, str]
     ) -> None:
@@ -158,6 +249,27 @@ class TestVolumeRestful:
         assert data["volumeName"] == "test_volume"
         assert data["endpoint"] == "s3.amazonaws.com"
         mock_post.assert_called_once()
+
+    @patch("pymilvus.bulk_writer.volume_restful.requests.get")
+    def test_list_volumes_with_type_filter(
+        self, mock_get: Mock, mock_response: Mock, api_params: Dict[str, str]
+    ) -> None:
+        mock_get.return_value = mock_response
+        mock_response.json.return_value = {
+            "code": 0,
+            "message": "success",
+            "data": {
+                "volumes": [{"volumeName": "ext-vol", "type": "EXTERNAL"}],
+                "count": 1,
+                "currentPage": 1,
+                "pageSize": 10,
+            },
+        }
+        response = list_volumes(**api_params, project_id="test_project", volume_type="EXTERNAL")
+        assert response.status_code == 200
+        # Verify type param was passed in the request
+        call_kwargs = mock_get.call_args
+        assert call_kwargs.kwargs["params"]["type"] == "EXTERNAL"
 
     @patch("pymilvus.bulk_writer.volume_restful.requests.get")
     def test_http_error_handling(self, mock_get: Mock, api_params: Dict[str, str]) -> None:
@@ -196,6 +308,9 @@ class TestVolumeManager:
             "test_project",
             "us-west-2",
             "test_volume",
+            None,
+            None,
+            None,
         )
 
     @patch("pymilvus.bulk_writer.volume_manager.delete_volume")
@@ -222,6 +337,70 @@ class TestVolumeManager:
             "test_project",
             1,
             10,
+            None,
+        )
+
+    @patch("pymilvus.bulk_writer.volume_manager.describe_volume")
+    def test_describe_volume(self, mock_describe: Mock, volume_manager: VolumeManager) -> None:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": {
+                "volumeName": "ext-volume",
+                "type": "EXTERNAL",
+                "regionId": "aws-us-west-2",
+                "storageIntegrationId": "si-xxxx",
+                "path": "data/",
+                "status": "RUNNING",
+                "createTime": "2024-04-15T12:00:00Z",
+            }
+        }
+        mock_describe.return_value = mock_response
+        result = volume_manager.describe_volume(volume_name="ext-volume")
+        assert result.json()["data"]["volumeName"] == "ext-volume"
+        assert result.json()["data"]["type"] == "EXTERNAL"
+        mock_describe.assert_called_once_with(
+            volume_manager.cloud_endpoint,
+            volume_manager.api_key,
+            "ext-volume",
+        )
+
+    @patch("pymilvus.bulk_writer.volume_manager.list_volumes")
+    def test_list_volumes_with_type(self, mock_list: Mock, volume_manager: VolumeManager) -> None:
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": {"volumes": [{"volumeName": "ext-vol", "type": "EXTERNAL"}]}
+        }
+        mock_list.return_value = mock_response
+        result = volume_manager.list_volumes(project_id="test_project", volume_type="EXTERNAL")
+        assert result.json()["data"]["volumes"][0]["type"] == "EXTERNAL"
+        mock_list.assert_called_once_with(
+            volume_manager.cloud_endpoint,
+            volume_manager.api_key,
+            "test_project",
+            1,
+            10,
+            "EXTERNAL",
+        )
+
+    @patch("pymilvus.bulk_writer.volume_manager.create_volume")
+    def test_create_external_volume(self, mock_create: Mock, volume_manager: VolumeManager) -> None:
+        volume_manager.create_volume(
+            project_id="test_project",
+            region_id="aws-us-west-2",
+            volume_name="ext-volume",
+            volume_type="EXTERNAL",
+            storage_integration_id="si-xxxx",
+            path="data/",
+        )
+        mock_create.assert_called_once_with(
+            volume_manager.cloud_endpoint,
+            volume_manager.api_key,
+            "test_project",
+            "aws-us-west-2",
+            "ext-volume",
+            "EXTERNAL",
+            "si-xxxx",
+            "data/",
         )
 
 
@@ -536,3 +715,22 @@ class TestIntegration:
         )
         file_manager._refresh_volume_and_client("data/")
         assert file_manager.volume_info["volumeName"] == "test_volume"
+
+
+# ── TestVolumeExports ────────────────────────────────────────────────────────
+
+
+class TestVolumeExports:
+    """Test that volume classes are properly exported from bulk_writer package."""
+
+    def test_volume_manager_exportable(self) -> None:
+        assert hasattr(bw, "VolumeManager")
+        assert bw.VolumeManager is VolumeManager
+
+    def test_volume_bulk_writer_exportable(self) -> None:
+        assert hasattr(bw, "VolumeBulkWriter")
+        assert bw.VolumeBulkWriter is VolumeBulkWriter
+
+    def test_volume_file_manager_exportable(self) -> None:
+        assert hasattr(bw, "VolumeFileManager")
+        assert bw.VolumeFileManager is VolumeFileManager


### PR DESCRIPTION
## Summary
- Cherry-pick commit `ca3c1315` from #3412 into `2.6`
- Include external volume enhancements (`volume_type`, `storage_integration_id`, `path`) and `describe_volume`
- Keep example update to call `describe_volume` after `list_volumes`

## Test plan
- [x] Cherry-pick cleanly applies on `origin/2.6`
- [x] Review diff contains only cherry-picked changes from #3412
- [ ] Run CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)