### PR TITLE
enhance: [cp2.6]add get_replicate_info() to MilvusClient and AsyncMilvusClient (#3509)

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -63,6 +63,7 @@ from .utils import (
     get_server_type,
     is_successful,
     len_of,
+    replicate_checkpoint_to_dict,
 )
 
 
@@ -2462,3 +2463,29 @@ class AsyncGrpcHandler:
         )
         check_status(response.status)
         return response.configuration
+
+    @retry_on_rpc_failure()
+    async def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """Async version of GrpcHandler.get_replicate_info. See sync version for docs."""
+        request = Prepare.get_replicate_info_request(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+        )
+        resp = await self._async_stub.GetReplicateInfo(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        return {
+            "checkpoint": replicate_checkpoint_to_dict(
+                resp.checkpoint if resp.HasField("checkpoint") else None
+            ),
+            "salvage_checkpoint": replicate_checkpoint_to_dict(
+                resp.salvage_checkpoint if resp.HasField("salvage_checkpoint") else None
+            ),
+        }

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -86,6 +86,7 @@ from .utils import (
     get_server_type,
     is_successful,
     len_of,
+    replicate_checkpoint_to_dict,
 )
 
 logger = logging.getLogger(__name__)
@@ -3179,3 +3180,44 @@ class GrpcHandler:
         )
         check_status(response.status)
         return response.configuration
+
+    @retry_on_rpc_failure()
+    def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """
+        Get the replication checkpoint that this (typically secondary) cluster
+        has recorded for a given source cluster and source pchannel.
+
+        Args:
+            source_cluster_id: ID of the source cluster.
+            target_pchannel: NOTE this is the SOURCE cluster's pchannel name.
+                The proto field naming is historical and misleading; the value
+                expected here is the pchannel belonging to source_cluster_id.
+            timeout: Optional RPC timeout in seconds.
+
+        Returns:
+            dict with two keys, each a dict or None:
+              - "checkpoint": current replication position
+              - "salvage_checkpoint": last-known position from a prior force_promote
+        """
+        request = Prepare.get_replicate_info_request(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+        )
+        resp = self._stub.GetReplicateInfo(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        return {
+            "checkpoint": replicate_checkpoint_to_dict(
+                resp.checkpoint if resp.HasField("checkpoint") else None
+            ),
+            "salvage_checkpoint": replicate_checkpoint_to_dict(
+                resp.salvage_checkpoint if resp.HasField("salvage_checkpoint") else None
+            ),
+        }

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2566,6 +2566,24 @@ class Prepare:
             force_promote=force_promote,
         )
 
