### PR TITLE
feat: add interface for alter_collection_schema (#3128)

### DIFF
--- a/examples/test_add_function_field_full_text_search.py
+++ b/examples/test_add_function_field_full_text_search.py
@@ -1,0 +1,442 @@
+"""
+Validate BM25 full-text search on a sparse field added through add_function_field.
+"""
+
+import logging
+import os
+import time
+from contextlib import contextmanager
+from typing import Any
+
+from pymilvus import DataType, FieldSchema, Function, FunctionType, MilvusClient
+from pymilvus.exceptions import MilvusException
+
+HOST = os.environ.get("MILVUS_URI", "http://localhost:19530")
+COLLECTION_NAME = os.environ.get(
+    "ADD_FUNCTION_FULL_TEXT_COLLECTION",
+    "test_add_function_field_full_text_search",
+)
+CLEAR_EXIST_COLLECTION = os.environ.get("FULL_TEXT_CLEAR_EXIST", "true").lower() in {
+    "1",
+    "true",
+    "yes",
+    "y",
+    "on",
+}
+DIM = 128
+SEALED_ROWS = int(os.environ.get("FULL_TEXT_SEALED_ROWS", "10000"))
+GROWING_ROWS = int(os.environ.get("FULL_TEXT_GROWING_ROWS", "200"))
+INSERT_BATCH = 5000
+TOTAL_ROWS = SEALED_ROWS + GROWING_ROWS
+SEARCH_TIMEOUT = float(os.environ.get("FULL_TEXT_SEARCH_TIMEOUT", "300"))
+SEARCH_POLL_INTERVAL = float(os.environ.get("FULL_TEXT_SEARCH_POLL_INTERVAL", "3"))
+ID_FIELD = "id"
+DENSE_FIELD = "vec"
+TEXT_FIELD = "text"
+SPARSE_FIELD = "sparse"
+FUNCTION_NAME = "bm25_fn"
+SPARSE_INDEX_NAME = "sparse_bm25_index"
+SEARCH_QUERY = "information retrieval ranking"
+QUERY_TERMS = {"information", "retrieval", "ranking"}
+TEXT_CORPUS = [
+    "information retrieval ranking for document search and scoring",
+    "ranking models compare relevance across sparse vector candidates",
+    "bm25 normalization balances term frequency and document length",
+    "schema evolution keeps searchable fields compatible over time",
+    "dense vectors complement sparse retrieval in hybrid recall",
+    "retrieval pipelines aggregate candidate sets before rerank",
+    "ranking accuracy depends on both term stats and index quality",
+    "background text with weak relevance and broad vocabulary coverage",
+    "long document body with many neutral terms and few query terms present",
+    "short focused text about retrieval ranking information relevance",
+]
+SEARCH_LIMIT = int(os.environ.get("FULL_TEXT_SEARCH_LIMIT", "20"))
+SEGMENT_CHECK_LIMIT = int(os.environ.get("FULL_TEXT_SEGMENT_CHECK_LIMIT", "20"))
+SEARCH_PARAMS = {"metric_type": "BM25", "params": {"drop_ratio_search": 0.2}}
+POST_FLUSH_SEARCH_ROUNDS = int(os.environ.get("FULL_TEXT_POST_FLUSH_SEARCH_ROUNDS", "20"))
+POST_FLUSH_SEARCH_INTERVAL = float(os.environ.get("FULL_TEXT_POST_FLUSH_SEARCH_INTERVAL", "1"))
+
+# Keep sealed and growing distributions aligned to avoid segment-source bias.
+SEALED_TEXTS = TEXT_CORPUS
+GROWING_TEXTS = TEXT_CORPUS
+
+SEALED_ID_FILTER = f"{ID_FIELD} >= 0 and {ID_FIELD} < {SEALED_ROWS}"
+GROWING_ID_FILTER = f"{ID_FIELD} >= {SEALED_ROWS} and {ID_FIELD} < {TOTAL_ROWS}"
+EOF_ERR = "BM25 search returned no hits within timeout"
+EXPECTED_NO_SPARSE_INDEX_ERR = "field sparse is not loaded"
+PYMILVUS_DECORATOR_LOGGER = "pymilvus.decorators"
+
+
+@contextmanager
+def _suppress_expected_pymilvus_rpc_error() -> None:
+    logger = logging.getLogger(PYMILVUS_DECORATOR_LOGGER)
+    previous_disabled = logger.disabled
+    logger.disabled = True
+    try:
+        yield
+    finally:
+        logger.disabled = previous_disabled
+
+
+def _drop_collection_if_exists(client: MilvusClient, collection_name: str) -> None:
+    if client.has_collection(collection_name):
+        client.drop_collection(collection_name)
+
+
+def _prepare_collection_start(client: MilvusClient, collection_name: str) -> None:
+    if CLEAR_EXIST_COLLECTION:
+        _drop_collection_if_exists(client, collection_name)
+        print(f"clear_exist enabled, dropped existing collection if present: {collection_name}")
+    else:
+        print(f"clear_exist disabled, keep existing collection if present: {collection_name}")
+
+
+def _create_collection(client: MilvusClient, collection_name: str) -> None:
+    schema = client.create_schema()
+    schema.add_field(ID_FIELD, DataType.INT64, is_primary=True, auto_id=False)
+    schema.add_field(DENSE_FIELD, DataType.FLOAT_VECTOR, dim=DIM)
+    schema.add_field(TEXT_FIELD, DataType.VARCHAR, max_length=2048, enable_analyzer=True)
+
+    index_params = client.prepare_index_params()
+    index_params.add_index(DENSE_FIELD, index_type="FLAT", metric_type="L2")
+
+    client.create_collection(collection_name, schema=schema, index_params=index_params)
+
+
+def _make_rows(start_id: int, count: int, text_pool: list[str]) -> list[dict[str, Any]]:
+    rows = []
+    for row_id in range(start_id, start_id + count):
+        rows.append(
+            {
+                ID_FIELD: row_id,
+                DENSE_FIELD: [float((row_id + dim) % 100) / 100 for dim in range(DIM)],
+                TEXT_FIELD: text_pool[row_id % len(text_pool)],
+            }
+        )
+    return rows
+
+
+def _insert_rows_in_batches(
+    client: MilvusClient,
+    collection_name: str,
+    start_id: int,
+    total_rows: int,
+    text_pool: list[str],
+) -> None:
+    inserted = 0
+    while inserted < total_rows:
+        batch_count = min(INSERT_BATCH, total_rows - inserted)
+        client.insert(collection_name, _make_rows(start_id + inserted, batch_count, text_pool))
+        inserted += batch_count
+
+
+def _insert_sealed_rows(client: MilvusClient, collection_name: str) -> None:
+    _insert_rows_in_batches(client, collection_name, 0, SEALED_ROWS, SEALED_TEXTS)
+
+
+def _insert_growing_rows(client: MilvusClient, collection_name: str) -> None:
+    _insert_rows_in_batches(client, collection_name, SEALED_ROWS, GROWING_ROWS, GROWING_TEXTS)
+
+
+def _function_field_spec() -> tuple[FieldSchema, Function]:
+    sparse_field = FieldSchema(
+        name=SPARSE_FIELD,
+        dtype=DataType.SPARSE_FLOAT_VECTOR,
+        desc="BM25 output field added by add_function_field full-text search test",
+    )
+    bm25_fn = Function(
+        name=FUNCTION_NAME,
+        input_field_names=[TEXT_FIELD],
+        output_field_names=[SPARSE_FIELD],
+        function_type=FunctionType.BM25,
+    )
+    return sparse_field, bm25_fn
+
+
+def _add_function_field_once(client: MilvusClient, collection_name: str) -> None:
+    sparse_field, bm25_fn = _function_field_spec()
+    client.add_function_field(
+        collection_name,
+        field_schema=sparse_field,
+        func=bm25_fn,
+    )
+
+
+def _create_sparse_index(client: MilvusClient, collection_name: str) -> None:
+    index_params = client.prepare_index_params()
+    index_params.add_index(
+        field_name=SPARSE_FIELD,
+        index_type="SPARSE_INVERTED_INDEX",
+        index_name=SPARSE_INDEX_NAME,
+        metric_type="BM25",
+        params={"inverted_index_algo": "DAAT_MAXSCORE", "bm25_k1": 1.2, "bm25_b": 0.75},
+    )
+    client.create_index(collection_name, index_params)
+
+
+def _assert_schema_after_add(schema_info: dict[str, Any]) -> None:
+    field_names = {field["name"] for field in schema_info["fields"]}
+    assert SPARSE_FIELD in field_names, f"Missing sparse field {SPARSE_FIELD!r}: {schema_info}"
+
+    functions = {func["name"]: func for func in schema_info["functions"]}
+    assert FUNCTION_NAME in functions, f"Missing BM25 function {FUNCTION_NAME!r}: {schema_info}"
+    assert functions[FUNCTION_NAME]["input_field_names"] == [TEXT_FIELD]
+    assert functions[FUNCTION_NAME]["output_field_names"] == [SPARSE_FIELD]
+    assert (
+        schema_info["schema_version"] == 1
+    ), f"Expected schema_version=1, got {schema_info['schema_version']}"
+
+
+# def _assert_sparse_index(client: MilvusClient, collection_name: str) -> None:
+#     indexes = client.list_indexes(collection_name)
+#     sparse_indexes = client.list_indexes(collection_name, field_name=SPARSE_FIELD)
+#     index_info = client.describe_index(collection_name, SPARSE_INDEX_NAME)
+#     print(f"Indexes after add_function_field/create_index: {indexes}")
+#     print(f"Sparse indexes: {sparse_indexes}")
+#     print(f"Sparse index info: {index_info}")
+#     assert SPARSE_INDEX_NAME in indexes, f"Missing index {SPARSE_INDEX_NAME!r}: {indexes}"
+#     assert SPARSE_INDEX_NAME in sparse_indexes, f"Missing sparse index for {SPARSE_FIELD!r}: {sparse_indexes}"
+#     assert index_info is not None, f"Missing index info for {SPARSE_INDEX_NAME!r}"
+
+
+def _hit_field(hit: dict[str, Any], field_name: str) -> Any:
+    if field_name in hit:
+        return hit[field_name]
+    entity = hit.get("entity")
+    if isinstance(entity, dict):
+        return entity.get(field_name)
+    return None
+
+
+def _search_once(
+    client: MilvusClient,
+    collection_name: str,
+    query: str,
+    limit: int,
+    filter_expr: str | None = None,
+) -> list[dict[str, Any]]:
+    search_kwargs = {
+        "collection_name": collection_name,
+        "data": [query],
+        "anns_field": SPARSE_FIELD,
+        "search_params": SEARCH_PARAMS,
+        "output_fields": [ID_FIELD, TEXT_FIELD],
+        "limit": limit,
+    }
+    if filter_expr:
+        search_kwargs["filter"] = filter_expr
+    results = client.search(**search_kwargs)
+    assert len(results) == 1, f"Expected one result set, got {len(results)}"
+    return results[0]
+
+
+def _milvus_exception_message(exc: MilvusException) -> str:
+    return f"code={exc.code}, message={exc.message}"
+
+
+def _assert_search_fails_without_sparse_index(client: MilvusClient, collection_name: str) -> None:
+    try:
+        with _suppress_expected_pymilvus_rpc_error():
+            hits = _search_once(client, collection_name, SEARCH_QUERY, SEARCH_LIMIT)
+    except MilvusException as exc:
+        err_msg = _milvus_exception_message(exc)
+        print(f"Expected BM25 search failure before sparse index creation: {err_msg}")
+        assert EXPECTED_NO_SPARSE_INDEX_ERR in exc.message, err_msg
+        return
+    except Exception as exc:
+        err_msg = str(exc)
+        print(f"Expected BM25 search failure before sparse index creation: {err_msg}")
+        assert EXPECTED_NO_SPARSE_INDEX_ERR in err_msg, err_msg
+        return
+
+    print(f"Raw BM25 search result before sparse index creation: {hits}")
+    if not hits:
+        print("Expected BM25 search returned no hits before sparse index creation")
+        return
+
+    try:
+        _assert_mixed_segment_hits(hits)
+    except Exception as exc:
+        print(f"Expected BM25 search returned invalid hits before sparse index creation: {exc}")
+        return
+
+    raise AssertionError("BM25 search unexpectedly succeeded before sparse index creation")
+
+
+def _search_until_ready(
+    client: MilvusClient,
+    collection_name: str,
+    query: str,
+    limit: int,
+    filter_expr: str | None = None,
+) -> list[dict[str, Any]]:
+    deadline = time.time() + SEARCH_TIMEOUT
+    last_error = None
+    printed_errors: set[str] = set()
+    while time.time() < deadline:
+        try:
+            with _suppress_expected_pymilvus_rpc_error():
+                hits = _search_once(client, collection_name, query, limit, filter_expr=filter_expr)
+            if hits:
+                return hits
+        except MilvusException as exc:
+            last_error = exc
+            err_msg = _milvus_exception_message(exc)
+            if err_msg not in printed_errors:
+                print(
+                    f"BM25 search is not ready yet for query={query!r}, filter={filter_expr!r}: {err_msg}"
+                )
+                printed_errors.add(err_msg)
+        except Exception as exc:
+            last_error = exc
+            err_msg = str(exc)
+            if err_msg not in printed_errors:
+                print(
+                    f"BM25 search is not ready yet for query={query!r}, filter={filter_expr!r}: {err_msg}"
+                )
+                printed_errors.add(err_msg)
+        time.sleep(SEARCH_POLL_INTERVAL)
+
+    raise AssertionError(
+        f"{EOF_ERR}: timeout={SEARCH_TIMEOUT}s, query={query!r}, filter={filter_expr!r}, last_error={last_error}"
+    )
+
+
+def _assert_ids_cover_segment_range(
+    hits: list[dict[str, Any]],
+    lower_bound: int,
+    upper_bound: int,
+    segment_name: str,
+) -> None:
+    hit_ids = [_hit_field(hit, ID_FIELD) for hit in hits]
+    assert any(
+        isinstance(hit_id, int) and lower_bound <= hit_id < upper_bound for hit_id in hit_ids
+    ), f"Expected at least one {segment_name} hit in [{lower_bound}, {upper_bound}), got ids={hit_ids}"
+
+
+def _assert_ids_do_not_exceed_total_rows(hits: list[dict[str, Any]]) -> None:
+    hit_ids = [_hit_field(hit, ID_FIELD) for hit in hits]
+    assert all(isinstance(hit_id, int) and 0 <= hit_id < TOTAL_ROWS for hit_id in hit_ids), hit_ids
+
+
+def _assert_top_hit_contains_terms(hits: list[dict[str, Any]], terms: set[str]) -> None:
+    top_text = str(_hit_field(hits[0], TEXT_FIELD)).lower()
+    assert terms.issubset(set(top_text.split())), f"Top hit is not query-relevant: {hits[0]}"
+
+
+def _print_hits(title: str, hits: list[dict[str, Any]]) -> None:
+    print(f"{title} returned {len(hits)} hits:")
+    for hit in hits:
+        print(
+            f"  id={_hit_field(hit, ID_FIELD)}, "
+            f"score={hit.get('distance')}, "
+            f"text={_hit_field(hit, TEXT_FIELD)!r}"
+        )
+
+
+def _assert_mixed_segment_hits(hits: list[dict[str, Any]]) -> None:
+    _print_hits("BM25 mixed segment search", hits)
+    _assert_ids_do_not_exceed_total_rows(hits)
+    _assert_top_hit_contains_terms(hits, QUERY_TERMS)
+    # Mixed query can legitimately skew to one segment depending on term stats.
+    # Segment-source validation is performed separately by _assert_segment_specific_hits.
+
+
+def _assert_segment_specific_hits(
+    title: str,
+    hits: list[dict[str, Any]],
+    lower_bound: int,
+    upper_bound: int,
+    segment_name: str,
+) -> None:
+    _print_hits(title, hits)
+    _assert_ids_do_not_exceed_total_rows(hits)
+    _assert_top_hit_contains_terms(hits, QUERY_TERMS)
+    _assert_ids_cover_segment_range(hits, lower_bound, upper_bound, segment_name)
+
+
+def _assert_search_hits(hits: list[dict[str, Any]]) -> None:
+    _assert_mixed_segment_hits(hits)
+
+
+def _assert_repeated_search_success(client: MilvusClient, collection_name: str) -> None:
+    for round_idx in range(1, POST_FLUSH_SEARCH_ROUNDS + 1):
+        hits = _search_once(client, collection_name, SEARCH_QUERY, SEARCH_LIMIT)
+        assert hits, f"Round {round_idx}: BM25 search returned no hits"
+        print(f"Post-flush BM25 search round {round_idx}/{POST_FLUSH_SEARCH_ROUNDS} succeeded")
+        if round_idx < POST_FLUSH_SEARCH_ROUNDS:
+            time.sleep(POST_FLUSH_SEARCH_INTERVAL)
+
+
+def _assert_basic_search_hits(hits: list[dict[str, Any]]) -> None:
+    _print_hits("BM25 search", hits)
+    _assert_ids_do_not_exceed_total_rows(hits)
+    _assert_top_hit_contains_terms(hits, QUERY_TERMS)
+
+
+def run_add_function_field_full_text_search() -> None:
+    client = MilvusClient(HOST)
+    try:
+        print(f"[STEP1] create collection without BM25 function: {COLLECTION_NAME}")
+        _prepare_collection_start(client, COLLECTION_NAME)
+        _create_collection(client, COLLECTION_NAME)
+        initial_schema = client.describe_collection(COLLECTION_NAME)
+        print(f"Initial collection schema: {initial_schema}")
+        assert initial_schema["functions"] == []
+
+        print(f"[STEP2] insert and flush {SEALED_ROWS} sealed rows before add_function_field")
+        _insert_sealed_rows(client, COLLECTION_NAME)
+        client.flush(COLLECTION_NAME)
+        stats = client.get_collection_stats(COLLECTION_NAME)
+        print(f"Collection stats after flush: {stats}")
+        assert (
+            stats["row_count"] == SEALED_ROWS
+        ), f"Expected {SEALED_ROWS} rows, got {stats['row_count']}"
+
+        print("[STEP3] load collection before add_function_field")
+        client.load_collection(COLLECTION_NAME, load_fields=[ID_FIELD, DENSE_FIELD, TEXT_FIELD])
+
+        print("[STEP4] add_function_field once for BM25 sparse output field")
+        _add_function_field_once(client, COLLECTION_NAME)
+        schema_after_add = client.describe_collection(COLLECTION_NAME)
+        print(f"Collection schema after add_function_field: {schema_after_add}")
+        _assert_schema_after_add(schema_after_add)
+
+        # print("[STEP4.1] verify create_index result on new sparse field")
+        # _assert_sparse_index(client, COLLECTION_NAME)
+
+        print(f"[STEP5.1] insert {GROWING_ROWS} rows after load without flush (growing data)")
+        _insert_growing_rows(client, COLLECTION_NAME)
+
+        print("[STEP5.2] verify BM25 search fails before sparse index creation")
+        _assert_search_fails_without_sparse_index(client, COLLECTION_NAME)
+
+        print("[STEP5.3] create sparse index explicitly")
+        _create_sparse_index(client, COLLECTION_NAME)
+
+        print("[STEP5.4] search sparse field until success")
+        mixed_hits = _search_until_ready(client, COLLECTION_NAME, SEARCH_QUERY, SEARCH_LIMIT)
+        _assert_mixed_segment_hits(mixed_hits)
+
+        print("[STEP5.5] flush growing rows")
+        client.flush(COLLECTION_NAME)
+
+        print(
+            f"[STEP5.6] verify {POST_FLUSH_SEARCH_ROUNDS} post-flush searches "
+            f"with interval={POST_FLUSH_SEARCH_INTERVAL}s"
+        )
+        _assert_repeated_search_success(client, COLLECTION_NAME)
+
+        print(f"Final collection stats: {client.get_collection_stats(COLLECTION_NAME)}")
+        print(f"Final collection schema: {client.describe_collection(COLLECTION_NAME)}")
+        print("PASS: add_function_field BM25 full-text search flow verified")
+    finally:
+        client.close()
+
+
+def main() -> None:
+    run_add_function_field_full_text_search()
+
+
+if __name__ == "__main__":
+    main()

--- a/pymilvus/client/abstract.py
+++ b/pymilvus/client/abstract.py
@@ -243,6 +243,7 @@ class CollectionSchema:
 
         self.collection_name = None
         self.description = None
+        self.schema_version = 0
         self.params = {}
         self.fields = []
         self.struct_array_fields = []
@@ -307,6 +308,7 @@ class CollectionSchema:
             StructArrayFieldSchema(f) for f in raw.schema.struct_array_fields
         ]
         self.functions = [FunctionSchema(f) for f in raw.schema.functions]
