### PR TITLE
feat: route collection schema drops through AlterCollectionSchema

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1635,6 +1635,7 @@ class AsyncGrpcHandler:
             collection_name=collection_name,
             drop_field_name=field_name,
             drop_field_id=field_id,
+            drop_function_name=function_name,
         )
         response = await self._async_stub.AlterCollectionSchema(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -1670,13 +1671,14 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        check_pass_param(collection_name=collection_name, timeout=timeout)
-        request = Prepare.drop_collection_function_request(collection_name, function_name)
-
-        status = await self._async_stub.DropCollectionFunction(
-            request, timeout=timeout, metadata=_api_level_md(context)
+        await self._alter_collection_schema_drop(
+            collection_name,
+            function_name=function_name,
+            timeout=timeout,
+            context=context,
+            **kwargs,
         )
-        check_status(status)
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     async def add_collection_function(
@@ -1725,6 +1727,7 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         drop_field_name: Optional[str] = None,
         drop_field_id: Optional[int] = None,
+        drop_function_name: Optional[str] = None,
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
@@ -1734,6 +1737,7 @@ class AsyncGrpcHandler:
             func=func,
             drop_field_name=drop_field_name,
             drop_field_id=drop_field_id,
+            drop_function_name=drop_function_name,
         )
         response = await self._async_stub.AlterCollectionSchema(
             request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -584,6 +584,7 @@ class GrpcHandler:
             collection_name=collection_name,
             drop_field_name=field_name,
             drop_field_id=field_id,
+            drop_function_name=function_name,
         )
         response = self._stub.AlterCollectionSchema(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -619,13 +620,14 @@ class GrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        check_pass_param(collection_name=collection_name, timeout=timeout)
-        request = Prepare.drop_collection_function_request(collection_name, function_name)
-
-        status = self._stub.DropCollectionFunction(
-            request, timeout=timeout, metadata=_api_level_md(context)
+        self._alter_collection_schema_drop(
+            collection_name,
+            function_name=function_name,
+            timeout=timeout,
+            context=context,
+            **kwargs,
         )
-        check_status(status)
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     def add_collection_function(
@@ -674,6 +676,7 @@ class GrpcHandler:
         context: Optional[CallContext] = None,
         drop_field_name: Optional[str] = None,
         drop_field_id: Optional[int] = None,
+        drop_function_name: Optional[str] = None,
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
@@ -683,6 +686,7 @@ class GrpcHandler:
             func=func,
             drop_field_name=drop_field_name,
             drop_field_id=drop_field_id,
+            drop_function_name=drop_function_name,
         )
         response = self._stub.AlterCollectionSchema(
             request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -392,8 +392,12 @@ class Prepare:
         func: Optional[Function] = None,
         drop_field_name: Optional[str] = None,
         drop_field_id: Optional[int] = None,
+        drop_function_name: Optional[str] = None,
     ) -> milvus_types.AlterCollectionSchemaRequest:
-        is_drop = drop_field_name is not None or (drop_field_id is not None and drop_field_id > 0)
+        is_drop = any(
+            identifier is not None
+            for identifier in (drop_field_name, drop_field_id, drop_function_name)
+        )
         is_add = field_schema is not None or func is not None
 
         if is_drop and is_add:
@@ -402,15 +406,27 @@ class Prepare:
             )
         if not is_drop and not is_add:
             raise ParamError(
-                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id)"
+                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id/drop_function_name)"
             )
 
         if is_drop:
+            valid_drop_identifiers = [
+                drop_field_name is not None and drop_field_name != "",
+                drop_field_id is not None and drop_field_id > 0,
+                drop_function_name is not None and drop_function_name != "",
+            ]
+            if sum(valid_drop_identifiers) != 1:
+                raise ParamError(
+                    message="Must specify exactly one valid Drop identifier (drop_field_name/drop_field_id/drop_function_name)"
+                )
+
             drop_request = milvus_types.AlterCollectionSchemaRequest.DropRequest()
-            if drop_field_name is not None:
+            if drop_field_name is not None and drop_field_name != "":
                 drop_request.field_name = drop_field_name
-            else:
+            elif drop_field_id is not None and drop_field_id > 0:
                 drop_request.field_id = drop_field_id
+            else:
+                drop_request.function_name = drop_function_name
 
             action = milvus_types.AlterCollectionSchemaRequest.Action(drop_request=drop_request)
         else:

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1081,12 +1081,10 @@ class AsyncMilvusClient(BaseMilvusClient):
         Raises:
             MilvusException: If anything goes wrong
         """
-        conn = await self._get_connection()
-        await conn.drop_collection_function(
-            collection_name,
-            function_name,
+        await self._alter_collection_schema(
+            collection_name=collection_name,
+            drop_function_name=function_name,
             timeout=timeout,
-            context=self._generate_call_context(**kwargs),
             **kwargs,
         )
 
@@ -1115,12 +1113,13 @@ class AsyncMilvusClient(BaseMilvusClient):
         timeout: Optional[float] = None,
         drop_field_name: Optional[str] = None,
         drop_field_id: Optional[int] = None,
+        drop_function_name: Optional[str] = None,
         **kwargs,
     ):
         """Alter collection schema supporting both Add and Drop operations.
 
         For Add operation: provide field_schema and func
-        For Drop operation: provide either drop_field_name or drop_field_id
+        For Drop operation: provide either drop_field_name, drop_field_id, or drop_function_name
 
         Args:
             collection_name(``str``): The name of the collection.
@@ -1129,6 +1128,7 @@ class AsyncMilvusClient(BaseMilvusClient):
             timeout(``float``, optional): Timeout for the operation.
             drop_field_name(``str``, optional): Field name to drop.
             drop_field_id(``int``, optional): Field ID to drop.
+            drop_function_name(``str``, optional): Function name to drop.
             **kwargs(``dict``): Additional keyword arguments.
 
         Raises:
@@ -1138,7 +1138,10 @@ class AsyncMilvusClient(BaseMilvusClient):
         validate_param("collection_name", collection_name, str)
         conn = await self._get_connection()
 
-        is_drop = drop_field_name is not None or drop_field_id is not None
+        is_drop = any(
+            identifier is not None
+            for identifier in (drop_field_name, drop_field_id, drop_function_name)
+        )
         is_add = field_schema is not None or func is not None
 
         if is_drop and is_add:
@@ -1147,7 +1150,7 @@ class AsyncMilvusClient(BaseMilvusClient):
             )
         if not is_drop and not is_add:
             raise ParamError(
-                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id)"
+                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id/drop_function_name)"
             )
 
         if is_add:
