### PR TITLE
enhance: add commit_import/abort_import SDK wrappers for import 2PC

### DIFF
--- a/pymilvus/bulk_writer/__init__.py
+++ b/pymilvus/bulk_writer/__init__.py
@@ -10,7 +10,9 @@ if len(missing) > 0:
 
 
 from .bulk_import import (
+    abort_import,
     bulk_import,
+    commit_import,
     get_import_progress,
     list_import_jobs,
 )
@@ -28,7 +30,9 @@ __all__ = [
     "VolumeBulkWriter",
     "VolumeFileManager",
     "VolumeManager",
+    "abort_import",
     "bulk_import",
+    "commit_import",
     "get_import_progress",
     "list_import_jobs",
 ]

--- a/pymilvus/bulk_writer/bulk_import.py
+++ b/pymilvus/bulk_writer/bulk_import.py
@@ -311,6 +311,110 @@ def get_import_progress(
     return resp
 
 
+def commit_import(
+    url: str,
+    job_id: str,
+    cluster_id: str = "",
+    project_id: str = "",
+    region_id: str = "",
+    api_key: str = "",
+    db_name: str = "",
+    verify: Optional[Union[bool, str]] = True,
+    cert: Optional[Union[str, tuple]] = None,
+    **kwargs,
+) -> requests.Response:
+    """commit an import job (2PC). Makes imported data visible.
+
+    Args:
+        url (str): url of the server
+        job_id (str): a job id
+        cluster_id (str): id of a milvus instance(for cloud)
+        project_id (str): id of a project(cloud, for project database)
+        region_id (str): id of a region(cloud, for project database)
+        api_key (str): API key to authenticate your requests.
+        db_name (str): database name, sent via DB-Name header for RBAC
+        verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
+             or a string, which must be server's certificate path. Defaults to `True`.
+        cert (str, tuple, optional): if String, path to ssl client cert file.
+                                     if Tuple, ('cert', 'key') pair.
+
+    Returns:
+        response of the restful interface
+    """
+    request_url = url + "/v2/vectordb/jobs/import/commit"
+
+    params = {
+        "jobId": job_id,
+        "clusterId": cluster_id,
+        "projectId": project_id,
+        "regionId": region_id,
+    }
+
+    resp = _post_request(
+        url=request_url,
+        api_key=api_key,
+        params=params,
+        verify=verify,
+        cert=cert,
+        db_name=db_name,
+        **kwargs,
+    )
+    _handle_response(request_url, resp.json())
+    return resp
+
+
+def abort_import(
+    url: str,
+    job_id: str,
+    cluster_id: str = "",
+    project_id: str = "",
+    region_id: str = "",
+    api_key: str = "",
+    db_name: str = "",
+    verify: Optional[Union[bool, str]] = True,
+    cert: Optional[Union[str, tuple]] = None,
+    **kwargs,
+) -> requests.Response:
+    """abort an import job (2PC). Discards the imported data.
+
+    Args:
+        url (str): url of the server
+        job_id (str): a job id
+        cluster_id (str): id of a milvus instance(for cloud)
+        project_id (str): id of a project(cloud, for project database)
+        region_id (str): id of a region(cloud, for project database)
+        api_key (str): API key to authenticate your requests.
+        db_name (str): database name, sent via DB-Name header for RBAC
+        verify (bool, str, optional): Either a boolean, to verify the server's TLS certificate
+             or a string, which must be server's certificate path. Defaults to `True`.
+        cert (str, tuple, optional): if String, path to ssl client cert file.
+                                     if Tuple, ('cert', 'key') pair.
+
+    Returns:
+        response of the restful interface
+    """
+    request_url = url + "/v2/vectordb/jobs/import/abort"
+
+    params = {
+        "jobId": job_id,
+        "clusterId": cluster_id,
+        "projectId": project_id,
+        "regionId": region_id,
+    }
+
+    resp = _post_request(
+        url=request_url,
+        api_key=api_key,
+        params=params,
+        verify=verify,
+        cert=cert,
+        db_name=db_name,
+        **kwargs,
+    )
+    _handle_response(request_url, resp.json())
+    return resp
+
+
 def list_import_jobs(
     url: str,
     collection_name: str = "",

--- a/tests/test_bulk_import.py
+++ b/tests/test_bulk_import.py
@@ -6,7 +6,9 @@ import pytest
 from pymilvus.bulk_writer.bulk_import import (
     _http_headers,
     _post_request,
+    abort_import,
     bulk_import,
+    commit_import,
     get_import_progress,
     list_import_jobs,
 )
@@ -211,3 +213,81 @@ class TestListImportJobs:
         _, kwargs = mock_post.call_args
         assert "DB-Name" not in kwargs["headers"]
         assert kwargs["json"]["dbName"] == ""
+
+
+class TestCommitImport:
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_sends_job_id_and_db_name_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0, "data": {}}
+        mock_post.return_value = mock_resp
+
+        resp = commit_import(
+            url="http://example.com",
+            job_id="job-123",
+            api_key="my-key",
+            db_name="my_db",
+        )
+
+        assert resp is mock_resp
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["url"] == "http://example.com/v2/vectordb/jobs/import/commit"
+        assert kwargs["headers"]["DB-Name"] == "my_db"
+        assert kwargs["json"] == {
+            "jobId": "job-123",
+            "clusterId": "",
+            "projectId": "",
+            "regionId": "",
+        }
+        assert "db_name" not in kwargs
+
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_non_zero_code_raises(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 1, "message": "boom"}
+        mock_post.return_value = mock_resp
+
+        with pytest.raises(MilvusException, match="boom"):
+            commit_import(url="http://example.com", job_id="job-123", api_key="my-key")
+
+
+class TestAbortImport:
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_sends_job_id_and_db_name_header(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 0, "data": {}}
+        mock_post.return_value = mock_resp
+
+        resp = abort_import(
+            url="http://example.com",
+            job_id="job-123",
+            api_key="my-key",
+            db_name="my_db",
+        )
+
+        assert resp is mock_resp
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["url"] == "http://example.com/v2/vectordb/jobs/import/abort"
+        assert kwargs["headers"]["DB-Name"] == "my_db"
+        assert kwargs["json"] == {
+            "jobId": "job-123",
+            "clusterId": "",
+            "projectId": "",
+            "regionId": "",
+        }
+        assert "db_name" not in kwargs
+
+    @patch.object(bulk_import_mod.requests, "post")
+    def test_non_zero_code_raises(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"code": 1, "message": "boom"}
+        mock_post.return_value = mock_resp
+
+        with pytest.raises(MilvusException, match="boom"):
+            abort_import(url="http://example.com", job_id="job-123", api_key="my-key")


### PR DESCRIPTION
## Summary

Adds Python SDK RESTful wrappers for the Import 2PC commit/abort endpoints introduced server-side in milvus-io/milvus#48524, mirroring the existing `get_import_progress` wrapper in `pymilvus/bulk_writer/bulk_import.py`:

- `commit_import` → `POST /v2/vectordb/jobs/import/commit`
- `abort_import` → `POST /v2/vectordb/jobs/import/abort`

Both accept `job_id` (plus optional `cluster_id`/`project_id`/`region_id`/`api_key`/`db_name`) and delegate status handling to the existing `_handle_response` helper. The 2PC opt-in (`auto_commit=false`) continues to flow through the existing import-create `options` map, so no create-path change is needed.

issue: #48525

### Changes

**Modified:**
- `pymilvus/bulk_writer/bulk_import.py`: add `commit_import` / `abort_import` (mirroring `get_import_progress`, incl. `db_name` DB-Name header and `project_id`/`region_id`).
- `pymilvus/bulk_writer/__init__.py`: export `commit_import` / `abort_import`.
- `tests/test_bulk_import.py`: add `TestCommitImport` / `TestAbortImport` (job_id + DB-Name header + JSON payload, and error-code path).

### Test Plan

- [x] `pytest tests/test_bulk_import.py` — 16 passed (12 existing + 4 new).
- [x] `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)