+    @classmethod
+    def get_replicate_info_request(
+        cls,
+        source_cluster_id: Optional[str] = None,
+        target_pchannel: Optional[str] = None,
+    ):
+        # Treat None and empty string as missing; empty IDs are meaningless to the server.
+        if not source_cluster_id:
+            msg = "'source_cluster_id' must be provided"
+            raise ParamError(message=msg)
+        if not target_pchannel:
+            msg = "'target_pchannel' must be provided"
+            raise ParamError(message=msg)
+        return milvus_types.GetReplicateInfoRequest(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+        )
+
     @staticmethod
     def convert_function_to_function_schema(f: Function) -> schema_types.FunctionSchema:
         function_schema = schema_types.FunctionSchema(

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -515,3 +515,35 @@ def convert_struct_fields_to_user_format(struct_array_fields: List[Dict]) -> Lis
         converted_fields.append(user_struct_field)
 
     return converted_fields
+
+
+def replicate_checkpoint_to_dict(cp: Optional[common_pb2.ReplicateCheckpoint]) -> Optional[Dict]:
+    """Convert a common_pb2.ReplicateCheckpoint proto to a plain dict, or None if empty.
+
+    Returns None when the proto is None or has all default values (no cluster_id,
+    no pchannel, time_tick=0). The nested message_id is itself a dict with
+    {"id": str, "wal_name": str} keys, where wal_name is the WALName enum name
+    ("Unknown" | "RocksMQ" | "Pulsar" | "Kafka" | "WoodPecker" | "Test").
+    Returns message_id=None when the proto's message_id field is unset.
+    """
+    if cp is None:
+        return None
+    if (
+        not cp.cluster_id
+        and not cp.pchannel
+        and cp.time_tick == 0
+        and not cp.HasField("message_id")
+    ):
+        return None
+    message_id = None
+    if cp.HasField("message_id"):
+        message_id = {
+            "id": cp.message_id.id,
+            "wal_name": common_pb2.WALName.Name(cp.message_id.WAL_name),
+        }
+    return {
+        "cluster_id": cp.cluster_id,
+        "pchannel": cp.pchannel,
+        "message_id": message_id,
+        "time_tick": cp.time_tick,
+    }

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1799,6 +1799,54 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    async def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Get replication checkpoint state for a source cluster + source pchannel.
+
+        Args:
+            source_cluster_id (str): ID of the source cluster.
+            target_pchannel (str): The SOURCE cluster's pchannel name. The proto
+                field naming is historical and misleading; the value expected here
+                is the pchannel belonging to source_cluster_id.
+            timeout (float, optional): RPC timeout in seconds.
+
+        Returns:
+            dict: {
+                "checkpoint": dict or None — current replication position,
+                "salvage_checkpoint": dict or None — last-known position from a
+                    prior force_promote (None when no force_promote occurred),
+            }
+            Each non-None checkpoint dict has keys: cluster_id (str), pchannel (str),
+            message_id ({"id": str, "wal_name": str} or None), time_tick (int).
+
+        Raises:
+            ParamError: If source_cluster_id or target_pchannel is empty.
+            MilvusException: If the RPC fails.
+
+        Note:
+            This is the async coroutine version; callers must `await` it.
+
+        Examples:
+            await client.get_replicate_info(
+                source_cluster_id="primary",
+                target_pchannel="by-dev-rootcoord-dml_0",
+            )
+        """
+        conn = await self._get_connection()
+        return await conn.get_replicate_info(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     async def _is_collection_loaded(
         self, collection_name: str, timeout: Optional[float] = None
     ) -> bool:

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2286,6 +2286,50 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    def get_replicate_info(
+        self,
+        source_cluster_id: str,
+        target_pchannel: str,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Get replication checkpoint state for a source cluster + source pchannel.
+
+        Args:
+            source_cluster_id (str): ID of the source cluster.
+            target_pchannel (str): The SOURCE cluster's pchannel name. The proto
+                field naming is historical and misleading; the value expected here
+                is the pchannel belonging to source_cluster_id.
+            timeout (float, optional): RPC timeout in seconds.
+
+        Returns:
+            dict: {
+                "checkpoint": dict or None — current replication position,
+                "salvage_checkpoint": dict or None — last-known position from a
+                    prior force_promote (None when no force_promote occurred),
+            }
+            Each non-None checkpoint dict has keys: cluster_id (str), pchannel (str),
+            message_id ({"id": str, "wal_name": str} or None), time_tick (int).
+
+        Raises:
+            ParamError: If source_cluster_id or target_pchannel is empty.
+            MilvusException: If the RPC fails.
+
+        Examples:
+            client.get_replicate_info(
+                source_cluster_id="primary",
+                target_pchannel="by-dev-rootcoord-dml_0",
+            )
+        """
+        return self._get_connection().get_replicate_info(
+            source_cluster_id=source_cluster_id,
+            target_pchannel=target_pchannel,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     def flush_all(self, timeout: Optional[float] = None, **kwargs) -> None:
         """Flush all collections.
 

--- a/tests/prepare/test_advanced.py
+++ b/tests/prepare/test_advanced.py
@@ -320,6 +320,46 @@ class TestUpdateReplicateConfiguration:
         assert req.force_promote is False
 
 
+class TestGetReplicateInfoRequest:
+    """Tests for Prepare.get_replicate_info_request."""
+
+    def test_builds_correct_request(self):
+        req = Prepare.get_replicate_info_request(
+            source_cluster_id="src",
+            target_pchannel="by-dev-rootcoord-dml_0",
+        )
+        assert req.source_cluster_id == "src"
+        assert req.target_pchannel == "by-dev-rootcoord-dml_0"
+
+    def test_missing_source_cluster_id_raises(self):
+        with pytest.raises(ParamError, match="source_cluster_id"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id="",
+                target_pchannel="ch0",
+            )
+
+    def test_missing_target_pchannel_raises(self):
+        with pytest.raises(ParamError, match="target_pchannel"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id="src",
+                target_pchannel="",
+            )
+
+    def test_none_source_cluster_id_raises(self):
+        with pytest.raises(ParamError, match="source_cluster_id"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id=None,
+                target_pchannel="ch0",
+            )
+
+    def test_none_target_pchannel_raises(self):
+        with pytest.raises(ParamError, match="target_pchannel"):
+            Prepare.get_replicate_info_request(
+                source_cluster_id="src",
+                target_pchannel=None,
+            )
+
+
 class TestConvertFunctionToFunctionSchema:
     """Tests for convert_function_to_function_schema."""
 

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -733,3 +733,49 @@ class TestAsyncMilvusClientDataOps:
         result = await client.get("test_collection", ids=[1])
 
         assert result == [{"id": 1, "name": "test"}]
+
+
+class TestAsyncMilvusClientGetReplicateInfo:
+    """Tests for AsyncMilvusClient.get_replicate_info."""
+
+    @pytest.mark.asyncio
+    async def test_delegation(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        expected = {
+            "checkpoint": {
+                "cluster_id": "primary",
+                "pchannel": "ch0",
+                "message_id": {"id": "msg-x", "wal_name": "Pulsar"},
+                "time_tick": 200,
+            },
+            "salvage_checkpoint": None,
+        }
+        mock_handler.get_replicate_info = AsyncMock(return_value=expected)
+
+        result = await client.get_replicate_info(
+            source_cluster_id="src",
+            target_pchannel="ch0",
+            timeout=10,
+        )
+
+        assert result == expected
+        mock_handler.get_replicate_info.assert_called_once_with(
+            source_cluster_id="src",
+            target_pchannel="ch0",
+            timeout=10,
+            context=ANY,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_dict_when_no_checkpoints(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        expected = {"checkpoint": None, "salvage_checkpoint": None}
+        mock_handler.get_replicate_info = AsyncMock(return_value=expected)
+
+        result = await client.get_replicate_info(
+            source_cluster_id="src",
+            target_pchannel="ch0",
+        )
+
+        assert result == expected
+        mock_handler.get_replicate_info.assert_called_once()

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -11,6 +11,7 @@ from pymilvus.exceptions import (
     ParamError,
     PrimaryKeyException,
 )
+from pymilvus.grpc_gen import common_pb2, milvus_pb2
 from pymilvus.milvus_client.index import IndexParams
 from pymilvus.milvus_client.milvus_client import MilvusClient
 from pymilvus.milvus_client.optimize_task import OptimizeResult, OptimizeTask
@@ -368,7 +369,6 @@ class TestMilvusClientCreateCollection:
                 mock_fast.assert_called_once()
 
     def test_create_collection_with_schema_routes_to_schema_method(self):
-
         handler = _make_handler()
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()
@@ -895,6 +895,7 @@ _SIMPLE_DELEGATION_CASES = [
     ("run_analyzer", ("hello world",), {}, "run_analyzer"),
     ("update_replicate_configuration", (), {"clusters": []}, "update_replicate_configuration"),
     ("get_replicate_configuration", (), {}, "get_replicate_configuration"),
+    ("get_replicate_info", ("src", "ch0"), {}, "get_replicate_info"),
     ("alter_database_properties", ("mydb", {"key": "val"}), {}, "alter_database"),
     ("describe_alias", ("alias1",), {}, "describe_alias"),
     ("describe_resource_group", ("rg1",), {}, "describe_resource_group"),
@@ -1310,3 +1311,70 @@ class TestMilvusClientInternalOps:
                 task._target_size = None
                 result = client._execute_optimize(task, "col", None, None)
                 assert result.collection_name == "col"
+
+
+class TestGrpcHandlerGetReplicateInfo:
+    """Tests for GrpcHandler.get_replicate_info response shaping (handler layer)."""
+
+    @staticmethod
+    def _checkpoint(cluster_id="primary", pchannel="ch0", tt=100):
+        return common_pb2.ReplicateCheckpoint(
+            cluster_id=cluster_id,
+            pchannel=pchannel,
+            message_id=common_pb2.MessageID(id="msg-x", WAL_name=common_pb2.WALName.Pulsar),
+            time_tick=tt,
+        )
+
+    @staticmethod
+    def _bare_handler(stub_response):
+        """Construct a GrpcHandler without running __init__; attach a mocked stub."""
+        from pymilvus.client.grpc_handler import GrpcHandler  # noqa: PLC0415
+
+        h = GrpcHandler.__new__(GrpcHandler)
+        h._stub = MagicMock()
+        h._stub.GetReplicateInfo.return_value = stub_response
+        return h
+
+    def test_both_checkpoints_populated(self):
+        resp = milvus_pb2.GetReplicateInfoResponse(
+            checkpoint=self._checkpoint(tt=200),
+            salvage_checkpoint=self._checkpoint(tt=150),
+        )
+        h = self._bare_handler(resp)
+
+        result = h.get_replicate_info(source_cluster_id="src", target_pchannel="ch0")
+
+        assert result == {
+            "checkpoint": {
+                "cluster_id": "primary",
+                "pchannel": "ch0",
+                "message_id": {"id": "msg-x", "wal_name": "Pulsar"},
+                "time_tick": 200,
+            },
+            "salvage_checkpoint": {
+                "cluster_id": "primary",
+                "pchannel": "ch0",
+                "message_id": {"id": "msg-x", "wal_name": "Pulsar"},
+                "time_tick": 150,
+            },
+        }
+        h._stub.GetReplicateInfo.assert_called_once()
+
+    def test_both_checkpoints_unset(self):
+        resp = milvus_pb2.GetReplicateInfoResponse()
+        h = self._bare_handler(resp)
+
+        result = h.get_replicate_info(source_cluster_id="src", target_pchannel="ch0")
+
+        assert result == {"checkpoint": None, "salvage_checkpoint": None}
+
+    def test_only_checkpoint_set(self):
+        resp = milvus_pb2.GetReplicateInfoResponse(
+            checkpoint=self._checkpoint(tt=300),
+        )
+        h = self._bare_handler(resp)
+
+        result = h.get_replicate_info(source_cluster_id="src", target_pchannel="ch0")
+
+        assert result["checkpoint"]["time_tick"] == 300
+        assert result["salvage_checkpoint"] is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,9 @@ import pytest
 from pymilvus.client import utils
 from pymilvus.client.constants import LOGICAL_BITS, LOGICAL_BITS_MASK
 from pymilvus.client.types import DataType
+from pymilvus.client.utils import replicate_checkpoint_to_dict
 from pymilvus.exceptions import MilvusException, ParamError
+from pymilvus.grpc_gen import common_pb2
 
 
 class TestGetServerType:
@@ -396,3 +398,55 @@ class TestUtils:
         ]
         for url, want in urls_and_wants:
             assert utils.get_server_type(url) == want
+
+
+class TestReplicateCheckpointToDict:
+    """Tests for replicate_checkpoint_to_dict helper."""
+
+    def test_returns_none_for_none_input(self):
+        assert replicate_checkpoint_to_dict(None) is None
+
+    def test_returns_none_for_empty_proto(self):
+        cp = common_pb2.ReplicateCheckpoint()
+        assert replicate_checkpoint_to_dict(cp) is None
+
+    def test_populated_with_message_id(self):
+        cp = common_pb2.ReplicateCheckpoint(
+            cluster_id="primary",
+            pchannel="by-dev-rootcoord-dml_0",
+            message_id=common_pb2.MessageID(id="msg-1", WAL_name=common_pb2.WALName.Pulsar),
+            time_tick=12345,
+        )
+        result = replicate_checkpoint_to_dict(cp)
+        assert result == {
+            "cluster_id": "primary",
+            "pchannel": "by-dev-rootcoord-dml_0",
+            "message_id": {"id": "msg-1", "wal_name": "Pulsar"},
+            "time_tick": 12345,
+        }
+
+    def test_populated_without_message_id(self):
+        cp = common_pb2.ReplicateCheckpoint(
+            cluster_id="primary",
+            pchannel="ch0",
+            time_tick=9,
+        )
+        result = replicate_checkpoint_to_dict(cp)
+        assert result == {
+            "cluster_id": "primary",
+            "pchannel": "ch0",
+            "message_id": None,
+            "time_tick": 9,
+        }
+
+    def test_only_message_id_set(self):
+        cp = common_pb2.ReplicateCheckpoint(
+            message_id=common_pb2.MessageID(id="msg-1", WAL_name=common_pb2.WALName.Pulsar),
+        )
+        result = replicate_checkpoint_to_dict(cp)
+        assert result == {
+            "cluster_id": "",
+            "pchannel": "",
+            "message_id": {"id": "msg-1", "wal_name": "Pulsar"},
+            "time_tick": 0,
+        }


### PR DESCRIPTION
Cherry-pick from master

pr: #3509
issue: #3510

## Summary

Cherry-picked from master PR #3509 (merged).
Resolved conflicts: master has unrelated APIs (snapshot, file_resource, refresh_external_collection) added after `update_replicate_configuration` that don't exist in 2.6; kept only PR #3509's additions (`get_replicate_info`, `replicate_checkpoint_to_dict`, `Prepare.get_replicate_info_request`) and the four new test classes.

## Verification

- [x] File count matches original PR (10 files, +420/-1)
- [x] Per-file diff matches original PR (no extra/missing changes)
- [x] No conflict markers
- [x] All 15 new tests pass; existing `_SIMPLE_DELEGATION` `get_replicate_info` row also passes
- [ ] make static-check (skipped by cherry-pick workflow)