@@ -1165,10 +1168,21 @@ class AsyncMilvusClient(BaseMilvusClient):
                 **kwargs,
             )
         else:
+            valid_drop_identifiers = [
+                drop_field_name is not None and drop_field_name != "",
+                drop_field_id is not None and drop_field_id > 0,
+                drop_function_name is not None and drop_function_name != "",
+            ]
+            if sum(valid_drop_identifiers) != 1:
+                raise ParamError(
+                    message="Must specify exactly one valid Drop identifier (drop_field_name/drop_field_id/drop_function_name)"
+                )
+
             await conn.alter_collection_schema(
                 collection_name=collection_name,
                 drop_field_name=drop_field_name,
                 drop_field_id=drop_field_id,
+                drop_function_name=drop_function_name,
                 timeout=timeout,
                 context=self._generate_call_context(**kwargs),
                 **kwargs,

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -1354,12 +1354,10 @@ class MilvusClient(BaseMilvusClient):
         Raises:
             MilvusException: If anything goes wrong
         """
-        conn = self._get_connection()
-        conn.drop_collection_function(
-            collection_name,
-            function_name,
+        self._alter_collection_schema(
+            collection_name=collection_name,
+            drop_function_name=function_name,
             timeout=timeout,
-            context=self._generate_call_context(**kwargs),
             **kwargs,
         )
 
@@ -1388,12 +1386,13 @@ class MilvusClient(BaseMilvusClient):
         timeout: Optional[float] = None,
         drop_field_name: Optional[str] = None,
         drop_field_id: Optional[int] = None,
+        drop_function_name: Optional[str] = None,
         **kwargs,
     ):
         """Alter collection schema supporting both Add and Drop operations.
 
         For Add operation: provide field_schema and func
-        For Drop operation: provide either drop_field_name or drop_field_id
+        For Drop operation: provide either drop_field_name, drop_field_id, or drop_function_name
 
         Args:
             collection_name(``str``): The name of the collection.
@@ -1402,6 +1401,7 @@ class MilvusClient(BaseMilvusClient):
             timeout(``float``, optional): Timeout for the operation.
             drop_field_name(``str``, optional): Field name to drop.
             drop_field_id(``int``, optional): Field ID to drop.
+            drop_function_name(``str``, optional): Function name to drop.
             **kwargs(``dict``): Additional keyword arguments.
 
         Raises:
@@ -1411,7 +1411,10 @@ class MilvusClient(BaseMilvusClient):
         validate_param("collection_name", collection_name, str)
         conn = self._get_connection()
 
-        is_drop = drop_field_name is not None or drop_field_id is not None
+        is_drop = any(
+            identifier is not None
+            for identifier in (drop_field_name, drop_field_id, drop_function_name)
+        )
         is_add = field_schema is not None or func is not None
 
         if is_drop and is_add:
@@ -1420,7 +1423,7 @@ class MilvusClient(BaseMilvusClient):
             )
         if not is_drop and not is_add:
             raise ParamError(
-                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id)"
+                message="Must specify either Add operation (field_schema/func) or Drop operation (drop_field_name/drop_field_id/drop_function_name)"
             )
 
         if is_add:
