### PR TITLE
Revert "feat: add drop_collection_field and drop_collection_function APIs"

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1529,54 +1529,6 @@ class AsyncGrpcHandler:
             request, timeout=timeout, metadata=_api_level_md(context)
         )
         check_status(status)
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
-
-    async def _alter_collection_schema_drop(
-        self,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        function_name: str = "",
-        db_name: str = "",
-        timeout: Optional[float] = None,
-        context: Optional[CallContext] = None,
-        **kwargs,
-    ):
-        await self.ensure_channel_ready()
-        check_pass_param(collection_name=collection_name, timeout=timeout)
-        request = Prepare.alter_collection_schema_drop_request(
-            collection_name,
-            field_name=field_name,
-            field_id=field_id,
-            function_name=function_name,
-            db_name=db_name,
-        )
-        response = await self._async_stub.AlterCollectionSchema(
-            request, timeout=timeout, metadata=_api_level_md(context)
-        )
-        check_status(response.alter_status)
-        if response.HasField("index_status"):
-            check_status(response.index_status)
-
-    @retry_on_rpc_failure()
-    async def drop_collection_field(
-        self,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        timeout: Optional[float] = None,
-        context: Optional[CallContext] = None,
-        **kwargs,
-    ):
-        await self._alter_collection_schema_drop(
-            collection_name,
-            field_name=field_name,
-            field_id=field_id,
-            timeout=timeout,
-            context=context,
-            **kwargs,
-        )
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     async def drop_collection_function(
@@ -1587,14 +1539,13 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        await self._alter_collection_schema_drop(
-            collection_name,
-            function_name=function_name,
-            timeout=timeout,
-            context=context,
-            **kwargs,
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.drop_collection_function_request(collection_name, function_name)
+
+        status = await self._async_stub.DropCollectionFunction(
+            request, timeout=timeout, metadata=_api_level_md(context)
         )
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
+        check_status(status)
 
     @retry_on_rpc_failure()
     async def add_collection_function(
@@ -1612,7 +1563,6 @@ class AsyncGrpcHandler:
             request, timeout=timeout, metadata=_api_level_md(context)
         )
         check_status(status)
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     async def alter_collection_function(

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -464,53 +464,6 @@ class GrpcHandler:
             request, timeout=timeout, metadata=_api_level_md(context)
         )
         check_status(status)
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
-
-    def _alter_collection_schema_drop(
-        self,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        function_name: str = "",
-        db_name: str = "",
-        timeout: Optional[float] = None,
-        context: Optional[CallContext] = None,
-        **kwargs,
-    ):
-        check_pass_param(collection_name=collection_name, timeout=timeout)
-        request = Prepare.alter_collection_schema_drop_request(
-            collection_name,
-            field_name=field_name,
-            field_id=field_id,
-            function_name=function_name,
-            db_name=db_name,
-        )
-        response = self._stub.AlterCollectionSchema(
-            request, timeout=timeout, metadata=_api_level_md(context)
-        )
-        check_status(response.alter_status)
-        if response.HasField("index_status"):
-            check_status(response.index_status)
-
-    @retry_on_rpc_failure()
-    def drop_collection_field(
-        self,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        timeout: Optional[float] = None,
-        context: Optional[CallContext] = None,
-        **kwargs,
-    ):
-        self._alter_collection_schema_drop(
-            collection_name,
-            field_name=field_name,
-            field_id=field_id,
-            timeout=timeout,
-            context=context,
-            **kwargs,
-        )
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     def drop_collection_function(
@@ -521,14 +474,13 @@ class GrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        self._alter_collection_schema_drop(
-            collection_name,
-            function_name=function_name,
-            timeout=timeout,
-            context=context,
-            **kwargs,
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.drop_collection_function_request(collection_name, function_name)
+
+        status = self._stub.DropCollectionFunction(
+            request, timeout=timeout, metadata=_api_level_md(context)
         )
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
+        check_status(status)
 
     @retry_on_rpc_failure()
     def add_collection_function(
@@ -546,7 +498,6 @@ class GrpcHandler:
             request, timeout=timeout, metadata=_api_level_md(context)
         )
         check_status(status)
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     def alter_collection_function(

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -433,32 +433,6 @@ class Prepare:
         )
 
     @classmethod
-    def alter_collection_schema_drop_request(
-        cls,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        function_name: str = "",
-        db_name: str = "",
-    ) -> milvus_types.AlterCollectionSchemaRequest:
-        drop_req = milvus_types.AlterCollectionSchemaRequest.DropRequest()
-        if function_name:
-            drop_req.function_name = function_name
-        elif field_name:
-            drop_req.field_name = field_name
-        elif field_id > 0:
-            drop_req.field_id = field_id
-
-        action = milvus_types.AlterCollectionSchemaRequest.Action(
-            drop_request=drop_req,
-        )
-        return milvus_types.AlterCollectionSchemaRequest(
-            collection_name=collection_name,
-            db_name=db_name,
-            action=action,
-        )
-
-    @classmethod
     def describe_collection_request(
         cls,
         collection_name: str,

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -943,37 +943,6 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
-    async def drop_collection_field(
-        self,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        timeout: Optional[float] = None,
-        **kwargs,
-    ):
-        """Drop a field from the collection.
-
-        Args:
-            collection_name(``string``): The name of collection.
-            field_name (str, optional): The name of the field to drop.
-            field_id (int, optional): The ID of the field to drop.
-            timeout (``float``, optional): A duration of time in seconds to allow for the RPC.
-                If timeout is set to None, the client keeps waiting until the server
-                responds or an error occurs.
-
-        Raises:
-            MilvusException: If anything goes wrong
-        """
-        conn = await self._get_connection()
-        await conn.drop_collection_field(
-            collection_name,
-            field_name=field_name,
-            field_id=field_id,
-            timeout=timeout,
-            context=self._generate_call_context(**kwargs),
-            **kwargs,
-        )
-
     async def add_collection_field(
         self,
         collection_name: str,
@@ -1073,7 +1042,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         conn = await self._get_connection()
         await conn.drop_collection_function(
             collection_name,
-            function_name=function_name,
+            function_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -1199,37 +1199,6 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
-    def drop_collection_field(
-        self,
-        collection_name: str,
-        field_name: str = "",
-        field_id: int = 0,
-        timeout: Optional[float] = None,
-        **kwargs,
-    ):
-        """Drop a field from the collection.
-
-        Args:
-            collection_name(``string``): The name of collection.
-            field_name (str, optional): The name of the field to drop.
-            field_id (int, optional): The ID of the field to drop.
-            timeout (``float``, optional): A duration of time in seconds to allow for the RPC.
-                If timeout is set to None, the client keeps waiting until the server
-                responds or an error occurs.
-
-        Raises:
-            MilvusException: If anything goes wrong
-        """
-        conn = self._get_connection()
-        conn.drop_collection_field(
-            collection_name,
-            field_name=field_name,
-            field_id=field_id,
-            timeout=timeout,
-            context=self._generate_call_context(**kwargs),
-            **kwargs,
-        )
-
     def add_collection_field(
         self,
         collection_name: str,
@@ -1346,7 +1315,7 @@ class MilvusClient(BaseMilvusClient):
         conn = self._get_connection()
         conn.drop_collection_function(
             collection_name,
-            function_name=function_name,
+            function_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
             **kwargs,

--- a/tests/async_grpc_handler/test_async_collection.py
+++ b/tests/async_grpc_handler/test_async_collection.py
@@ -632,12 +632,8 @@ class TestAsyncGrpcHandlerCollectionProperties:
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
             mock_prepare.add_collection_field_request.return_value = MagicMock()
-            GlobalCache._reset_for_testing()
-            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
             await handler.add_collection_field("test_coll", mock_field_schema)
             mock_stub.AddCollectionField.assert_called_once()
-            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
-            GlobalCache._reset_for_testing()
 
     @pytest.mark.asyncio
     async def test_drop_collection_function(self) -> None:
@@ -649,76 +645,17 @@ class TestAsyncGrpcHandlerCollectionProperties:
         handler.ensure_channel_ready = AsyncMock()
 
         mock_stub = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.alter_status.code = 0
-        mock_response.HasField.return_value = False
-        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        mock_status = MagicMock()
+        mock_status.code = 0
+        mock_stub.DropCollectionFunction = AsyncMock(return_value=mock_status)
         handler._async_stub = mock_stub
 
         with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
-            mock_prepare.alter_collection_schema_drop_request.return_value = MagicMock()
-            GlobalCache._reset_for_testing()
-            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
+            mock_prepare.drop_collection_function_request.return_value = MagicMock()
             await handler.drop_collection_function("test_coll", "func1")
-            mock_stub.AlterCollectionSchema.assert_called_once()
-            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
-            GlobalCache._reset_for_testing()
-
-    @pytest.mark.asyncio
-    async def test_drop_collection_field(self) -> None:
-        """Test drop_collection_field async API"""
-        mock_channel = MagicMock()
-        mock_channel._unary_unary_interceptors = []
-        handler = AsyncGrpcHandler(channel=mock_channel)
-        handler._is_channel_ready = True
-        handler.ensure_channel_ready = AsyncMock()
-
-        mock_stub = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.alter_status.code = 0
-        mock_response.HasField.return_value = False
-        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
-        handler._async_stub = mock_stub
-
-        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
-            "pymilvus.client.async_grpc_handler.check_pass_param"
-        ), patch("pymilvus.client.async_grpc_handler.check_status"):
-            mock_prepare.alter_collection_schema_drop_request.return_value = MagicMock()
-            GlobalCache._reset_for_testing()
-            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
-            await handler.drop_collection_field("test_coll", field_name="f")
-            mock_stub.AlterCollectionSchema.assert_called_once()
-            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
-            GlobalCache._reset_for_testing()
-
-    @pytest.mark.asyncio
-    async def test_drop_collection_schema_propagates_index_status(self) -> None:
-        """index_status failures from cascade index drop must surface as MilvusException"""
-        mock_channel = MagicMock()
-        mock_channel._unary_unary_interceptors = []
-        handler = AsyncGrpcHandler(channel=mock_channel)
-        handler._is_channel_ready = True
-        handler.ensure_channel_ready = AsyncMock()
-
-        mock_stub = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.alter_status.code = 0
-        mock_response.alter_status.error_code = 0
-        mock_response.HasField.return_value = True
-        mock_response.index_status.code = 1
-        mock_response.index_status.error_code = 1
-        mock_response.index_status.reason = "cascade index drop failed"
-        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
-        handler._async_stub = mock_stub
-
-        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
-            "pymilvus.client.async_grpc_handler.check_pass_param"
-        ):
-            mock_prepare.alter_collection_schema_drop_request.return_value = MagicMock()
-            with pytest.raises(MilvusException):
-                await handler.drop_collection_field("test_coll", field_name="f")
+            mock_stub.DropCollectionFunction.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_add_collection_function(self) -> None:
@@ -740,12 +677,8 @@ class TestAsyncGrpcHandlerCollectionProperties:
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
             mock_prepare.add_collection_function_request.return_value = MagicMock()
-            GlobalCache._reset_for_testing()
-            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
             await handler.add_collection_function("test_coll", mock_function)
             mock_stub.AddCollectionFunction.assert_called_once()
-            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
-            GlobalCache._reset_for_testing()
 
     @pytest.mark.asyncio
     async def test_alter_collection_function(self) -> None:

--- a/tests/grpc_handler/test_collection.py
+++ b/tests/grpc_handler/test_collection.py
@@ -6,7 +6,7 @@ import pytest
 from pymilvus import FieldSchema
 from pymilvus.client.cache import GlobalCache
 from pymilvus.client.types import DataType
-from pymilvus.exceptions import DescribeCollectionException, MilvusException
+from pymilvus.exceptions import DescribeCollectionException
 from pymilvus.grpc_gen import common_pb2
 
 from .conftest import (
@@ -204,58 +204,10 @@ class TestGrpcHandlerCollectionProperties:
 
         handler._stub.AddCollectionField.return_value = make_status()
         field = FieldSchema(name="new_field", dtype=DataType.VARCHAR, max_length=256)
-        GlobalCache._reset_for_testing()
-        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
         handler.add_collection_field("coll", field)
         handler._stub.AddCollectionField.assert_called_once()
-        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
-        GlobalCache._reset_for_testing()
-
-    def test_add_collection_function(self, handler):
-        handler._stub.AddCollectionFunction.return_value = make_status()
-        GlobalCache._reset_for_testing()
-        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
-        with patch("pymilvus.client.grpc_handler.Prepare") as mock_prepare:
-            mock_prepare.add_collection_function_request.return_value = MagicMock()
-            handler.add_collection_function("coll", MagicMock())
-            handler._stub.AddCollectionFunction.assert_called_once()
-        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
-        GlobalCache._reset_for_testing()
 
     def test_drop_collection_function(self, handler):
-        response = MagicMock()
-        response.alter_status.code = 0
-        response.alter_status.error_code = 0
-        response.HasField.return_value = False
-        handler._stub.AlterCollectionSchema.return_value = response
-        GlobalCache._reset_for_testing()
-        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
+        handler._stub.DropCollectionFunction.return_value = make_status()
         handler.drop_collection_function("coll", "func")
-        handler._stub.AlterCollectionSchema.assert_called_once()
-        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
-        GlobalCache._reset_for_testing()
-
-    def test_drop_collection_field(self, handler):
-        response = MagicMock()
-        response.alter_status.code = 0
-        response.alter_status.error_code = 0
-        response.HasField.return_value = False
-        handler._stub.AlterCollectionSchema.return_value = response
-        GlobalCache._reset_for_testing()
-        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
-        handler.drop_collection_field("coll", field_name="f")
-        handler._stub.AlterCollectionSchema.assert_called_once()
-        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
-        GlobalCache._reset_for_testing()
-
-    def test_drop_collection_schema_propagates_index_status(self, handler):
-        response = MagicMock()
-        response.alter_status.code = 0
-        response.alter_status.error_code = 0
-        response.HasField.return_value = True
-        response.index_status.code = 1
-        response.index_status.error_code = 1
-        response.index_status.reason = "cascade index drop failed"
-        handler._stub.AlterCollectionSchema.return_value = response
-        with pytest.raises(MilvusException):
-            handler.drop_collection_field("coll", field_name="f")
+        handler._stub.DropCollectionFunction.assert_called_once()

--- a/tests/test_async_milvus_client_ops.py
+++ b/tests/test_async_milvus_client_ops.py
@@ -127,7 +127,6 @@ _SIMPLE_ASYNC_DELEGATION_CASES = [
         "alter_collection_field",
     ),
     ("drop_collection_function", ("col", "fn"), {}, "drop_collection_function"),
-    ("drop_collection_field", ("col",), {"field_name": "f"}, "drop_collection_field"),
     ("add_collection_function", ("col", MagicMock()), {}, "add_collection_function"),
     ("alter_collection_function", ("col", "fn", MagicMock()), {}, "alter_collection_function"),
     # Server ops

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1445,13 +1445,6 @@ class TestMilvusClientCollectionMgmt:
             client.drop_collection_function("col", "fn")
             handler.drop_collection_function.assert_called_once()
 
-    def test_drop_collection_field_delegates(self):
-        handler = _make_handler()
-        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
-            client = MilvusClient()
-            client.drop_collection_field("col", field_name="f")
-            handler.drop_collection_field.assert_called_once()
-
 
 class TestMilvusClientMiscOps:
     def test_compact_returns_id(self, mc):


### PR DESCRIPTION
## Summary
- Revert https://github.com/milvus-io/pymilvus/pull/3406
- Remove the `drop_collection_field` client API for now
- Restore `drop_collection_function` to call the existing `DropCollectionFunction` RPC

## Reason
Milvus server support for `AlterCollectionSchema` with `DropRequest` has not been merged yet. Keeping the PyMilvus API change in master can make clients call unsupported server behavior.

## Tests
- Not run, per request.

issue: https://github.com/milvus-io/milvus/issues/48983