### PR TITLE
enhance: add get_replicate_info() to MilvusClient and AsyncMilvusClient

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -69,6 +69,7 @@ from .utils import (
     get_server_type,
     is_successful,
     len_of,
+    replicate_checkpoint_to_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -2827,3 +2828,29 @@ class AsyncGrpcHandler:
         )
         check_status(response.status)
         return [parse_refresh_job_info(job) for job in response.jobs]
+
+    @retry_on_rpc_failure()
+    async def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """Async version of GrpcHandler.get_replicate_info. See sync version for docs."""
+        request = Prepare.get_replicate_info_request(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+        )
+        resp = await self._async_stub.GetReplicateInfo(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        return {
+            "checkpoint": replicate_checkpoint_to_dict(
+                resp.checkpoint if resp.HasField("checkpoint") else None
+            ),
+            "salvage_checkpoint": replicate_checkpoint_to_dict(
+                resp.salvage_checkpoint if resp.HasField("salvage_checkpoint") else None
+            ),
+        }

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -91,6 +91,7 @@ from .utils import (
     get_server_type,
     is_successful,
     len_of,
+    replicate_checkpoint_to_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -3229,6 +3230,47 @@ class GrpcHandler:
         )
         check_status(response.status)
         return response.configuration
+
+    @retry_on_rpc_failure()
+    def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """
+        Get the replication checkpoint that this (typically secondary) cluster
+        has recorded for a given source cluster and source pchannel.
+
+        Args:
+            source_cluster_id: ID of the source cluster.
+            target_pchannel: NOTE this is the SOURCE cluster's pchannel name.
+                The proto field naming is historical and misleading; the value
+                expected here is the pchannel belonging to source_cluster_id.
+            timeout: Optional RPC timeout in seconds.
+
+        Returns:
+            dict with two keys, each a dict or None:
+              - "checkpoint": current replication position
+              - "salvage_checkpoint": last-known position from a prior force_promote
+        """
+        request = Prepare.get_replicate_info_request(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+        )
+        resp = self._stub.GetReplicateInfo(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        return {
+            "checkpoint": replicate_checkpoint_to_dict(
+                resp.checkpoint if resp.HasField("checkpoint") else None
+            ),
+            "salvage_checkpoint": replicate_checkpoint_to_dict(
+                resp.salvage_checkpoint if resp.HasField("salvage_checkpoint") else None
+            ),
+        }
 
     @retry_on_rpc_failure()
     def create_snapshot(

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2734,6 +2734,23 @@ class Prepare:
             force_promote=force_promote,
         )
 
+    @classmethod
+    def get_replicate_info_request(
+        cls,
+        source_cluster_id: Optional[str] = None,
+        target_pchannel: Optional[str] = None,
+    ):
+        if not source_cluster_id:
+            msg = "'source_cluster_id' must be provided"
+            raise ParamError(message=msg)
+        if not target_pchannel:
+            msg = "'target_pchannel' must be provided"
+            raise ParamError(message=msg)
+        return milvus_types.GetReplicateInfoRequest(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+        )
+
     @staticmethod
     def convert_function_to_function_schema(f: Function) -> schema_types.FunctionSchema:
         function_schema = schema_types.FunctionSchema(

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2740,6 +2740,7 @@ class Prepare:
         source_cluster_id: Optional[str] = None,
         target_pchannel: Optional[str] = None,
     ):
+        # Treat None and empty string as missing; empty IDs are meaningless to the server.
         if not source_cluster_id:
             msg = "'source_cluster_id' must be provided"
             raise ParamError(message=msg)

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -534,3 +534,30 @@ def validate_iso_timestamp(s: str) -> bool:
         return False
     else:
         return True
+
+
+def replicate_checkpoint_to_dict(cp) -> Optional[Dict]:
+    """Convert a common_pb2.ReplicateCheckpoint proto to a plain dict, or None if empty.
+
+    Returns None when the proto is None or has all default values (no cluster_id,
+    no pchannel, time_tick=0). The nested message_id is itself a dict with
+    {"id": str, "wal_name": str} keys, where wal_name is the WALName enum name
+    ("Unknown" | "RocksMQ" | "Pulsar" | "Kafka" | "WoodPecker" | "Test").
+    Returns message_id=None when the proto's message_id field is unset.
+    """
+    if cp is None:
+        return None
+    if not cp.cluster_id and not cp.pchannel and cp.time_tick == 0:
+        return None
+    message_id = None
+    if cp.HasField("message_id"):
+        message_id = {
+            "id": cp.message_id.id,
+            "wal_name": common_pb2.WALName.Name(cp.message_id.WAL_name),
+        }
+    return {
+        "cluster_id": cp.cluster_id,
+        "pchannel": cp.pchannel,
+        "message_id": message_id,
+        "time_tick": cp.time_tick,
+    }

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -547,7 +547,12 @@ def replicate_checkpoint_to_dict(cp) -> Optional[Dict]:
     """
     if cp is None:
         return None
-    if not cp.cluster_id and not cp.pchannel and cp.time_tick == 0:
+    if (
+        not cp.cluster_id
+        and not cp.pchannel
+        and cp.time_tick == 0
+        and not cp.HasField("message_id")
+    ):
         return None
     message_id = None
     if cp.HasField("message_id"):

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -536,7 +536,7 @@ def validate_iso_timestamp(s: str) -> bool:
         return True
 
 
-def replicate_checkpoint_to_dict(cp) -> Optional[Dict]:
+def replicate_checkpoint_to_dict(cp: Optional[common_pb2.ReplicateCheckpoint]) -> Optional[Dict]:
     """Convert a common_pb2.ReplicateCheckpoint proto to a plain dict, or None if empty.
 
     Returns None when the proto is None or has all default values (no cluster_id,

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1863,7 +1863,38 @@ class AsyncMilvusClient(BaseMilvusClient):
         timeout: Optional[float] = None,
         **kwargs,
     ):
-        """Async version of MilvusClient.get_replicate_info. See sync version for docs."""
+        """
+        Get replication checkpoint state for a source cluster + source pchannel.
+
+        Args:
+            source_cluster_id (str): ID of the source cluster.
+            target_pchannel (str): The SOURCE cluster's pchannel name. The proto
+                field naming is historical and misleading; the value expected here
+                is the pchannel belonging to source_cluster_id.
+            timeout (float, optional): RPC timeout in seconds.
+
+        Returns:
+            dict: {
+                "checkpoint": dict or None — current replication position,
+                "salvage_checkpoint": dict or None — last-known position from a
+                    prior force_promote (None when no force_promote occurred),
+            }
+            Each non-None checkpoint dict has keys: cluster_id (str), pchannel (str),
+            message_id ({"id": str, "wal_name": str} or None), time_tick (int).
+
+        Raises:
+            ParamError: If source_cluster_id or target_pchannel is empty.
+            MilvusException: If the RPC fails.
+
+        Note:
+            This is the async coroutine version; callers must `await` it.
+
+        Examples:
+            await client.get_replicate_info(
+                source_cluster_id="primary",
+                target_pchannel="by-dev-rootcoord-dml_0",
+            )
+        """
         conn = await self._get_connection()
         return await conn.get_replicate_info(
             source_cluster_id=source_cluster_id,

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1856,6 +1856,23 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    async def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """Async version of MilvusClient.get_replicate_info. See sync version for docs."""
+        conn = await self._get_connection()
+        return await conn.get_replicate_info(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     async def _is_collection_loaded(
         self, collection_name: str, timeout: Optional[float] = None
     ) -> bool:

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2348,6 +2348,50 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Get replication checkpoint state for a source cluster + source pchannel.
+
+        Args:
+            source_cluster_id (str): ID of the source cluster.
+            target_pchannel (str): The SOURCE cluster's pchannel name. The proto
+                field naming is historical and misleading; the value expected here
+                is the pchannel belonging to source_cluster_id.
+            timeout (float, optional): RPC timeout in seconds.
+
+        Returns:
+            dict: {
+                "checkpoint": dict or None — current replication position,
+                "salvage_checkpoint": dict or None — last-known position from a
+                    prior force_promote (None when no force_promote occurred),
+            }
+            Each non-None checkpoint dict has keys: cluster_id (str), pchannel (str),
+            message_id ({"id": str, "wal_name": str} or None), time_tick (int).
+
+        Raises:
+            ParamError: If source_cluster_id or target_pchannel is empty.
+            MilvusException: If the RPC fails.
+
+        Examples:
+            client.get_replicate_info(
+                source_cluster_id="primary",
+                target_pchannel="by-dev-rootcoord-dml_0",
+            )
+        """
+        return self._get_connection().get_replicate_info(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     def flush_all(self, timeout: Optional[float] = None, **kwargs) -> None:
         """Flush all collections.
 

--- a/tests/prepare/test_advanced.py
+++ b/tests/prepare/test_advanced.py
@@ -320,6 +320,46 @@ class TestUpdateReplicateConfiguration:
         assert req.force_promote is False
 
 
+class TestGetReplicateInfoRequest:
+    """Tests for Prepare.get_replicate_info_request."""
+
+    def test_builds_correct_request(self):
+        req = Prepare.get_replicate_info_request(
+            source_cluster_id="src",
+            target_pchannel="by-dev-rootcoord-dml_0",
+        )
+        assert req.source_cluster_id == "src"
+        assert req.target_pchannel == "by-dev-rootcoord-dml_0"
+
+    def test_missing_source_cluster_id_raises(self):
+        with pytest.raises(ParamError, match="source_cluster_id"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id="",
+                target_pchannel="ch0",
+            )
+
+    def test_missing_target_pchannel_raises(self):
+        with pytest.raises(ParamError, match="target_pchannel"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id="src",
+                target_pchannel="",
+            )
+
+    def test_none_source_cluster_id_raises(self):
+        with pytest.raises(ParamError, match="source_cluster_id"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id=None,
+                target_pchannel="ch0",
+            )
+
+    def test_none_target_pchannel_raises(self):
+        with pytest.raises(ParamError, match="target_pchannel"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id="src",
+                target_pchannel=None,
+            )
+
+
 class TestConvertFunctionToFunctionSchema:
     """Tests for convert_function_to_function_schema."""
 

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1289,3 +1289,48 @@ class TestAsyncMilvusClientExternalCollection:
         mock_handler.list_refresh_external_collection_jobs.assert_called_once_with(
             collection_name="ext_coll", timeout=None, context=ANY
         )
+
+
+class TestAsyncMilvusClientGetReplicateInfo:
+    """Tests for AsyncMilvusClient.get_replicate_info."""
+
+    @pytest.mark.asyncio
+    async def test_delegation(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        expected = {
+            "checkpoint": {
+                "cluster_id": "primary",
+                "pchannel": "ch0",
+                "message_id": {"id": "msg-x", "wal_name": "Pulsar"},
+                "time_tick": 200,
+            },
+            "salvage_checkpoint": None,
+        }
+        mock_handler.get_replicate_info = AsyncMock(return_value=expected)
+
+        result = await client.get_replicate_info(
+            source_cluster_id="src",
+            target_pchannel="ch0",
+            timeout=10,
+        )
+
+        assert result == expected
+        mock_handler.get_replicate_info.assert_called_once_with(
+            source_cluster_id="src",
+            target_pchannel="ch0",
+            timeout=10,
+            context=ANY,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_dict_when_no_checkpoints(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        expected = {"checkpoint": None, "salvage_checkpoint": None}
+        mock_handler.get_replicate_info = AsyncMock(return_value=expected)
+
+        result = await client.get_replicate_info(
+            source_cluster_id="src",
+            target_pchannel="ch0",
+        )
+
+        assert result == expected

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1334,3 +1334,4 @@ class TestAsyncMilvusClientGetReplicateInfo:
         )
 
         assert result == expected
+        mock_handler.get_replicate_info.assert_called_once()

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1,6 +1,8 @@
 import logging
 from unittest.mock import ANY, MagicMock, patch
 
+from pymilvus.grpc_gen import common_pb2, milvus_pb2
+
 import pytest
 from pymilvus import DataType, SearchAggregation, StructFieldSchema, TopHits
 from pymilvus.client.connection_manager import ConnectionManager
@@ -1364,6 +1366,7 @@ _SIMPLE_DELEGATION_CASES = [
     ("run_analyzer", ("hello world",), {}, "run_analyzer"),
     ("update_replicate_configuration", (), {"clusters": []}, "update_replicate_configuration"),
     ("get_replicate_configuration", (), {}, "get_replicate_configuration"),
+    ("get_replicate_info", ("src", "ch0"), {}, "get_replicate_info"),
     ("alter_database_properties", ("mydb", {"key": "val"}), {}, "alter_database"),
     ("describe_alias", ("alias1",), {}, "describe_alias"),
     ("describe_resource_group", ("rg1",), {}, "describe_resource_group"),
@@ -1952,3 +1955,70 @@ class TestMilvusClientExternalCollection:
             assert result == []
             call_kwargs = mock_handler.list_refresh_external_collection_jobs.call_args[1]
             assert call_kwargs["collection_name"] == ""
+
+
+class TestGrpcHandlerGetReplicateInfo:
+    """Tests for GrpcHandler.get_replicate_info response shaping (handler layer)."""
+
+    @staticmethod
+    def _checkpoint(cluster_id="primary", pchannel="ch0", tt=100):
+        return common_pb2.ReplicateCheckpoint(
+            cluster_id=cluster_id,
+            pchannel=pchannel,
+            message_id=common_pb2.MessageID(id="msg-x", WAL_name=common_pb2.WALName.Pulsar),
+            time_tick=tt,
+        )
+
+    @staticmethod
+    def _bare_handler(stub_response):
+        """Construct a GrpcHandler without running __init__; attach a mocked stub."""
+        from pymilvus.client.grpc_handler import GrpcHandler
+
+        h = GrpcHandler.__new__(GrpcHandler)
+        h._stub = MagicMock()
+        h._stub.GetReplicateInfo.return_value = stub_response
+        return h
+
+    def test_both_checkpoints_populated(self):
+        resp = milvus_pb2.GetReplicateInfoResponse(
+            checkpoint=self._checkpoint(tt=200),
+            salvage_checkpoint=self._checkpoint(tt=150),
+        )
+        h = self._bare_handler(resp)
+
+        result = h.get_replicate_info(source_cluster_id="src", target_pchannel="ch0")
+
+        assert result == {
+            "checkpoint": {
+                "cluster_id": "primary",
+                "pchannel": "ch0",
+                "message_id": {"id": "msg-x", "wal_name": "Pulsar"},
+                "time_tick": 200,
+            },
+            "salvage_checkpoint": {
+                "cluster_id": "primary",
+                "pchannel": "ch0",
+                "message_id": {"id": "msg-x", "wal_name": "Pulsar"},
+                "time_tick": 150,
+            },
+        }
+        h._stub.GetReplicateInfo.assert_called_once()
+
+    def test_both_checkpoints_unset(self):
+        resp = milvus_pb2.GetReplicateInfoResponse()
+        h = self._bare_handler(resp)
+
+        result = h.get_replicate_info(source_cluster_id="src", target_pchannel="ch0")
+
+        assert result == {"checkpoint": None, "salvage_checkpoint": None}
+
+    def test_only_checkpoint_set(self):
+        resp = milvus_pb2.GetReplicateInfoResponse(
+            checkpoint=self._checkpoint(tt=300),
+        )
+        h = self._bare_handler(resp)
+
+        result = h.get_replicate_info(source_cluster_id="src", target_pchannel="ch0")
+
+        assert result["checkpoint"]["time_tick"] == 300
+        assert result["salvage_checkpoint"] is None

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1970,7 +1970,7 @@ class TestGrpcHandlerGetReplicateInfo:
     @staticmethod
     def _bare_handler(stub_response):
         """Construct a GrpcHandler without running __init__; attach a mocked stub."""
-        from pymilvus.client.grpc_handler import GrpcHandler
+        from pymilvus.client.grpc_handler import GrpcHandler  # noqa: PLC0415
 
         h = GrpcHandler.__new__(GrpcHandler)
         h._stub = MagicMock()

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1,8 +1,6 @@
 import logging
 from unittest.mock import ANY, MagicMock, patch
 
-from pymilvus.grpc_gen import common_pb2, milvus_pb2
-
 import pytest
 from pymilvus import DataType, SearchAggregation, StructFieldSchema, TopHits
 from pymilvus.client.connection_manager import ConnectionManager
@@ -18,6 +16,7 @@ from pymilvus.exceptions import (
     ParamError,
     PrimaryKeyException,
 )
+from pymilvus.grpc_gen import common_pb2, milvus_pb2
 from pymilvus.milvus_client.index import IndexParams
 from pymilvus.milvus_client.milvus_client import MilvusClient, MilvusClientSession
 from pymilvus.milvus_client.optimize_task import OptimizeResult, OptimizeTask
@@ -749,7 +748,6 @@ class TestMilvusClientCreateCollection:
                 mock_fast.assert_called_once()
 
     def test_create_collection_with_schema_routes_to_schema_method(self):
-
         handler = _make_handler()
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -493,3 +493,15 @@ class TestReplicateCheckpointToDict:
             "message_id": None,
             "time_tick": 9,
         }
+
+    def test_only_message_id_set(self):
+        cp = common_pb2.ReplicateCheckpoint(
+            message_id=common_pb2.MessageID(id="msg-1", WAL_name=common_pb2.WALName.Pulsar),
+        )
+        result = replicate_checkpoint_to_dict(cp)
+        assert result == {
+            "cluster_id": "",
+            "pchannel": "",
+            "message_id": {"id": "msg-1", "wal_name": "Pulsar"},
+            "time_tick": 0,
+        }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,9 @@ import pytest
 from pymilvus.client import utils
 from pymilvus.client.constants import LOGICAL_BITS, LOGICAL_BITS_MASK
 from pymilvus.client.types import DataType
+from pymilvus.client.utils import replicate_checkpoint_to_dict
 from pymilvus.exceptions import MilvusException, ParamError
+from pymilvus.grpc_gen import common_pb2
 
 
 class TestGetServerType:
@@ -451,3 +453,43 @@ class TestValidateIsoTimestamp:
     def test_invalid_type(self):
         assert utils.validate_iso_timestamp(None) is False
         assert utils.validate_iso_timestamp(123) is False
+
+
+class TestReplicateCheckpointToDict:
+    """Tests for replicate_checkpoint_to_dict helper."""
+
+    def test_returns_none_for_none_input(self):
+        assert replicate_checkpoint_to_dict(None) is None
+
+    def test_returns_none_for_empty_proto(self):
+        cp = common_pb2.ReplicateCheckpoint()
+        assert replicate_checkpoint_to_dict(cp) is None
+
+    def test_populated_with_message_id(self):
+        cp = common_pb2.ReplicateCheckpoint(
+            cluster_id="primary",
+            pchannel="by-dev-rootcoord-dml_0",
+            message_id=common_pb2.MessageID(id="msg-1", WAL_name=common_pb2.WALName.Pulsar),
+            time_tick=12345,
+        )
+        result = replicate_checkpoint_to_dict(cp)
+        assert result == {
+            "cluster_id": "primary",
+            "pchannel": "by-dev-rootcoord-dml_0",
+            "message_id": {"id": "msg-1", "wal_name": "Pulsar"},
+            "time_tick": 12345,
+        }
+
+    def test_populated_without_message_id(self):
+        cp = common_pb2.ReplicateCheckpoint(
+            cluster_id="primary",
+            pchannel="ch0",
+            time_tick=9,
+        )
+        result = replicate_checkpoint_to_dict(cp)
+        assert result == {
+            "cluster_id": "primary",
+            "pchannel": "ch0",
+            "message_id": None,
+            "time_tick": 9,
+        }


### PR DESCRIPTION
issue: #3510

## Summary

Wrap the existing `MilvusService.GetReplicateInfo` gRPC RPC as a user-facing `get_replicate_info(source_cluster_id, target_pchannel, timeout=None)` method on both `MilvusClient` (sync) and `AsyncMilvusClient` (async). Mirrors the existing `update_replicate_configuration` pattern.

- New `Prepare.get_replicate_info_request(...)` request builder with empty/None validation.
- New `replicate_checkpoint_to_dict(cp)` helper in `pymilvus/client/utils.py` to convert `common_pb2.ReplicateCheckpoint` into a plain Python dict (with nested `message_id={"id", "wal_name"}`), returning `None` for empty / unset checkpoints.
- Sync + async handler methods (`GrpcHandler.get_replicate_info`, `AsyncGrpcHandler.get_replicate_info`) shape the proto response into:
  ```python
  {
      "checkpoint": dict | None,            # current replication position
      "salvage_checkpoint": dict | None,    # last-known position from a prior force_promote
  }
  ```
- Thin `MilvusClient` / `AsyncMilvusClient` wrappers delegate to the handlers with the standard `_generate_call_context(**kwargs)` plumbing.

The proto field is misleadingly named `target_pchannel` but is actually the **source** cluster's pchannel name; this is called out explicitly in the docstrings.

## Test Plan

- [x] Unit tests for `replicate_checkpoint_to_dict` (None input, empty proto, populated with/without `message_id`, only-`message_id` set) — `tests/test_utils.py::TestReplicateCheckpointToDict` (5 cases)
- [x] Unit tests for `Prepare.get_replicate_info_request` (happy path + missing/None for each parameter) — `tests/prepare/test_advanced.py::TestGetReplicateInfoRequest` (5 cases)
- [x] Handler-layer integration tests covering both checkpoints populated, both unset, mixed — `tests/test_milvus_client.py::TestGrpcHandlerGetReplicateInfo` (3 cases)
- [x] Async client delegation tests (delegation with full kwargs, no-checkpoints path) — `tests/test_async_milvus_client.py::TestAsyncMilvusClientGetReplicateInfo` (2 cases)
- [x] Parametrized delegation entry added to the existing `_SIMPLE_DELEGATION_CASES` table for the sync client
- [x] Full suite: 4024 passed, 0 failed (`pytest tests --ignore=tests/benchmark`)
- [x] `ruff check` clean on all changed files
- [x] `black --check` clean on all changed files