@@ -1438,10 +1441,21 @@ class MilvusClient(BaseMilvusClient):
                 **kwargs,
             )
         else:
+            valid_drop_identifiers = [
+                drop_field_name is not None and drop_field_name != "",
+                drop_field_id is not None and drop_field_id > 0,
+                drop_function_name is not None and drop_function_name != "",
+            ]
+            if sum(valid_drop_identifiers) != 1:
+                raise ParamError(
+                    message="Must specify exactly one valid Drop identifier (drop_field_name/drop_field_id/drop_function_name)"
+                )
+
             conn.alter_collection_schema(
                 collection_name=collection_name,
                 drop_field_name=drop_field_name,
                 drop_field_id=drop_field_id,
+                drop_function_name=drop_function_name,
                 timeout=timeout,
                 context=self._generate_call_context(**kwargs),
                 **kwargs,

--- a/tests/async_grpc_handler/test_async_collection.py
+++ b/tests/async_grpc_handler/test_async_collection.py
@@ -681,17 +681,29 @@ class TestAsyncGrpcHandlerCollectionProperties:
         handler.ensure_channel_ready = AsyncMock()
 
         mock_stub = AsyncMock()
-        mock_status = MagicMock()
-        mock_status.code = 0
-        mock_stub.DropCollectionFunction = AsyncMock(return_value=mock_status)
+        mock_response = MagicMock()
+        mock_response.alter_status = MagicMock(code=0, error_code=0, reason="")
+        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        mock_stub.DropCollectionFunction = AsyncMock()
         handler._async_stub = mock_stub
 
         with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
-            mock_prepare.drop_collection_function_request.return_value = MagicMock()
+            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            GlobalCache._reset_for_testing()
+            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"functions": []})
             await handler.drop_collection_function("test_coll", "func1")
-            mock_stub.DropCollectionFunction.assert_called_once()
+            mock_prepare.alter_collection_schema_request.assert_called_once_with(
+                collection_name="test_coll",
+                drop_field_name="",
+                drop_field_id=0,
+                drop_function_name="func1",
+            )
+            mock_stub.AlterCollectionSchema.assert_called_once()
+            mock_stub.DropCollectionFunction.assert_not_called()
+            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
+            GlobalCache._reset_for_testing()
 
     @pytest.mark.asyncio
     async def test_drop_collection_field(self) -> None:
@@ -814,5 +826,9 @@ class TestAsyncGrpcHandlerCollectionProperties:
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
             mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            GlobalCache._reset_for_testing()
