### PR TITLE
feat: add projectId and regionId support for cloud import interfaces

### DIFF
--- a/examples/bulk_import/example_bulkwriter.py
+++ b/examples/bulk_import/example_bulkwriter.py
@@ -438,6 +438,58 @@ def cloud_bulkinsert():
     print(resp.json())
 
 
+def cloud_bulkinsert_pdb():
+    # The value of the URL is fixed.
+    # For overseas regions, it is: https://api.cloud.zilliz.com
+    # For regions in China, it is: https://api.cloud.zilliz.com.cn
+    url = "https://api.cloud.zilliz.com"
+    api_key = "_api_key_for_cluster_org_"
+    project_id = "_your_cloud_project_id_"
+    region_id = "_your_cloud_region_id_"
+    collection_name = "_collection_name_on_the_project_"
+    # If partition_name is not specified, use ""
+    partition_name = "_partition_name_on_the_collection_"
+
+    print(f"\n===================== import files to cloud project database ====================")
+    object_url = "_your_object_storage_service_url_"
+    object_url_access_key = "_your_object_storage_service_access_key_"
+    object_url_secret_key = "_your_object_storage_service_secret_key_"
+    resp = bulk_import(
+        url=url,
+        collection_name=collection_name,
+        partition_name=partition_name,
+        object_urls=[[object_url]],
+        project_id=project_id,
+        region_id=region_id,
+        api_key=api_key,
+        access_key=object_url_access_key,
+        secret_key=object_url_secret_key,
+    )
+    print(resp.json())
+
+    print(f"\n===================== get import job progress ====================")
+    job_id = resp.json()['data']['jobId']
+    resp = get_import_progress(
+        url=url,
+        job_id=job_id,
+        project_id=project_id,
+        region_id=region_id,
+        api_key=api_key,
+    )
+    print(resp.json())
+
+    print(f"\n===================== list import jobs ====================")
+    resp = list_import_jobs(
+        url=url,
+        project_id=project_id,
+        region_id=region_id,
+        api_key=api_key,
+        page_size=10,
+        current_page=1,
+    )
+    print(resp.json())
+
+
 if __name__ == '__main__':
     create_connection()
 

--- a/pymilvus/bulk_writer/bulk_import.py
+++ b/pymilvus/bulk_writer/bulk_import.py
@@ -114,6 +114,8 @@ def bulk_import(
     object_url: str = "",
     object_urls: Optional[List[List[str]]] = None,
     cluster_id: str = "",
+    project_id: str = "",
+    region_id: str = "",
     api_key: str = "",
     access_key: str = "",
     secret_key: str = "",
@@ -136,6 +138,8 @@ def bulk_import(
         api_key (str): API key to authenticate your requests
 
         cluster_id (str): id of a milvus instance(cloud)
+        project_id (str): id of a project(cloud, for project database)
+        region_id (str): id of a region(cloud, for project database)
         object_url (str): The object URL of the object to import(cloud), use `object_urls` instead.
         object_urls (list of list of str): The object urls that contain the data to import.
              A sub-list contains a single object url
@@ -199,6 +203,24 @@ def bulk_import(
         ...         ["parquet-folder-2/"]
         ...     ]
         ... )
+
+        >>> # 4. Import multiple files or folders into a Zilliz Cloud project database
+        >>> bulk_import(
+        ...     url="https://api.cloud.zilliz.com", # If regions in China, it is: https://api.cloud.zilliz.com.cn
+        ...     api_key="YOUR_API_KEY",
+        ...     project_id="proj-xxx",
+        ...     region_id="aws-us-west-2",
+        ...     collection_name="my_collection",
+        ...     partition_name="", # If Collection not enable partitionKey, can be specified.
+        ...     object_urls=[
+        ...         ["s3://bucket-name/parquet-folder-1/1.parquet"],
+        ...         ["s3://bucket-name/parquet-folder-2/1.parquet"],
+        ...         ["s3://bucket-name/parquet-folder-3/"]
+        ...     ],
+        ...     access_key="your-access-key",
+        ...     secret_key="your-secret-key",
+        ...     token="your-token" # for short-term credentials, also include `token`
+        ... )
     """
     request_url = url + "/v2/vectordb/jobs/import/create"
 
@@ -211,6 +233,8 @@ def bulk_import(
         "objectUrl": object_url,
         "objectUrls": object_urls,
         "clusterId": cluster_id,
+        "projectId": project_id,
+        "regionId": region_id,
         "accessKey": access_key,
         "secretKey": secret_key,
         "token": token,
@@ -239,6 +263,8 @@ def get_import_progress(
     url: str,
     job_id: str,
     cluster_id: str = "",
+    project_id: str = "",
+    region_id: str = "",
     api_key: str = "",
     db_name: str = "",
     verify: Optional[Union[bool, str]] = True,
@@ -251,6 +277,8 @@ def get_import_progress(
         url (str): url of the server
         job_id (str): a job id
         cluster_id (str): id of a milvus instance(for cloud)
+        project_id (str): id of a project(cloud, for project database)
+        region_id (str): id of a region(cloud, for project database)
         api_key (str): API key to authenticate your requests.
         db_name (str): database name, sent via DB-Name header for RBAC
         verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
@@ -266,6 +294,8 @@ def get_import_progress(
     params = {
         "jobId": job_id,
         "clusterId": cluster_id,
+        "projectId": project_id,
+        "regionId": region_id,
     }
 
     resp = _post_request(
@@ -286,6 +316,8 @@ def list_import_jobs(
     collection_name: str = "",
     db_name: str = "",
     cluster_id: str = "",
+    project_id: str = "",
+    region_id: str = "",
     api_key: str = "",
     page_size: int = 10,
     current_page: int = 1,
@@ -299,6 +331,8 @@ def list_import_jobs(
         url (str): url of the server
         collection_name (str): name of the target collection
         cluster_id (str): id of a milvus instance(for cloud)
+        project_id (str): id of a project(cloud, for project database)
+        region_id (str): id of a region(cloud, for project database)
         api_key (str): API key to authenticate your requests.
         page_size (int): pagination size
         current_page (int): pagination
@@ -316,6 +350,8 @@ def list_import_jobs(
         "collectionName": collection_name,
         "dbName": db_name,
         "clusterId": cluster_id,
+        "projectId": project_id,
+        "regionId": region_id,
         "pageSize": page_size,
         "currentPage": current_page,
     }

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -87,7 +87,12 @@ class TestGetImportProgress:
         _, kwargs = mock_post.call_args
         assert kwargs["url"] == "http://example.com/v2/vectordb/jobs/import/describe"
         assert kwargs["headers"]["DB-Name"] == "my_db"
-        assert kwargs["json"] == {"jobId": "job-123", "clusterId": ""}
+        assert kwargs["json"] == {
+            "jobId": "job-123",
+            "clusterId": "",
+            "projectId": "",
+            "regionId": "",
+        }
         assert "db_name" not in kwargs
 
     @patch.object(bulk_import_mod.requests, "post")


### PR DESCRIPTION
## Summary
Add project database (pdb) support for cloud import related interfaces (cherry-picked from #3459).

## Changes
- `bulk_import()`: add `project_id` and `region_id` parameters
- `get_import_progress()`: add `project_id` and `region_id` parameters
- `list_import_jobs()`: add `project_id` and `region_id` parameters
- Add `cloud_bulkinsert_pdb()` example function