### PR TITLE
feat: support external field mappings in add_collection_field

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -328,6 +328,7 @@ class Prepare:
             nullable=nullable,
             default_value=field.get("default_value"),
             element_type=field.get("element_type"),
+            external_field=field.get("external_field", ""),
         )
 
         type_params = field.get("params", {})

--- a/tests/prepare/test_collection.py
+++ b/tests/prepare/test_collection.py
@@ -6,6 +6,7 @@ import pytest
 from pymilvus import CollectionSchema, DataType, FieldSchema, Function, FunctionType
 from pymilvus.client.prepare import Prepare
 from pymilvus.exceptions import ParamError
+from pymilvus.grpc_gen import schema_pb2
 from pymilvus.orm.schema import StructFieldSchema
 
 
@@ -281,6 +282,24 @@ class TestGetFieldSchema:
         assert primary == "pk"
         assert auto_id == "pk"
 
+    def test_external_field_is_copied_to_proto(self):
+        """External field mapping should survive dict -> proto conversion."""
+        field_schema, primary, auto_id = Prepare.get_field_schema(
+            {
+                "name": "score",
+                "type": DataType.DOUBLE,
+                "nullable": True,
+                "external_field": "score",
+            }
+        )
+
+        assert field_schema.name == "score"
+        assert field_schema.data_type == DataType.DOUBLE
+        assert field_schema.nullable is True
+        assert field_schema.external_field == "score"
+        assert primary is None
+        assert auto_id is None
+
 
 class TestGetSchema:
     """Tests for get_schema."""
@@ -336,6 +355,25 @@ class TestAddCollectionFieldRequest:
         field = FieldSchema("new_field", DataType.VARCHAR, max_length=100)
         req = Prepare.add_collection_field_request("test_coll", field)
         assert req.collection_name == "test_coll"
+
+    def test_add_external_field_request_serializes_mapping(self):
+        """AddCollectionFieldRequest.schema should include external_field."""
+        field = FieldSchema(
+            "score",
+            DataType.DOUBLE,
+            nullable=True,
+            external_field="score",
+        )
+
+        req = Prepare.add_collection_field_request("ext_coll", field)
+        parsed = schema_pb2.FieldSchema()
+        parsed.ParseFromString(req.schema)
+
+        assert req.collection_name == "ext_coll"
+        assert parsed.name == "score"
+        assert parsed.data_type == DataType.DOUBLE
+        assert parsed.nullable is True
+        assert parsed.external_field == "score"
 
     def test_add_struct_field_request(self):
         """Test adding a nullable struct field to collection."""

--- a/tests/test_async_milvus_client.py
+++ b/tests/test_async_milvus_client.py
@@ -415,6 +415,28 @@ class TestAsyncMilvusClientNewFeatures:
             )
 
     @pytest.mark.asyncio
+    async def test_add_collection_field_forwards_external_field(self, client_and_handler):
+        """External field kwargs should reach the async handler FieldSchema."""
+        client, mock_handler = client_and_handler
+        mock_handler.add_collection_field = AsyncMock()
+
+        await client.add_collection_field(
+            "ext_coll",
+            "score",
+            DataType.DOUBLE,
+            nullable=True,
+            external_field="score",
+        )
+
+        mock_handler.add_collection_field.assert_awaited_once()
+        assert mock_handler.add_collection_field.call_args.args[0] == "ext_coll"
+        added_schema = mock_handler.add_collection_field.call_args.args[1]
+        assert added_schema.name == "score"
+        assert added_schema.dtype == DataType.DOUBLE
+        assert added_schema.nullable is True
+        assert added_schema.external_field == "score"
+
+    @pytest.mark.asyncio
     async def test_add_collection_struct_field_requires_nullable(self, client_and_handler):
         """Test that adding struct field requires nullable=True."""
         client, _ = client_and_handler

--- a/tests/test_milvus_client.py
+++ b/tests/test_milvus_client.py
@@ -279,6 +279,34 @@ class TestMilvusClient:
             )
             mock_conn.add_collection_field.assert_called_once()
 
+    def test_add_collection_field_forwards_external_field(self):
+        """External field kwargs should reach the handler FieldSchema."""
+        mock_handler = MagicMock()
+        mock_handler.get_server_type.return_value = "milvus"
+        mock_handler._wait_for_channel_ready = MagicMock()
+        mock_conn = MagicMock()
+
+        with patch(
+            "pymilvus.client.grpc_handler.GrpcHandler", return_value=mock_handler
+        ), patch.object(MilvusClient, "_get_connection", return_value=mock_conn):
+            client = MilvusClient()
+
+            client.add_collection_field(
+                collection_name="ext_coll",
+                field_name="score",
+                data_type=DataType.DOUBLE,
+                nullable=True,
+                external_field="score",
+            )
+
+            mock_conn.add_collection_field.assert_called_once()
+            assert mock_conn.add_collection_field.call_args.args[0] == "ext_coll"
+            added_schema = mock_conn.add_collection_field.call_args.args[1]
+            assert added_schema.name == "score"
+            assert added_schema.dtype == DataType.DOUBLE
+            assert added_schema.nullable is True
+            assert added_schema.external_field == "score"
+
     def test_add_collection_struct_field_requires_nullable(self):
         """Test that adding struct field requires nullable=True."""
         mock_handler = MagicMock()


### PR DESCRIPTION
## Summary

- Preserve `FieldSchema.external_field` when PyMilvus builds `AddCollectionFieldRequest` schema payloads.
- Add focused prepare-layer and sync/async `MilvusClient.add_collection_field()` forwarding tests.

## Related Issues

See also: [#3576](https://github.com/milvus-io/pymilvus/issues/3576)

Related to external collection feature:
[#45881](https://github.com/milvus-io/milvus/issues/45881)

## Details

Milvus server already validates whether `external_field` is required for external collections or rejected for regular collections. PyMilvus should preserve the mapping and let server-side validation remain authoritative.

This PR keeps the public API as `MilvusClient.add_collection_field()` and `AsyncMilvusClient.add_collection_field()`. It does not add a public high-level `alter_collection_schema` API.

## Test Plan

- `python -m pytest tests/prepare/test_collection.py -k "external_field or add_collection_field" -q`
- `python -m pytest tests/test_milvus_client.py -k "add_collection_field or schema_extension_signatures_exclude_physical_backfill" -q`
- `python -m pytest tests/test_async_milvus_client.py -k "add_collection_field or signature_excludes_physical_backfill" -q`
- `python -m pytest tests/orm/test_schema.py -k external_field -q`
- `git diff --check`