+            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
             await handler.alter_collection_schema("test_coll", drop_field_name="old_field")
             mock_stub.AlterCollectionSchema.assert_called_once()
+            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
+            GlobalCache._reset_for_testing()

--- a/tests/grpc_handler/test_collection.py
+++ b/tests/grpc_handler/test_collection.py
@@ -227,9 +227,18 @@ class TestGrpcHandlerCollectionProperties:
         GlobalCache._reset_for_testing()
 
     def test_drop_collection_function(self, handler):
-        handler._stub.DropCollectionFunction.return_value = make_status()
+        response = MagicMock()
+        response.alter_status = make_status()
+        handler._stub.AlterCollectionSchema.return_value = response
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"functions": []})
         handler.drop_collection_function("coll", "func")
-        handler._stub.DropCollectionFunction.assert_called_once()
+        handler._stub.AlterCollectionSchema.assert_called_once()
+        request = handler._stub.AlterCollectionSchema.call_args.args[0]
+        assert request.action.drop_request.function_name == "func"
+        handler._stub.DropCollectionFunction.assert_not_called()
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()
 
     def test_drop_collection_field(self, handler):
         response = MagicMock()
@@ -269,18 +278,26 @@ class TestGrpcHandlerCollectionProperties:
         resp = MagicMock()
         resp.alter_status = make_status()
         handler._stub.AlterCollectionSchema.return_value = resp
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
         handler.alter_collection_schema(
             collection_name="coll",
             drop_field_name="old_field",
         )
         handler._stub.AlterCollectionSchema.assert_called_once()
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()
 
     def test_alter_collection_schema_drop_by_id(self, handler):
         resp = MagicMock()
         resp.alter_status = make_status()
         handler._stub.AlterCollectionSchema.return_value = resp
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
         handler.alter_collection_schema(
             collection_name="coll",
             drop_field_id=42,
         )
         handler._stub.AlterCollectionSchema.assert_called_once()
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()

--- a/tests/prepare/test_collection.py
+++ b/tests/prepare/test_collection.py
@@ -436,6 +436,14 @@ class TestAlterCollectionSchemaRequest:
         assert req.action.HasField("drop_request")
         assert req.action.drop_request.field_id == 42
 
+    def test_drop_by_function_name(self):
+        req = Prepare.alter_collection_schema_request(
+            collection_name="coll",
+            drop_function_name="bm25",
+        )
+        assert req.action.HasField("drop_request")
+        assert req.action.drop_request.function_name == "bm25"
+
     def test_error_on_both_add_and_drop(self):
         field = FieldSchema("vec", DataType.FLOAT_VECTOR, dim=128)
         with pytest.raises(ParamError, match="Cannot perform both"):
