### PR TITLE
fix(abstract): LoopBase.__getitem__ treats stop=0 as falsy, returning wrong slice

### DIFF
--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -581,7 +581,7 @@ class LoopBase:
     def __getitem__(self, item: Any):
         if isinstance(item, slice):
             _start = item.start or 0
-            _end = min(item.stop, self.__len__()) if item.stop else self.__len__()
+            _end = min(item.stop, self.__len__()) if item.stop is not None else self.__len__()
             _step = item.step or 1
 
             return [self.get__item(i) for i in range(_start, _end, _step)]

--- a/tests/test_client_abstract.py
+++ b/tests/test_client_abstract.py
@@ -985,6 +985,12 @@ class TestLoopBase:
         assert loop[:] == [1, 2, 3]
         assert loop[None:None:None] == [1, 2, 3]
 
+    def test_loop_base_getitem_slice_stop_zero(self):
+        """Test LoopBase slice with stop=0 returns empty list (not all items)."""
+        loop = self.ConcreteLoop([1, 2, 3])
+        assert loop[0:0] == []
+        assert loop[1:0] == []
+
     def test_loop_base_str(self):
         """Test LoopBase __str__ method."""
         loop = self.ConcreteLoop([1, 2, 3])


### PR DESCRIPTION
## What's broken

`LoopBase.__getitem__` uses `if item.stop` to decide whether to use the caller's stop value, but `0` is falsy in Python. Any slice with `stop=0` (e.g. `page[0:0]`, `page[1:0]`) silently sets `_end = self.__len__()` and returns all elements from `start` onwards instead of an empty list. Every `LoopBase` subclass is affected, including `SearchPage` used by the search iterator.

## Why it happens

The guard in `abstract.py` line 584 was `if item.stop` — a truthiness check that treats `0` the same as `None`.

## Fix

One-character change: `if item.stop` → `if item.stop is not None`. This preserves the existing behaviour for `None` (open-ended slice) while correctly handling zero.

## Test

Added `test_loop_base_getitem_slice_stop_zero` to `tests/test_client_abstract.py`. It asserts that `loop[0:0]` and `loop[1:0]` both return `[]` for a three-element loop.

Fixes #3543