+        self.schema_version = raw.schema.version
         function_output_field_names = [f for fn in self.functions for f in fn.output_field_names]
         for field in self.fields:
             if field.name in function_output_field_names:
@@ -346,6 +348,7 @@ class CollectionSchema:
             "num_partitions": self.num_partitions,
             "enable_dynamic_field": self.enable_dynamic_field,
             "enable_namespace": self.enable_namespace,
+            "schema_version": self.schema_version,
         }
 
         if self.external_source:

--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1618,6 +1618,49 @@ class AsyncGrpcHandler:
         check_status(status)
         self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
+    async def _alter_collection_schema_drop(
+        self,
+        collection_name: str,
+        field_name: str = "",
+        field_id: int = 0,
+        function_name: str = "",
+        db_name: str = "",
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        await self.ensure_channel_ready()
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.alter_collection_schema_request(
+            collection_name=collection_name,
+            drop_field_name=field_name,
+            drop_field_id=field_id,
+        )
+        response = await self._async_stub.AlterCollectionSchema(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.alter_status)
+
+    @retry_on_rpc_failure()
+    async def drop_collection_field(
+        self,
+        collection_name: str,
+        field_name: str = "",
+        field_id: int = 0,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        await self._alter_collection_schema_drop(
+            collection_name,
+            field_name=field_name,
+            field_id=field_id,
+            timeout=timeout,
+            context=context,
+            **kwargs,
+        )
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
+
     @retry_on_rpc_failure()
     async def drop_collection_function(
         self,
@@ -1671,6 +1714,32 @@ class AsyncGrpcHandler:
             request, timeout=timeout, metadata=_api_level_md(context)
         )
         check_status(status)
+
+    @retry_on_rpc_failure()
+    async def alter_collection_schema(
+        self,
+        collection_name: str,
+        field_schema: Optional[FieldSchema] = None,
+        func: Optional[Function] = None,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        drop_field_name: Optional[str] = None,
+        drop_field_id: Optional[int] = None,
+        **kwargs,
+    ):
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.alter_collection_schema_request(
+            collection_name=collection_name,
+            field_schema=field_schema,
+            func=func,
+            drop_field_name=drop_field_name,
+            drop_field_id=drop_field_id,
+        )
+        response = await self._async_stub.AlterCollectionSchema(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.alter_status)
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     async def list_indexes(

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -568,6 +568,48 @@ class GrpcHandler:
         check_status(status)
         self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
+    def _alter_collection_schema_drop(
+        self,
+        collection_name: str,
+        field_name: str = "",
+        field_id: int = 0,
+        function_name: str = "",
+        db_name: str = "",
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.alter_collection_schema_request(
+            collection_name=collection_name,
+            drop_field_name=field_name,
+            drop_field_id=field_id,
+        )
+        response = self._stub.AlterCollectionSchema(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.alter_status)
+
+    @retry_on_rpc_failure()
+    def drop_collection_field(
+        self,
+        collection_name: str,
+        field_name: str = "",
+        field_id: int = 0,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        self._alter_collection_schema_drop(
+            collection_name,
+            field_name=field_name,
+            field_id=field_id,
+            timeout=timeout,
+            context=context,
+            **kwargs,
+        )
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
+
     @retry_on_rpc_failure()
     def drop_collection_function(
         self,
@@ -621,6 +663,32 @@ class GrpcHandler:
             request, timeout=timeout, metadata=_api_level_md(context)
         )
         check_status(status)
+
+    @retry_on_rpc_failure()
+    def alter_collection_schema(
+        self,
+        collection_name: str,
+        field_schema: Optional[FieldSchema] = None,
+        func: Optional[Function] = None,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        drop_field_name: Optional[str] = None,
+        drop_field_id: Optional[int] = None,
+        **kwargs,
+    ):
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.alter_collection_schema_request(
+            collection_name=collection_name,
+            field_schema=field_schema,
+            func=func,
+            drop_field_name=drop_field_name,
+            drop_field_id=drop_field_id,
+        )
+        response = self._stub.AlterCollectionSchema(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+        check_status(response.alter_status)
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     def alter_collection_properties(

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -385,6 +385,62 @@ class Prepare:
         return schema
 
     @classmethod
+    def alter_collection_schema_request(
+        cls,
+        collection_name: str,
+        field_schema: Optional[FieldSchema] = None,
+        func: Optional[Function] = None,
+        drop_field_name: Optional[str] = None,
+        drop_field_id: Optional[int] = None,
+    ) -> milvus_types.AlterCollectionSchemaRequest:
+        is_drop = drop_field_name is not None or (drop_field_id is not None and drop_field_id > 0)
+        is_add = field_schema is not None or func is not None
+
+        if is_drop and is_add:
+            raise ParamError(
+                message="Cannot perform both Add and Drop operations in a single request"
+            )
+        if not is_drop and not is_add:
+            raise ParamError(
+                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id)"
+            )
+
+        if is_drop:
+            drop_request = milvus_types.AlterCollectionSchemaRequest.DropRequest()
+            if drop_field_name is not None:
+                drop_request.field_name = drop_field_name
+            else:
+                drop_request.field_id = drop_field_id
+
+            action = milvus_types.AlterCollectionSchemaRequest.Action(drop_request=drop_request)
+        else:
+            field_infos = []
+            func_schemas = []
+
+            if field_schema is not None:
+                field_schema_proto, _, _ = cls.get_field_schema(field_schema.to_dict())
+
+                field_info = milvus_types.AlterCollectionSchemaRequest.FieldInfo(
+                    field_schema=field_schema_proto,
+                )
+                field_infos.append(field_info)
+
+            if func is not None:
+                func_schemas.append(cls.convert_function_to_function_schema(func))
+
+            add_request = milvus_types.AlterCollectionSchemaRequest.AddRequest(
+                field_infos=field_infos,
+                func_schema=func_schemas,
+            )
+
+            action = milvus_types.AlterCollectionSchemaRequest.Action(add_request=add_request)
+
+        return milvus_types.AlterCollectionSchemaRequest(
+            collection_name=collection_name,
+            action=action,
+        )
+
+    @classmethod
     def drop_collection_request(cls, collection_name: str) -> milvus_types.DropCollectionRequest:
         return milvus_types.DropCollectionRequest(collection_name=collection_name)
 

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -11,6 +11,7 @@ from pymilvus.client.constants import CLUSTER_ID, DEFAULT_CONSISTENCY_LEVEL
 from pymilvus.client.search_aggregation import SearchAggregation
 from pymilvus.client.types import (
     ExceptionsMessage,
+    FunctionType,
     LoadState,
     OmitZeroDict,
     RefreshExternalCollectionJobInfo,
@@ -32,7 +33,7 @@ from pymilvus.exceptions import (
     PrimaryKeyException,
 )
 from pymilvus.orm.collection import CollectionSchema, Function, FunctionScore
-from pymilvus.orm.schema import StructFieldSchema
+from pymilvus.orm.schema import FieldSchema, StructFieldSchema
 from pymilvus.orm.types import DataType
 
 from .async_optimize_task import AsyncOptimizeTask
@@ -1086,6 +1087,121 @@ class AsyncMilvusClient(BaseMilvusClient):
             function_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    async def drop_collection_field(
+        self,
+        collection_name: str,
+        field_name: str = "",
+        field_id: int = 0,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """Drop a field from the collection."""
+        await self._alter_collection_schema(
+            collection_name=collection_name,
+            drop_field_name=field_name,
+            drop_field_id=field_id,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    async def _alter_collection_schema(
+        self,
+        collection_name: str,
+        field_schema: Optional[FieldSchema] = None,
+        func: Optional[Function] = None,
+        timeout: Optional[float] = None,
+        drop_field_name: Optional[str] = None,
+        drop_field_id: Optional[int] = None,
+        **kwargs,
+    ):
+        """Alter collection schema supporting both Add and Drop operations.
+
+        For Add operation: provide field_schema and func
+        For Drop operation: provide either drop_field_name or drop_field_id
+
+        Args:
+            collection_name(``str``): The name of the collection.
+            field_schema(``FieldSchema``, optional): Field schema to add.
+            func(``Function``, optional): Function to add.
+            timeout(``float``, optional): Timeout for the operation.
+            drop_field_name(``str``, optional): Field name to drop.
+            drop_field_id(``int``, optional): Field ID to drop.
+            **kwargs(``dict``): Additional keyword arguments.
+
+        Raises:
+            ParamError: If operation parameters are invalid.
+            MilvusException: If the operation fails.
+        """
+        validate_param("collection_name", collection_name, str)
+        conn = await self._get_connection()
+
+        is_drop = drop_field_name is not None or drop_field_id is not None
+        is_add = field_schema is not None or func is not None
+
+        if is_drop and is_add:
+            raise ParamError(
+                message="Cannot perform both Add and Drop operations in a single request"
+            )
+        if not is_drop and not is_add:
+            raise ParamError(
+                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id)"
+            )
+
+        if is_add:
+            if field_schema is None:
+                raise ParamError(message="field_schema is required for Add operation")
+            if func is None:
+                raise ParamError(message="func is required for Add operation")
+
+            await conn.alter_collection_schema(
+                collection_name=collection_name,
+                field_schema=field_schema,
+                func=func,
+                timeout=timeout,
+                context=self._generate_call_context(**kwargs),
+                **kwargs,
+            )
+        else:
+            await conn.alter_collection_schema(
+                collection_name=collection_name,
+                drop_field_name=drop_field_name,
+                drop_field_id=drop_field_id,
+                timeout=timeout,
+                context=self._generate_call_context(**kwargs),
+                **kwargs,
+            )
+
+    async def add_function_field(
+        self,
+        collection_name: str,
+        field_schema: FieldSchema,
+        func: Function,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """Add a function-backed field (e.g. BM25 sparse vector) to an existing collection."""
+        validate_param("collection_name", collection_name, str)
+        validate_param("field_schema", field_schema, FieldSchema)
+        validate_param("func", func, Function)
+
+        # Only BM25 + SPARSE_FLOAT_VECTOR is currently supported on the server side.
+        if func.type != FunctionType.BM25:
+            raise ParamError(
+                message=f"add_function_field only supports FunctionType.BM25 for now, got {func.type}"
+            )
+        if field_schema.dtype != DataType.SPARSE_FLOAT_VECTOR:
+            raise ParamError(
+                message=f"add_function_field only supports SPARSE_FLOAT_VECTOR output field for now, got {field_schema.dtype}"
+            )
+
+        await self._alter_collection_schema(
+            collection_name=collection_name,
+            field_schema=field_schema,
+            func=func,
+            timeout=timeout,
             **kwargs,
         )
 

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -13,6 +13,7 @@ from pymilvus.client.search_iterator import SearchIteratorV2
 from pymilvus.client.types import (
     CompactionPlans,
     ExceptionsMessage,
+    FunctionType,
     LoadedSegmentInfo,
     LoadState,
     OmitZeroDict,
@@ -39,7 +40,7 @@ from pymilvus.exceptions import (
 from pymilvus.orm.collection import CollectionSchema, Function, FunctionScore, Highlighter
 from pymilvus.orm.constants import FIELDS, METRIC_TYPE, TYPE, UNLIMITED
 from pymilvus.orm.iterator import QueryIterator, SearchIterator
-from pymilvus.orm.schema import StructFieldSchema
+from pymilvus.orm.schema import FieldSchema, StructFieldSchema
 from pymilvus.orm.types import DataType
 
 from .base import BaseMilvusClient
@@ -1359,6 +1360,141 @@ class MilvusClient(BaseMilvusClient):
             function_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    def drop_collection_field(
+        self,
+        collection_name: str,
+        field_name: str = "",
+        field_id: int = 0,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """Drop a field from the collection."""
+        self._alter_collection_schema(
+            collection_name=collection_name,
+            drop_field_name=field_name,
+            drop_field_id=field_id,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    def _alter_collection_schema(
+        self,
+        collection_name: str,
+        field_schema: Optional[FieldSchema] = None,
+        func: Optional[Function] = None,
+        timeout: Optional[float] = None,
+        drop_field_name: Optional[str] = None,
+        drop_field_id: Optional[int] = None,
+        **kwargs,
+    ):
+        """Alter collection schema supporting both Add and Drop operations.
+
+        For Add operation: provide field_schema and func
+        For Drop operation: provide either drop_field_name or drop_field_id
+
+        Args:
+            collection_name(``str``): The name of the collection.
+            field_schema(``FieldSchema``, optional): Field schema to add.
+            func(``Function``, optional): Function to add.
+            timeout(``float``, optional): Timeout for the operation.
+            drop_field_name(``str``, optional): Field name to drop.
+            drop_field_id(``int``, optional): Field ID to drop.
+            **kwargs(``dict``): Additional keyword arguments.
+
+        Raises:
+            ParamError: If operation parameters are invalid.
+            MilvusException: If the operation fails.
+        """
+        validate_param("collection_name", collection_name, str)
+        conn = self._get_connection()
+
+        is_drop = drop_field_name is not None or drop_field_id is not None
+        is_add = field_schema is not None or func is not None
+
+        if is_drop and is_add:
+            raise ParamError(
+                message="Cannot perform both Add and Drop operations in a single request"
+            )
+        if not is_drop and not is_add:
+            raise ParamError(
+                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id)"
+            )
+
+        if is_add:
+            if field_schema is None:
+                raise ParamError(message="field_schema is required for Add operation")
+            if func is None:
+                raise ParamError(message="func is required for Add operation")
+
+            conn.alter_collection_schema(
+                collection_name=collection_name,
+                field_schema=field_schema,
+                func=func,
+                timeout=timeout,
+                context=self._generate_call_context(**kwargs),
+                **kwargs,
+            )
+        else:
+            conn.alter_collection_schema(
+                collection_name=collection_name,
+                drop_field_name=drop_field_name,
+                drop_field_id=drop_field_id,
+                timeout=timeout,
+                context=self._generate_call_context(**kwargs),
+                **kwargs,
+            )
+
+    def add_function_field(
+        self,
+        collection_name: str,
+        field_schema: FieldSchema,
+        func: Function,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """Add a function-backed field (e.g. BM25 sparse vector) to an existing collection.
+
+        This is a high-level convenience wrapper that commits the schema change
+        (new output field + function definition). Create indexes separately with
+        ``create_index`` after the schema change succeeds.
+
+        Args:
+            collection_name(``str``): Name of the collection to modify.
+            field_schema(``FieldSchema``): Schema of the new output field produced by
+                the function (e.g. a ``SPARSE_FLOAT_VECTOR`` field for BM25).
+            func(``Function``): Function definition that generates the output field
+                (e.g. a ``FunctionType.BM25`` function).
+            timeout(``float``, optional): Timeout in seconds for the schema-change RPC.
+            **kwargs: Additional keyword arguments forwarded to the underlying calls.
+
+        Raises:
+            ParamError: If any required parameter is missing or invalid.
+            MilvusException: If the schema change fails.
+        """
+        validate_param("collection_name", collection_name, str)
+        validate_param("field_schema", field_schema, FieldSchema)
+        validate_param("func", func, Function)
+
+        # Only BM25 + SPARSE_FLOAT_VECTOR is currently supported on the server side.
+        # The Proxy and RootCoord both enforce this; reject early here for a clearer
+        # error message before any RPC is sent.
+        if func.type != FunctionType.BM25:
+            raise ParamError(
+                message=f"add_function_field only supports FunctionType.BM25 for now, got {func.type}"
+            )
+        if field_schema.dtype != DataType.SPARSE_FLOAT_VECTOR:
+            raise ParamError(
+                message=f"add_function_field only supports SPARSE_FLOAT_VECTOR output field for now, got {field_schema.dtype}"
+            )
+
+        self._alter_collection_schema(
+            collection_name=collection_name,
+            field_schema=field_schema,
+            func=func,
+            timeout=timeout,
             **kwargs,
         )
 

--- a/tests/async_grpc_handler/test_async_collection.py
+++ b/tests/async_grpc_handler/test_async_collection.py
@@ -3,6 +3,7 @@
 Coverage: Collection create/drop/load/release, schema caching, collection properties.
 """
 
+import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -16,6 +17,10 @@ from pymilvus.orm.schema import StructFieldSchema
 
 class TestAsyncGrpcHandlerCollection:
     """Tests for AsyncGrpcHandler collection operations."""
+
+    def test_alter_collection_schema_signature_excludes_physical_backfill(self) -> None:
+        signature = inspect.signature(AsyncGrpcHandler.alter_collection_schema)
+        assert "do_physical_backfill" not in signature.parameters
 
     @pytest.mark.asyncio
     async def test_create_collection(self) -> None:
@@ -689,6 +694,32 @@ class TestAsyncGrpcHandlerCollectionProperties:
             mock_stub.DropCollectionFunction.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_drop_collection_field(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+        handler.ensure_channel_ready = AsyncMock()
+
+        mock_stub = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.alter_status = MagicMock(code=0, error_code=0, reason="")
+        mock_response.HasField.return_value = False
+        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        handler._async_stub = mock_stub
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_pass_param"
+        ), patch("pymilvus.client.async_grpc_handler.check_status"):
+            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            GlobalCache._reset_for_testing()
+            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
+            await handler.drop_collection_field("test_coll", field_name="old_field")
+            mock_stub.AlterCollectionSchema.assert_called_once()
+            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
+            GlobalCache._reset_for_testing()
+
+    @pytest.mark.asyncio
     async def test_add_collection_function(self) -> None:
         """Test add_collection_function async API"""
         mock_channel = MagicMock()
@@ -733,3 +764,55 @@ class TestAsyncGrpcHandlerCollectionProperties:
             mock_prepare.alter_collection_function_request.return_value = MagicMock()
             await handler.alter_collection_function("test_coll", "func1", mock_function)
             mock_stub.AlterCollectionFunction.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_alter_collection_schema_add(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+        handler.ensure_channel_ready = AsyncMock()
+
+        mock_stub = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.alter_status = MagicMock(code=0, error_code=0, reason="")
+        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        handler._async_stub = mock_stub
+
+        mock_field = MagicMock()
+        mock_func = MagicMock()
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_pass_param"
+        ), patch("pymilvus.client.async_grpc_handler.check_status"):
+            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            GlobalCache._reset_for_testing()
+            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
+            await handler.alter_collection_schema(
+                "test_coll",
+                field_schema=mock_field,
+                func=mock_func,
+            )
+            mock_stub.AlterCollectionSchema.assert_called_once()
+            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
+            GlobalCache._reset_for_testing()
+
+    @pytest.mark.asyncio
+    async def test_alter_collection_schema_drop(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+        handler.ensure_channel_ready = AsyncMock()
+
+        mock_stub = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.alter_status = MagicMock(code=0, error_code=0, reason="")
+        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        handler._async_stub = mock_stub
+
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_pass_param"
+        ), patch("pymilvus.client.async_grpc_handler.check_status"):
+            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            await handler.alter_collection_schema("test_coll", drop_field_name="old_field")
+            mock_stub.AlterCollectionSchema.assert_called_once()

--- a/tests/grpc_handler/test_collection.py
+++ b/tests/grpc_handler/test_collection.py
@@ -1,9 +1,10 @@
 """Tests for GrpcHandler collection operations."""
 
+import inspect
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pymilvus import FieldSchema, StructFieldSchema
+from pymilvus import FieldSchema, Function, FunctionType, StructFieldSchema
 from pymilvus.client.cache import GlobalCache
 from pymilvus.client.types import DataType
 from pymilvus.exceptions import DescribeCollectionException
@@ -19,6 +20,10 @@ from .conftest import (
 
 class TestGrpcHandlerCollectionOps:
     """Tests for collection operations."""
+
+    def test_alter_collection_schema_signature_excludes_physical_backfill(self, handler):
+        signature = inspect.signature(handler.alter_collection_schema)
+        assert "do_physical_backfill" not in signature.parameters
 
     @pytest.mark.parametrize("coll_name,expected_error", COLLECTION_VALIDATION_CASES)
     def test_create_collection_validation(self, handler, coll_name, expected_error):
@@ -225,3 +230,57 @@ class TestGrpcHandlerCollectionProperties:
         handler._stub.DropCollectionFunction.return_value = make_status()
         handler.drop_collection_function("coll", "func")
         handler._stub.DropCollectionFunction.assert_called_once()
+
+    def test_drop_collection_field(self, handler):
+        response = MagicMock()
+        response.alter_status.code = 0
+        response.alter_status.error_code = 0
+        handler._stub.AlterCollectionSchema.return_value = response
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
+        handler.drop_collection_field("coll", field_name="f")
+        handler._stub.AlterCollectionSchema.assert_called_once()
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()
+
+    def test_alter_collection_schema_add(self, handler):
+        resp = MagicMock()
+        resp.alter_status = make_status()
+        handler._stub.AlterCollectionSchema.return_value = resp
+        field = FieldSchema(name="new_field", dtype=DataType.FLOAT_VECTOR, dim=128)
+        func = Function(
+            name="bm25",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["sparse"],
+        )
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
+        handler.alter_collection_schema(
+            collection_name="coll",
+            field_schema=field,
+            func=func,
+        )
+        handler._stub.AlterCollectionSchema.assert_called_once()
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()
+
+    def test_alter_collection_schema_drop_by_name(self, handler):
+        resp = MagicMock()
+        resp.alter_status = make_status()
+        handler._stub.AlterCollectionSchema.return_value = resp
+        handler.alter_collection_schema(
+            collection_name="coll",
+            drop_field_name="old_field",
+        )
+        handler._stub.AlterCollectionSchema.assert_called_once()
+
+    def test_alter_collection_schema_drop_by_id(self, handler):
+        resp = MagicMock()
+        resp.alter_status = make_status()
+        handler._stub.AlterCollectionSchema.return_value = resp
+        handler.alter_collection_schema(
+            collection_name="coll",
+            drop_field_id=42,
+        )
+        handler._stub.AlterCollectionSchema.assert_called_once()

--- a/tests/prepare/test_collection.py
+++ b/tests/prepare/test_collection.py
@@ -1,5 +1,7 @@
 """Tests for collection-related Prepare methods."""
 
+import inspect
+
 import pytest
 from pymilvus import CollectionSchema, DataType, FieldSchema, Function, FunctionType
 from pymilvus.client.prepare import Prepare
@@ -378,3 +380,71 @@ class TestAddCollectionFieldRequest:
 
         assert params["mmap.enabled"] == "true"
         assert params["warmup"] == '{"policy":"async"}'
+
+
+class TestAlterCollectionSchemaRequest:
+    """Tests for alter_collection_schema_request."""
+
+    def test_request_builder_signature_excludes_physical_backfill(self):
+        signature = inspect.signature(Prepare.alter_collection_schema_request)
+        assert "do_physical_backfill" not in signature.parameters
+
+    def test_add_with_field_and_function(self):
+        field = FieldSchema("vec", DataType.FLOAT_VECTOR, dim=128)
+        func = Function(
+            name="bm25",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["sparse"],
+        )
+        req = Prepare.alter_collection_schema_request(
+            collection_name="coll",
+            field_schema=field,
+            func=func,
+        )
+        assert req.collection_name == "coll"
+        assert req.action.HasField("add_request")
+        assert len(req.action.add_request.field_infos) == 1
+        assert req.action.add_request.field_infos[0].index_name == ""
+        assert len(req.action.add_request.field_infos[0].extra_params) == 0
+        assert len(req.action.add_request.func_schema) == 1
+
+    def test_add_with_field_only(self):
+        field = FieldSchema("vec", DataType.FLOAT_VECTOR, dim=128)
+        req = Prepare.alter_collection_schema_request(
+            collection_name="coll",
+            field_schema=field,
+        )
+        assert req.action.HasField("add_request")
+        assert len(req.action.add_request.field_infos) == 1
+        assert len(req.action.add_request.func_schema) == 0
+
+    def test_drop_by_field_name(self):
+        req = Prepare.alter_collection_schema_request(
+            collection_name="coll",
+            drop_field_name="old_field",
+        )
+        assert req.collection_name == "coll"
+        assert req.action.HasField("drop_request")
+        assert req.action.drop_request.field_name == "old_field"
+
+    def test_drop_by_field_id(self):
+        req = Prepare.alter_collection_schema_request(
+            collection_name="coll",
+            drop_field_id=42,
+        )
+        assert req.action.HasField("drop_request")
+        assert req.action.drop_request.field_id == 42
+
+    def test_error_on_both_add_and_drop(self):
+        field = FieldSchema("vec", DataType.FLOAT_VECTOR, dim=128)
+        with pytest.raises(ParamError, match="Cannot perform both"):
+            Prepare.alter_collection_schema_request(
+                collection_name="coll",
+                field_schema=field,
+                drop_field_name="old",
+            )
+
+    def test_error_on_neither_add_nor_drop(self):
+        with pytest.raises(ParamError, match="Must specify"):
+            Prepare.alter_collection_schema_request(collection_name="coll")

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1,10 +1,19 @@
 """Test cases for AsyncMilvusClient new features"""
 
+import inspect
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
-from pymilvus import AsyncMilvusClient, DataType, SearchAggregation, TopHits
+from pymilvus import (
+    AsyncMilvusClient,
+    DataType,
+    FieldSchema,
+    Function,
+    FunctionType,
+    SearchAggregation,
+    TopHits,
+)
 from pymilvus.client.abstract import AnnSearchRequest
 from pymilvus.client.connection_manager import AsyncConnectionManager
 from pymilvus.client.types import (
@@ -16,7 +25,6 @@ from pymilvus.client.types import (
 )
 from pymilvus.exceptions import MilvusException, ParamError
 from pymilvus.milvus_client.async_milvus_client import AsyncMilvusClientSession
-from pymilvus.orm.collection import Function
 from pymilvus.orm.schema import StructFieldSchema
 
 
@@ -1350,3 +1358,99 @@ class TestAsyncMilvusClientGetReplicateInfo:
 
         assert result == expected
         mock_handler.get_replicate_info.assert_called_once()
+
+
+class TestAsyncAlterCollectionSchema:
+    def test_signature_excludes_physical_backfill(self):
+        assert not hasattr(AsyncMilvusClient, "alter_collection_schema")
+        assert (
+            "do_physical_backfill"
+            not in inspect.signature(AsyncMilvusClient._alter_collection_schema).parameters
+        )
+
+    @pytest.mark.asyncio
+    async def test_private_add_delegates(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        field = MagicMock()
+        func = MagicMock()
+        await client._alter_collection_schema("col", field_schema=field, func=func)
+        mock_handler.alter_collection_schema.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_private_drop_delegates(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        await client._alter_collection_schema("col", drop_field_name="old")
+        mock_handler.alter_collection_schema.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_private_rejects_both_add_and_drop(self, client_and_handler):
+        client, _ = client_and_handler
+
+        with pytest.raises(ParamError, match="Cannot perform both"):
+            await client._alter_collection_schema(
+                "col", field_schema=MagicMock(), drop_field_name="old"
+            )
+
+    @pytest.mark.asyncio
+    async def test_private_rejects_neither_add_nor_drop(self, client_and_handler):
+        client, _ = client_and_handler
+
+        with pytest.raises(ParamError, match="Must specify"):
+            await client._alter_collection_schema("col")
+
+    @pytest.mark.asyncio
+    async def test_private_add_requires_field_and_func(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
+        func = Function("bm25", FunctionType.BM25, ["text"], ["sparse"])
+
+        with pytest.raises(ParamError, match="func is required"):
+            await client._alter_collection_schema("col", field_schema=field)
+        with pytest.raises(ParamError, match="field_schema is required"):
+            await client._alter_collection_schema("col", func=func)
+        mock_handler.alter_collection_schema.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drop_collection_field_delegates(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+
+        await client.drop_collection_field("col", field_name="old")
+
+        mock_handler.alter_collection_schema.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_add_function_field_delegates(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
+        func = Function("bm25", FunctionType.BM25, ["text"], ["sparse"])
+
+        await client.add_function_field("col", field, func)
+
+        mock_handler.alter_collection_schema.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_add_function_field_rejects_unsupported_function_type(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
+        func = Function("embed", FunctionType.TEXTEMBEDDING, ["text"], ["sparse"])
+
+        with pytest.raises(ParamError, match=r"only supports FunctionType\.BM25"):
+            await client.add_function_field("col", field, func)
+        mock_handler.alter_collection_schema.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_function_field_rejects_non_sparse_output(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        field = FieldSchema("dense", DataType.FLOAT_VECTOR, dim=8)
+        func = Function("bm25", FunctionType.BM25, ["text"], ["dense"])
+
+        with pytest.raises(ParamError, match="only supports SPARSE_FLOAT_VECTOR"):
+            await client.add_function_field("col", field, func)
+        mock_handler.alter_collection_schema.assert_not_called()

--- a/tests/test_client_abstract.py
+++ b/tests/test_client_abstract.py
@@ -459,6 +459,7 @@ class TestCollectionSchema:
         mock_schema.fields = []
         mock_schema.struct_array_fields = []
         mock_schema.functions = []
+        mock_schema.version = 0
 
         raw = MagicMock()
         raw.schema = mock_schema
@@ -509,6 +510,16 @@ class TestCollectionSchema:
         assert schema.enable_namespace is False
         assert schema.created_timestamp == 1704067200
         assert schema.update_timestamp == 1704153600
+        assert schema.schema_version == 0
+
+    def test_collection_schema_version(self):
+        """Test CollectionSchema schema_version field."""
+        raw = self._create_mock_collection_raw()
+        raw.schema.version = 5
+        schema = CollectionSchema(raw)
+        assert schema.schema_version == 5
+        d = schema.dict()
+        assert d["schema_version"] == 5
 
     def test_collection_schema_with_properties(self):
         """Test CollectionSchema with properties."""

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1,8 +1,17 @@
+import inspect
 import logging
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from pymilvus import DataType, SearchAggregation, StructFieldSchema, TopHits
+from pymilvus import (
+    DataType,
+    FieldSchema,
+    Function,
+    FunctionType,
+    SearchAggregation,
+    StructFieldSchema,
+    TopHits,
+)
 from pymilvus.client.connection_manager import ConnectionManager
 from pymilvus.client.types import (
     LoadState,
@@ -34,6 +43,17 @@ def reset_connection_manager():
 
 
 class TestMilvusClient:
+    def test_schema_extension_signatures_exclude_physical_backfill(self):
+        assert not hasattr(MilvusClient, "alter_collection_schema")
+        assert (
+            "do_physical_backfill"
+            not in inspect.signature(MilvusClient._alter_collection_schema).parameters
+        )
+        assert (
+            "do_physical_backfill"
+            not in inspect.signature(MilvusClient.add_function_field).parameters
+        )
+
     @pytest.mark.parametrize("index_params", [None, {}, "str", MilvusClient.prepare_index_params()])
     def test_create_index_invalid_params(self, index_params):
         mock_handler = MagicMock()
@@ -1547,6 +1567,98 @@ class TestMilvusClientCollectionMgmt:
             client = MilvusClient()
             client.drop_collection_function("col", "fn")
             handler.drop_collection_function.assert_called_once()
+
+    def test_drop_collection_field_delegates(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            client.drop_collection_field("col", field_name="f")
+            handler.alter_collection_schema.assert_called_once()
+
+    def test_private_alter_collection_schema_add_delegates(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            field = MagicMock()
+            func = MagicMock()
+            client._alter_collection_schema("col", field_schema=field, func=func)
+            handler.alter_collection_schema.assert_called_once()
+
+    def test_private_alter_collection_schema_drop_delegates(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            client._alter_collection_schema("col", drop_field_name="old")
+            handler.alter_collection_schema.assert_called_once()
+
+    def test_private_alter_collection_schema_rejects_both_add_and_drop(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            with pytest.raises(ParamError, match="Cannot perform both"):
+                client._alter_collection_schema(
+                    "col", field_schema=MagicMock(), drop_field_name="old"
+                )
+
+    def test_private_alter_collection_schema_rejects_neither_add_nor_drop(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            with pytest.raises(ParamError, match="Must specify"):
+                client._alter_collection_schema("col")
+
+    def test_private_alter_collection_schema_add_requires_field_and_func(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            with pytest.raises(ParamError, match="func is required"):
+                client._alter_collection_schema("col", field_schema=MagicMock())
+            with pytest.raises(ParamError, match="field_schema is required"):
+                client._alter_collection_schema("col", func=MagicMock())
+
+    def test_add_function_field_delegates(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
+            func = Function(
+                name="bm25",
+                function_type=FunctionType.BM25,
+                input_field_names=["text"],
+                output_field_names=["sparse"],
+            )
+            client.add_function_field("col", field, func)
+            handler.alter_collection_schema.assert_called_once()
+
+    def test_add_function_field_rejects_unsupported_function_type(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
+            func = Function(
+                name="embed",
+                function_type=FunctionType.TEXTEMBEDDING,
+                input_field_names=["text"],
+                output_field_names=["sparse"],
+            )
+            with pytest.raises(ParamError, match=r"only supports FunctionType\.BM25"):
+                client.add_function_field("col", field, func)
+            handler.alter_collection_schema.assert_not_called()
+
+    def test_add_function_field_rejects_non_sparse_output(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            field = FieldSchema("dense", DataType.FLOAT_VECTOR, dim=8)
+            func = Function(
+                name="bm25",
+                function_type=FunctionType.BM25,
+                input_field_names=["text"],
+                output_field_names=["dense"],
+            )
+            with pytest.raises(ParamError, match="only supports SPARSE_FLOAT_VECTOR"):
+                client.add_function_field("col", field, func)
+            handler.alter_collection_schema.assert_not_called()
 
 
 class TestMilvusClientMiscOps:


### PR DESCRIPTION
Add AlterCollectionSchema API supporting both Add and Drop operations:
- Add operation: provide field_schema, func, index_param
- Drop operation: provide drop_field_name or drop_field_id

related: #3128