@@ -448,3 +456,27 @@ class TestAlterCollectionSchemaRequest:
     def test_error_on_neither_add_nor_drop(self):
         with pytest.raises(ParamError, match="Must specify"):
             Prepare.alter_collection_schema_request(collection_name="coll")
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"drop_field_name": ""},
+            {"drop_field_id": 0},
+            {"drop_function_name": ""},
+        ],
+    )
+    def test_error_on_empty_drop_identifier(self, kwargs):
+        with pytest.raises(ParamError, match="exactly one valid Drop identifier"):
+            Prepare.alter_collection_schema_request(collection_name="coll", **kwargs)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"drop_field_name": "old_field", "drop_field_id": 42},
+            {"drop_field_name": "old_field", "drop_function_name": "bm25"},
+            {"drop_field_id": 42, "drop_function_name": "bm25"},
+        ],
+    )
+    def test_error_on_multiple_drop_identifiers(self, kwargs):
+        with pytest.raises(ParamError, match="exactly one valid Drop identifier"):
+            Prepare.alter_collection_schema_request(collection_name="coll", **kwargs)

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1423,6 +1423,38 @@ class TestAsyncAlterCollectionSchema:
         mock_handler.alter_collection_schema.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_drop_collection_function_delegates(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+        mock_handler.drop_collection_function = AsyncMock()
+
+        await client.drop_collection_function("col", "fn")
+
+        mock_handler.alter_collection_schema.assert_called_once()
+        assert mock_handler.alter_collection_schema.call_args.kwargs["drop_function_name"] == "fn"
+        mock_handler.drop_collection_function.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drop_collection_field_rejects_missing_identifier(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+
+        with pytest.raises(ParamError, match="exactly one valid Drop identifier"):
+            await client.drop_collection_field("col")
+
+        mock_handler.alter_collection_schema.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_drop_collection_field_rejects_multiple_identifiers(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.alter_collection_schema = AsyncMock()
+
+        with pytest.raises(ParamError, match="exactly one valid Drop identifier"):
+            await client.drop_collection_field("col", field_name="old", field_id=42)
+
+        mock_handler.alter_collection_schema.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_add_function_field_delegates(self, client_and_handler):
         client, mock_handler = client_and_handler
         mock_handler.alter_collection_schema = AsyncMock()

--- a/tests/test_async_milvus_client_ops.py
+++ b/tests/test_async_milvus_client_ops.py
@@ -126,7 +126,7 @@ _SIMPLE_ASYNC_DELEGATION_CASES = [
         {},
         "alter_collection_field",
     ),
-    ("drop_collection_function", ("col", "fn"), {}, "drop_collection_function"),
+    ("drop_collection_function", ("col", "fn"), {}, "alter_collection_schema"),
     ("add_collection_function", ("col", MagicMock()), {}, "add_collection_function"),
     ("alter_collection_function", ("col", "fn", MagicMock()), {}, "alter_collection_function"),
     # Server ops

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1566,7 +1566,9 @@ class TestMilvusClientCollectionMgmt:
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()
             client.drop_collection_function("col", "fn")
-            handler.drop_collection_function.assert_called_once()
+            handler.alter_collection_schema.assert_called_once()
+            assert handler.alter_collection_schema.call_args.kwargs["drop_function_name"] == "fn"
+            handler.drop_collection_function.assert_not_called()
 
     def test_drop_collection_field_delegates(self):
         handler = _make_handler()
@@ -1574,6 +1576,22 @@ class TestMilvusClientCollectionMgmt:
             client = MilvusClient()
             client.drop_collection_field("col", field_name="f")
             handler.alter_collection_schema.assert_called_once()
+
+    def test_drop_collection_field_rejects_missing_identifier(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            with pytest.raises(ParamError, match="exactly one valid Drop identifier"):
+                client.drop_collection_field("col")
+            handler.alter_collection_schema.assert_not_called()
+
+    def test_drop_collection_field_rejects_multiple_identifiers(self):
+        handler = _make_handler()
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+            with pytest.raises(ParamError, match="exactly one valid Drop identifier"):
+                client.drop_collection_field("col", field_name="f", field_id=42)
+            handler.alter_collection_schema.assert_not_called()
 
     def test_private_alter_collection_schema_add_delegates(self):
         handler = _make_handler()


### PR DESCRIPTION
issue: #3128
related: https://github.com/milvus-io/milvus/issues/48983

## What changed
- Keep the public drop field/function APIs while routing their implementations through AlterCollectionSchema DropRequest.
- Support function_name in AlterCollectionSchema drop requests and validate that exactly one drop identifier is provided.
- Keep schema cache invalidation on AlterCollectionSchema paths and cover sync/async handlers and clients.

## Tests
- python -m ruff check pymilvus/client/prepare.py pymilvus/client/grpc_handler.py pymilvus/client/async_grpc_handler.py pymilvus/milvus_client/milvus_client.py pymilvus/milvus_client/async_milvus_client.py tests/prepare/test_collection.py tests/grpc_handler/test_collection.py tests/async_grpc_handler/test_async_collection.py tests/test_milvus_client.py tests/test_async_milvus_client.py
- python -m pytest tests/prepare/test_collection.py::TestAlterCollectionSchemaRequest tests/grpc_handler/test_collection.py::TestGrpcHandlerCollectionProperties tests/async_grpc_handler/test_async_collection.py::TestAsyncGrpcHandlerCollectionProperties tests/test_milvus_client.py::TestMilvusClientCollectionMgmt tests/test_async_milvus_client.py::TestAsyncAlterCollectionSchema -q
- git diff --check