### PR TITLE
feat: support dump_messages for data salvage

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -493,7 +493,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> bool:
-
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.describe_collection_request(collection_name)
         reply = await self._async_stub.DescribeCollection(
@@ -521,7 +520,6 @@ class AsyncGrpcHandler:
     async def list_collections(
         self, timeout: Optional[float] = None, context: Optional[CallContext] = None, **kwargs
     ) -> List[str]:
-
         request = Prepare.show_collections_request()
         response = await self._async_stub.ShowCollections(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -605,7 +603,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> Union[str, dict]:
-
         if detail:
             if self._server_info_cache is None:
                 req = Prepare.register_request("", "")
@@ -635,7 +632,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[ReplicaInfo]:
-
         collection_schema, _ = await self._get_schema(
             collection_name, timeout=timeout, context=context, **kwargs
         )
@@ -804,7 +800,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[milvus_types.PersistentSegmentInfo]:
-
         check_pass_param(collection_name=collection_name, timeout=timeout)
         req = Prepare.get_persistent_segment_info_request(collection_name)
         response = await self._async_stub.GetPersistentSegmentInfo(
@@ -1407,7 +1402,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> bool:
-
         check_pass_param(
             collection_name=collection_name, partition_name=partition_name, timeout=timeout
         )
@@ -1426,7 +1420,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> List[str]:
-
         check_pass_param(collection_name=collection_name, timeout=timeout)
         request = Prepare.show_partitions_request(collection_name)
         response = await self._async_stub.ShowPartitions(
@@ -1527,7 +1520,6 @@ class AsyncGrpcHandler:
     async def alloc_timestamp(
         self, timeout: Optional[float] = None, context: Optional[CallContext] = None, **kwargs
     ) -> int:
-
         request = milvus_types.AllocTimestampRequest()
         response = await self._async_stub.AllocTimestamp(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -2564,7 +2556,6 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ) -> int:
-
         request = Prepare.describe_collection_request(collection_name)
         response = await self._async_stub.DescribeCollection(
             request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -67,6 +67,7 @@ from .utils import (
     check_invalid_binary_vector,
     check_status,
     get_server_type,
+    immutable_message_to_dict,
     is_successful,
     len_of,
     replicate_checkpoint_to_dict,
@@ -2997,3 +2998,44 @@ class AsyncGrpcHandler:
                 resp.salvage_checkpoint if resp.HasField("salvage_checkpoint") else None
             ),
         }
+
+    # NOTE: no @retry_on_rpc_failure — retrying a streaming RPC would replay
+    # already-yielded messages, and errors surface during iteration, not at call time.
+    def dump_messages(
+        self,
+        pchannel: str,
+        start_message_id: Dict,
+        start_timetick: int = 0,
+        end_timetick: int = 0,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """Async version of GrpcHandler.dump_messages; returns an async generator.
+
+        Intentionally a regular method (not ``async def``) so parameter
+        validation raises ParamError eagerly at call time. See the sync
+        version for full docs.
+        """
+        request = Prepare.dump_messages_request(
+            pchannel=pchannel,
+            start_message_id=start_message_id,
+            start_timetick=start_timetick,
+            end_timetick=end_timetick,
+        )
+        stream = self._async_stub.DumpMessages(
+            request, timeout=timeout, metadata=_api_level_md(context)
+        )
+
+        async def _message_generator():
+            async for resp in stream:
+                which = resp.WhichOneof("response")
+                if which == "status":
+                    check_status(resp.status)
+                elif which == "message":
+                    yield immutable_message_to_dict(resp.message)
+                else:
+                    msg = f"unexpected DumpMessagesResponse oneof arm: {which!r}"
+                    raise MilvusException(message=msg)
+
+        return _message_generator()

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -3488,6 +3488,9 @@ class GrpcHandler:
                     check_status(resp.status)
                 elif which == "message":
                     yield immutable_message_to_dict(resp.message)
+                else:
+                    msg = f"unexpected DumpMessagesResponse oneof arm: {which!r}"
+                    raise MilvusException(message=msg)
 
         return _message_generator()
 

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -89,6 +89,7 @@ from .utils import (
     check_invalid_binary_vector,
     check_status,
     get_server_type,
+    immutable_message_to_dict,
     is_successful,
     len_of,
     replicate_checkpoint_to_dict,
@@ -3438,6 +3439,57 @@ class GrpcHandler:
                 resp.salvage_checkpoint if resp.HasField("salvage_checkpoint") else None
             ),
         }
+
+    # NOTE: no @retry_on_rpc_failure — retrying a streaming RPC would replay
+    # already-yielded messages, and errors surface during iteration, not at call time.
+    def dump_messages(
+        self,
+        pchannel: str,
+        start_message_id: Dict,
+        start_timetick: int = 0,
+        end_timetick: int = 0,
+        timeout: Optional[float] = None,
+        context: Optional[CallContext] = None,
+        **kwargs,
+    ):
+        """
+        Dump messages from a WAL range for data salvage (server-streaming RPC).
+
+        Args:
+            pchannel: Physical channel name to dump from.
+            start_message_id: Start position in WAL, a dict {"id": str, "wal_name": str}.
+                Accepts get_replicate_info()["salvage_checkpoint"]["message_id"] directly.
+            start_timetick: Only dump messages with timetick >= start_timetick. 0 = no filter.
+            end_timetick: Only dump messages with timetick <= end_timetick.
+                0 = no limit; the server streams until the RPC is cancelled.
+            timeout: Optional timeout in seconds applied to the entire stream.
+
+        Returns:
+            A generator yielding one dict per message:
+            {"message_id": {"id": str, "wal_name": str} or None,
+             "payload": bytes, "properties": dict}.
+
+        Raises:
+            ParamError: If pchannel or start_message_id is missing/invalid (at call time).
+            MilvusException: If the server reports an error (during iteration).
+        """
+        request = Prepare.dump_messages_request(
+            pchannel=pchannel,
+            start_message_id=start_message_id,
+            start_timetick=start_timetick,
+            end_timetick=end_timetick,
+        )
+        stream = self._stub.DumpMessages(request, timeout=timeout, metadata=_api_level_md(context))
+
+        def _message_generator():
+            for resp in stream:
+                which = resp.WhichOneof("response")
+                if which == "status":
+                    check_status(resp.status)
+                elif which == "message":
+                    yield immutable_message_to_dict(resp.message)
+
+        return _message_generator()
 
     @retry_on_rpc_failure()
     def create_snapshot(

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2821,6 +2821,40 @@ class Prepare:
             target_pchannel=target_pchannel,
         )
 
+    @classmethod
+    def dump_messages_request(
+        cls,
+        pchannel: Optional[str] = None,
+        start_message_id: Optional[Dict] = None,
+        start_timetick: int = 0,
+        end_timetick: int = 0,
+    ):
+        if not pchannel:
+            msg = "'pchannel' must be provided"
+            raise ParamError(message=msg)
+        if not start_message_id or not isinstance(start_message_id, dict):
+            msg = "'start_message_id' must be a non-empty dict with 'id' and 'wal_name' keys"
+            raise ParamError(message=msg)
+        if not start_message_id.get("id"):
+            msg = "'start_message_id.id' must be provided"
+            raise ParamError(message=msg)
+        wal_name = start_message_id.get("wal_name")
+        try:
+            wal_name_value = common_types.WALName.Value(wal_name)
+        except (ValueError, TypeError) as e:
+            valid = ", ".join(common_types.WALName.keys())
+            msg = f"'start_message_id.wal_name' must be one of [{valid}], got {wal_name!r}"
+            raise ParamError(message=msg) from e
+        return milvus_types.DumpMessagesRequest(
+            pchannel=pchannel,
+            start_message_id=common_types.MessageID(
+                id=start_message_id["id"],
+                WAL_name=wal_name_value,
+            ),
+            start_timetick=start_timetick,
+            end_timetick=end_timetick,
+        )
+
     @staticmethod
     def convert_function_to_function_schema(f: Function) -> schema_types.FunctionSchema:
         function_schema = schema_types.FunctionSchema(

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -495,6 +495,27 @@ def validate_iso_timestamp(s: str) -> bool:
         return True
 
 
+def immutable_message_to_dict(msg: common_pb2.ImmutableMessage) -> Dict:
+    """Convert a common_pb2.ImmutableMessage proto to a plain dict.
+
+    Returns {"message_id": {"id": str, "wal_name": str} or None,
+    "payload": bytes, "properties": dict}, where wal_name is the WALName
+    enum name ("Unknown" | "RocksMQ" | "Pulsar" | "Kafka" | "WoodPecker" | "Test").
+    Returns message_id=None when the proto's id field is unset.
+    """
+    message_id = None
+    if msg.HasField("id"):
+        message_id = {
+            "id": msg.id.id,
+            "wal_name": common_pb2.WALName.Name(msg.id.WAL_name),
+        }
+    return {
+        "message_id": message_id,
+        "payload": msg.payload,
+        "properties": dict(msg.properties),
+    }
+
+
 def replicate_checkpoint_to_dict(cp: Optional[common_pb2.ReplicateCheckpoint]) -> Optional[Dict]:
     """Convert a common_pb2.ReplicateCheckpoint proto to a plain dict, or None if empty.
 

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -2034,6 +2034,46 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    async def dump_messages(
+        self,
+        pchannel: str,
+        start_message_id: Dict,
+        start_timetick: int = 0,
+        end_timetick: int = 0,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Dump messages from a WAL range for data salvage (server-streaming RPC).
+
+        Async generator version — iterate with ``async for``. See
+        MilvusClient.dump_messages for full parameter and return-value docs.
+
+        Note:
+            Because this is an async generator, parameter validation errors
+            (ParamError) surface at the first iteration step, not at call time.
+
+        Examples:
+            async for msg in client.dump_messages(
+                pchannel="by-dev-rootcoord-dml_0",
+                start_message_id=ckpt["message_id"],
+                start_timetick=ckpt["time_tick"],
+                end_timetick=end_tt,
+            ):
+                print(msg["message_id"], len(msg["payload"]))
+        """
+        conn = await self._get_connection()
+        async for msg in conn.dump_messages(
+            pchannel=pchannel,
+            start_message_id=start_message_id,
+            start_timetick=start_timetick,
+            end_timetick=end_timetick,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        ):
+            yield msg
+
     async def _is_collection_loaded(
         self, collection_name: str, timeout: Optional[float] = None
     ) -> bool:

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -2542,6 +2542,67 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    def dump_messages(
+        self,
+        pchannel: str,
+        start_message_id: Dict,
+        start_timetick: int = 0,
+        end_timetick: int = 0,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ):
+        """
+        Dump messages from a WAL range for data salvage (server-streaming RPC).
+
+        Typically used after a force failover: call get_replicate_info() on the
+        old primary to obtain the salvage_checkpoint, then dump the messages that
+        were not yet synchronized to the new primary.
+
+        Args:
+            pchannel (str): Physical channel name to dump from.
+            start_message_id (Dict): Start position in WAL, {"id": str, "wal_name": str}.
+                Accepts get_replicate_info()["salvage_checkpoint"]["message_id"] directly.
+            start_timetick (int, optional): Only dump messages with timetick >=
+                start_timetick. 0 means no lower bound.
+            end_timetick (int, optional): Only dump messages with timetick <=
+                end_timetick. 0 means no limit — the server keeps streaming until
+                the RPC is cancelled; combined with no timeout, iteration blocks
+                indefinitely.
+            timeout (float, optional): Timeout in seconds applied to the entire stream.
+
+        Returns:
+            Generator yielding one dict per message:
+            {"message_id": {"id": str, "wal_name": str} or None,
+             "payload": bytes, "properties": dict}.
+
+        Raises:
+            ParamError: If pchannel or start_message_id is missing/invalid (at call time).
+            MilvusException: If the server reports an error (during iteration).
+
+        Examples:
+            info = client.get_replicate_info(
+                source_cluster_id="primary",
+                target_pchannel="by-dev-rootcoord-dml_0",
+            )
+            ckpt = info["salvage_checkpoint"]
+            for msg in client.dump_messages(
+                pchannel="by-dev-rootcoord-dml_0",
+                start_message_id=ckpt["message_id"],
+                start_timetick=ckpt["time_tick"],
+                end_timetick=end_tt,
+            ):
+                print(msg["message_id"], len(msg["payload"]))
+        """
+        return self._get_connection().dump_messages(
+            pchannel=pchannel,
+            start_message_id=start_message_id,
+            start_timetick=start_timetick,
+            end_timetick=end_timetick,
+            timeout=timeout,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
     def flush_all(self, timeout: Optional[float] = None, **kwargs) -> None:
         """Flush all collections.
 

--- a/tests/prepare/test_advanced.py
+++ b/tests/prepare/test_advanced.py
@@ -4,6 +4,7 @@ import pytest
 from pymilvus import Function, FunctionType
 from pymilvus.client.prepare import Prepare
 from pymilvus.exceptions import ParamError
+from pymilvus.grpc_gen import common_pb2
 
 
 class TestBulkInsertRequests:
@@ -357,6 +358,71 @@ class TestGetReplicateInfoRequest:
             Prepare.get_replicate_info_request(
                 source_cluster_id="src",
                 target_pchannel=None,
+            )
+
+
+class TestDumpMessagesRequest:
+    """Tests for Prepare.dump_messages_request."""
+
+    _MSG_ID = {"id": "msg-1", "wal_name": "Pulsar"}
+
+    def test_builds_correct_request(self):
+        req = Prepare.dump_messages_request(
+            pchannel="by-dev-rootcoord-dml_0",
+            start_message_id=self._MSG_ID,
+            start_timetick=100,
+            end_timetick=200,
+        )
+        assert req.pchannel == "by-dev-rootcoord-dml_0"
+        assert req.start_message_id.id == "msg-1"
+        assert req.start_message_id.WAL_name == common_pb2.WALName.Pulsar
+        assert req.start_timetick == 100
+        assert req.end_timetick == 200
+
+    def test_timeticks_default_to_zero(self):
+        req = Prepare.dump_messages_request(
+            pchannel="ch0",
+            start_message_id=self._MSG_ID,
+        )
+        assert req.start_timetick == 0
+        assert req.end_timetick == 0
+
+    def test_missing_pchannel_raises(self):
+        with pytest.raises(ParamError, match="pchannel"):
+            Prepare.dump_messages_request(pchannel="", start_message_id=self._MSG_ID)
+
+    def test_none_pchannel_raises(self):
+        with pytest.raises(ParamError, match="pchannel"):
+            Prepare.dump_messages_request(pchannel=None, start_message_id=self._MSG_ID)
+
+    def test_missing_start_message_id_raises(self):
+        with pytest.raises(ParamError, match="start_message_id"):
+            Prepare.dump_messages_request(pchannel="ch0", start_message_id=None)
+
+    def test_empty_start_message_id_raises(self):
+        with pytest.raises(ParamError, match="start_message_id"):
+            Prepare.dump_messages_request(pchannel="ch0", start_message_id={})
+
+    def test_non_dict_start_message_id_raises(self):
+        with pytest.raises(ParamError, match="start_message_id"):
+            Prepare.dump_messages_request(pchannel="ch0", start_message_id="msg-1")
+
+    def test_missing_id_key_raises(self):
+        with pytest.raises(ParamError, match="start_message_id.id"):
+            Prepare.dump_messages_request(
+                pchannel="ch0", start_message_id={"wal_name": "Pulsar"}
+            )
+
+    def test_invalid_wal_name_raises(self):
+        with pytest.raises(ParamError, match="wal_name"):
+            Prepare.dump_messages_request(
+                pchannel="ch0", start_message_id={"id": "m", "wal_name": "NotAWal"}
+            )
+
+    def test_missing_wal_name_raises(self):
+        with pytest.raises(ParamError, match="wal_name"):
+            Prepare.dump_messages_request(
+                pchannel="ch0", start_message_id={"id": "m"}
             )
 
 

--- a/tests/prepare/test_advanced.py
+++ b/tests/prepare/test_advanced.py
@@ -1,5 +1,7 @@
 """Tests for advanced Prepare methods (bulk operations, replication, analyzers)."""
 
+from typing import ClassVar
+
 import pytest
 from pymilvus import Function, FunctionType
 from pymilvus.client.prepare import Prepare
@@ -364,7 +366,7 @@ class TestGetReplicateInfoRequest:
 class TestDumpMessagesRequest:
     """Tests for Prepare.dump_messages_request."""
 
-    _MSG_ID = {"id": "msg-1", "wal_name": "Pulsar"}
+    _MSG_ID: ClassVar[dict] = {"id": "msg-1", "wal_name": "Pulsar"}
 
     def test_builds_correct_request(self):
         req = Prepare.dump_messages_request(
@@ -408,10 +410,8 @@ class TestDumpMessagesRequest:
             Prepare.dump_messages_request(pchannel="ch0", start_message_id="msg-1")
 
     def test_missing_id_key_raises(self):
-        with pytest.raises(ParamError, match="start_message_id.id"):
-            Prepare.dump_messages_request(
-                pchannel="ch0", start_message_id={"wal_name": "Pulsar"}
-            )
+        with pytest.raises(ParamError, match=r"start_message_id\.id"):
+            Prepare.dump_messages_request(pchannel="ch0", start_message_id={"wal_name": "Pulsar"})
 
     def test_invalid_wal_name_raises(self):
         with pytest.raises(ParamError, match="wal_name"):
@@ -421,9 +421,7 @@ class TestDumpMessagesRequest:
 
     def test_missing_wal_name_raises(self):
         with pytest.raises(ParamError, match="wal_name"):
-            Prepare.dump_messages_request(
-                pchannel="ch0", start_message_id={"id": "m"}
-            )
+            Prepare.dump_messages_request(pchannel="ch0", start_message_id={"id": "m"})
 
 
 class TestConvertFunctionToFunctionSchema:

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1582,3 +1582,60 @@ class TestAsyncGrpcHandlerDumpMessages:
         with pytest.raises(ParamError):
             h.dump_messages(pchannel="", start_message_id=self._START)
         h._async_stub.DumpMessages.assert_not_called()
+
+
+class TestAsyncMilvusClientDumpMessages:
+    """Tests for AsyncMilvusClient.dump_messages delegation."""
+
+    @pytest.mark.asyncio
+    async def test_streams_messages(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        expected = [
+            {"message_id": {"id": "m1", "wal_name": "Pulsar"}, "payload": b"p1", "properties": {}},
+            {"message_id": {"id": "m2", "wal_name": "Pulsar"}, "payload": b"p2", "properties": {}},
+        ]
+
+        async def _gen():
+            for m in expected:
+                yield m
+
+        mock_handler.dump_messages = MagicMock(return_value=_gen())
+
+        result = [
+            m
+            async for m in client.dump_messages(
+                pchannel="ch0",
+                start_message_id={"id": "s", "wal_name": "Pulsar"},
+                start_timetick=1,
+                end_timetick=2,
+            )
+        ]
+
+        assert result == expected
+        mock_handler.dump_messages.assert_called_once_with(
+            pchannel="ch0",
+            start_message_id={"id": "s", "wal_name": "Pulsar"},
+            start_timetick=1,
+            end_timetick=2,
+            timeout=None,
+            context=ANY,
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self, client_and_handler):
+        client, mock_handler = client_and_handler
+
+        async def _gen():
+            return
+            yield  # pragma: no cover — makes this an async generator
+
+        mock_handler.dump_messages = MagicMock(return_value=_gen())
+
+        result = [
+            m
+            async for m in client.dump_messages(
+                pchannel="ch0",
+                start_message_id={"id": "s", "wal_name": "Pulsar"},
+            )
+        ]
+        assert result == []

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -24,6 +24,7 @@ from pymilvus.client.types import (
     SnapshotInfo,
 )
 from pymilvus.exceptions import MilvusException, ParamError
+from pymilvus.grpc_gen import common_pb2, milvus_pb2
 from pymilvus.milvus_client.async_milvus_client import AsyncMilvusClientSession
 from pymilvus.orm.schema import StructFieldSchema
 
@@ -1486,3 +1487,98 @@ class TestAsyncAlterCollectionSchema:
         with pytest.raises(ParamError, match="only supports SPARSE_FLOAT_VECTOR"):
             await client.add_function_field("col", field, func)
         mock_handler.alter_collection_schema.assert_not_called()
+
+
+class _FakeAsyncStream:
+    """Minimal async iterator over a list of prepared responses."""
+
+    def __init__(self, items):
+        self._it = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+class TestAsyncGrpcHandlerDumpMessages:
+    """Tests for AsyncGrpcHandler.dump_messages stream shaping (handler layer)."""
+
+    _START = {"id": "start-1", "wal_name": "Pulsar"}
+
+    @staticmethod
+    def _msg_resp(mid="m1", payload=b"p"):
+        return milvus_pb2.DumpMessagesResponse(
+            message=common_pb2.ImmutableMessage(
+                id=common_pb2.MessageID(id=mid, WAL_name=common_pb2.WALName.Pulsar),
+                payload=payload,
+            )
+        )
+
+    @staticmethod
+    def _bare_handler(responses):
+        from pymilvus.client.async_grpc_handler import AsyncGrpcHandler  # noqa: PLC0415
+
+        h = AsyncGrpcHandler.__new__(AsyncGrpcHandler)
+        h._async_stub = MagicMock()
+        h._async_stub.DumpMessages.return_value = _FakeAsyncStream(responses)
+        return h
+
+    @pytest.mark.asyncio
+    async def test_yields_message_dicts_in_order(self):
+        h = self._bare_handler([self._msg_resp("m1", b"p1"), self._msg_resp("m2", b"p2")])
+
+        result = [
+            m
+            async for m in h.dump_messages(pchannel="ch0", start_message_id=self._START)
+        ]
+
+        assert [m["message_id"]["id"] for m in result] == ["m1", "m2"]
+        assert result[0]["payload"] == b"p1"
+
+    @pytest.mark.asyncio
+    async def test_error_status_raises_mid_stream(self):
+        err = milvus_pb2.DumpMessagesResponse(
+            status=common_pb2.Status(code=65535, reason="dump failed")
+        )
+        h = self._bare_handler([self._msg_resp("m1"), err])
+
+        gen = h.dump_messages(pchannel="ch0", start_message_id=self._START)
+        first = await gen.__anext__()
+        assert first["message_id"]["id"] == "m1"
+        with pytest.raises(MilvusException, match="dump failed"):
+            await gen.__anext__()
+
+    @pytest.mark.asyncio
+    async def test_success_status_mid_stream_is_skipped(self):
+        ok = milvus_pb2.DumpMessagesResponse(status=common_pb2.Status())
+        h = self._bare_handler([self._msg_resp("m1"), ok, self._msg_resp("m2")])
+
+        result = [
+            m
+            async for m in h.dump_messages(pchannel="ch0", start_message_id=self._START)
+        ]
+
+        assert [m["message_id"]["id"] for m in result] == ["m1", "m2"]
+
+    @pytest.mark.asyncio
+    async def test_unset_oneof_raises(self):
+        empty = milvus_pb2.DumpMessagesResponse()
+        h = self._bare_handler([empty])
+
+        gen = h.dump_messages(pchannel="ch0", start_message_id=self._START)
+        with pytest.raises(MilvusException, match="oneof"):
+            await gen.__anext__()
+
+    @pytest.mark.asyncio
+    async def test_param_error_raised_eagerly_not_lazily(self):
+        h = self._bare_handler([])
+        # dump_messages is a regular method returning an async generator,
+        # so validation must raise at call time without any await.
+        with pytest.raises(ParamError):
+            h.dump_messages(pchannel="", start_message_id=self._START)
+        h._async_stub.DumpMessages.assert_not_called()

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -1,6 +1,7 @@
 """Test cases for AsyncMilvusClient new features"""
 
 import inspect
+from typing import ClassVar
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -1508,7 +1509,7 @@ class _FakeAsyncStream:
 class TestAsyncGrpcHandlerDumpMessages:
     """Tests for AsyncGrpcHandler.dump_messages stream shaping (handler layer)."""
 
-    _START = {"id": "start-1", "wal_name": "Pulsar"}
+    _START: ClassVar[dict] = {"id": "start-1", "wal_name": "Pulsar"}
 
     @staticmethod
     def _msg_resp(mid="m1", payload=b"p"):
@@ -1532,10 +1533,7 @@ class TestAsyncGrpcHandlerDumpMessages:
     async def test_yields_message_dicts_in_order(self):
         h = self._bare_handler([self._msg_resp("m1", b"p1"), self._msg_resp("m2", b"p2")])
 
-        result = [
-            m
-            async for m in h.dump_messages(pchannel="ch0", start_message_id=self._START)
-        ]
+        result = [m async for m in h.dump_messages(pchannel="ch0", start_message_id=self._START)]
 
         assert [m["message_id"]["id"] for m in result] == ["m1", "m2"]
         assert result[0]["payload"] == b"p1"
@@ -1558,10 +1556,7 @@ class TestAsyncGrpcHandlerDumpMessages:
         ok = milvus_pb2.DumpMessagesResponse(status=common_pb2.Status())
         h = self._bare_handler([self._msg_resp("m1"), ok, self._msg_resp("m2")])
 
-        result = [
-            m
-            async for m in h.dump_messages(pchannel="ch0", start_message_id=self._START)
-        ]
+        result = [m async for m in h.dump_messages(pchannel="ch0", start_message_id=self._START)]
 
         assert [m["message_id"]["id"] for m in result] == ["m1", "m2"]
 

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1415,6 +1415,7 @@ _SIMPLE_DELEGATION_CASES = [
     ("update_replicate_configuration", (), {"clusters": []}, "update_replicate_configuration"),
     ("get_replicate_configuration", (), {}, "get_replicate_configuration"),
     ("get_replicate_info", ("src", "ch0"), {}, "get_replicate_info"),
+    ("dump_messages", ("ch0", {"id": "m", "wal_name": "Pulsar"}), {}, "dump_messages"),
     ("alter_database_properties", ("mydb", {"key": "val"}), {}, "alter_database"),
     ("describe_alias", ("alias1",), {}, "describe_alias"),
     ("describe_resource_group", ("rg1",), {}, "describe_resource_group"),

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -2180,3 +2180,88 @@ class TestGrpcHandlerGetReplicateInfo:
 
         assert result["checkpoint"]["time_tick"] == 300
         assert result["salvage_checkpoint"] is None
+
+
+class TestGrpcHandlerDumpMessages:
+    """Tests for GrpcHandler.dump_messages stream shaping (handler layer)."""
+
+    _START = {"id": "start-1", "wal_name": "Pulsar"}
+
+    @staticmethod
+    def _msg_resp(mid="m1", payload=b"p", props=None):
+        return milvus_pb2.DumpMessagesResponse(
+            message=common_pb2.ImmutableMessage(
+                id=common_pb2.MessageID(id=mid, WAL_name=common_pb2.WALName.Pulsar),
+                payload=payload,
+                properties=props or {},
+            )
+        )
+
+    @staticmethod
+    def _bare_handler(responses):
+        """Construct a GrpcHandler without running __init__; attach a mocked stub."""
+        from pymilvus.client.grpc_handler import GrpcHandler  # noqa: PLC0415
+
+        h = GrpcHandler.__new__(GrpcHandler)
+        h._stub = MagicMock()
+        h._stub.DumpMessages.return_value = iter(responses)
+        return h
+
+    def test_yields_message_dicts_in_order(self):
+        h = self._bare_handler(
+            [self._msg_resp("m1", b"p1", {"_t": "Insert"}), self._msg_resp("m2", b"p2")]
+        )
+
+        result = list(h.dump_messages(pchannel="ch0", start_message_id=self._START))
+
+        assert result == [
+            {
+                "message_id": {"id": "m1", "wal_name": "Pulsar"},
+                "payload": b"p1",
+                "properties": {"_t": "Insert"},
+            },
+            {
+                "message_id": {"id": "m2", "wal_name": "Pulsar"},
+                "payload": b"p2",
+                "properties": {},
+            },
+        ]
+        h._stub.DumpMessages.assert_called_once()
+
+    def test_error_status_raises_mid_stream(self):
+        err = milvus_pb2.DumpMessagesResponse(
+            status=common_pb2.Status(code=65535, reason="dump failed")
+        )
+        h = self._bare_handler([self._msg_resp("m1"), err])
+
+        gen = h.dump_messages(pchannel="ch0", start_message_id=self._START)
+        assert next(gen)["message_id"]["id"] == "m1"
+        with pytest.raises(MilvusException, match="dump failed"):
+            next(gen)
+
+    def test_empty_stream_yields_nothing(self):
+        h = self._bare_handler([])
+        assert list(h.dump_messages(pchannel="ch0", start_message_id=self._START)) == []
+
+    def test_param_error_raised_eagerly_not_lazily(self):
+        h = self._bare_handler([])
+        # Must raise at call time, before any iteration happens.
+        with pytest.raises(ParamError):
+            h.dump_messages(pchannel="", start_message_id=self._START)
+        h._stub.DumpMessages.assert_not_called()
+
+    def test_request_fields_forwarded(self):
+        h = self._bare_handler([])
+        list(
+            h.dump_messages(
+                pchannel="ch0",
+                start_message_id=self._START,
+                start_timetick=100,
+                end_timetick=200,
+            )
+        )
+        request = h._stub.DumpMessages.call_args[0][0]
+        assert request.pchannel == "ch0"
+        assert request.start_message_id.id == "start-1"
+        assert request.start_timetick == 100
+        assert request.end_timetick == 200

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from typing import ClassVar
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -2186,7 +2187,7 @@ class TestGrpcHandlerGetReplicateInfo:
 class TestGrpcHandlerDumpMessages:
     """Tests for GrpcHandler.dump_messages stream shaping (handler layer)."""
 
-    _START = {"id": "start-1", "wal_name": "Pulsar"}
+    _START: ClassVar[dict] = {"id": "start-1", "wal_name": "Pulsar"}
 
     @staticmethod
     def _msg_resp(mid="m1", payload=b"p", props=None):

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -2265,3 +2265,21 @@ class TestGrpcHandlerDumpMessages:
         assert request.start_message_id.id == "start-1"
         assert request.start_timetick == 100
         assert request.end_timetick == 200
+        assert h._stub.DumpMessages.call_args.kwargs["timeout"] is None
+        assert "metadata" in h._stub.DumpMessages.call_args.kwargs
+
+    def test_success_status_mid_stream_is_skipped(self):
+        ok = milvus_pb2.DumpMessagesResponse(status=common_pb2.Status())
+        h = self._bare_handler([self._msg_resp("m1"), ok, self._msg_resp("m2")])
+
+        result = list(h.dump_messages(pchannel="ch0", start_message_id=self._START))
+
+        assert [m["message_id"]["id"] for m in result] == ["m1", "m2"]
+
+    def test_unset_oneof_raises(self):
+        empty = milvus_pb2.DumpMessagesResponse()
+        h = self._bare_handler([empty])
+
+        gen = h.dump_messages(pchannel="ch0", start_message_id=self._START)
+        with pytest.raises(MilvusException, match="oneof"):
+            next(gen)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 from pymilvus.client import utils
 from pymilvus.client.constants import LOGICAL_BITS, LOGICAL_BITS_MASK
 from pymilvus.client.types import DataType
-from pymilvus.client.utils import replicate_checkpoint_to_dict
+from pymilvus.client.utils import immutable_message_to_dict, replicate_checkpoint_to_dict
 from pymilvus.exceptions import MilvusException, ParamError
 from pymilvus.grpc_gen import common_pb2
 
@@ -459,4 +459,35 @@ class TestReplicateCheckpointToDict:
             "pchannel": "",
             "message_id": {"id": "msg-1", "wal_name": "Pulsar"},
             "time_tick": 0,
+        }
+
+
+class TestImmutableMessageToDict:
+    """Tests for immutable_message_to_dict."""
+
+    def test_full_message(self):
+        msg = common_pb2.ImmutableMessage(
+            id=common_pb2.MessageID(id="msg-1", WAL_name=common_pb2.WALName.Pulsar),
+            payload=b"\x01\x02",
+            properties={"_t": "Insert"},
+        )
+        assert immutable_message_to_dict(msg) == {
+            "message_id": {"id": "msg-1", "wal_name": "Pulsar"},
+            "payload": b"\x01\x02",
+            "properties": {"_t": "Insert"},
+        }
+
+    def test_unset_id_returns_none_message_id(self):
+        msg = common_pb2.ImmutableMessage(payload=b"data")
+        result = immutable_message_to_dict(msg)
+        assert result["message_id"] is None
+        assert result["payload"] == b"data"
+        assert result["properties"] == {}
+
+    def test_empty_message(self):
+        msg = common_pb2.ImmutableMessage()
+        assert immutable_message_to_dict(msg) == {
+            "message_id": None,
+            "payload": b"",
+            "properties": {},
         }


### PR DESCRIPTION
issue: https://github.com/milvus-io/milvus/issues/47598

related: milvus-io/milvus#47599, milvus-io/milvus-proto#568

## Summary

Expose the `DumpMessages` server-streaming RPC in pymilvus, completing the data salvage flow started in #3509 (`get_replicate_info`). After a force failover, users can now retrieve unsynchronized WAL messages from the old primary entirely through pymilvus:

```python
info = client.get_replicate_info(source_cluster_id=..., target_pchannel=pchannel)
ckpt = info["salvage_checkpoint"]
for msg in client.dump_messages(
    pchannel=pchannel,
    start_message_id=ckpt["message_id"],
    start_timetick=ckpt["time_tick"],
    end_timetick=end_tt,
):
    ...  # {"message_id": {...}, "payload": bytes, "properties": dict}
```

## Changes

- `MilvusClient.dump_messages()` — returns a generator of plain-dict messages
- `AsyncMilvusClient.dump_messages()` — async generator variant
- `GrpcHandler` / `AsyncGrpcHandler` — wrap the unary-stream RPC; oneof handling: error status raises `MilvusException` mid-iteration, unexpected frames raise, success-status frames are skipped; no retry decorator (retrying a stream would replay messages)
- `Prepare.dump_messages_request()` — eager `ParamError` validation (pchannel, start_message_id dict, WALName enum name)
- `utils.immutable_message_to_dict()` — proto → dict converter, mirroring `replicate_checkpoint_to_dict`

No proto regeneration needed — `DumpMessages` stubs already exist on master.

## Test Plan

- [x] Unit tests: 26 new tests across `tests/test_utils.py`, `tests/prepare/test_advanced.py`, `tests/test_milvus_client.py`, `tests/test_async_milvus_client.py` (mocked stubs, sync + async)
- [x] Full suite passes: 4195 passed
- [x] `black` / `ruff` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)