### PR TITLE
fix: recover closed grpc channel errors

### DIFF
--- a/pymilvus/client/connection_manager.py
+++ b/pymilvus/client/connection_manager.py
@@ -35,6 +35,25 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 19530
 
+_RECOVERABLE_MILVUS_EXCEPTION_MARKERS = (
+    "STREAMING_CODE_REPLICATE_VIOLATION",
+    "cannot invoke rpc on closed channel",
+    "no channel in handler",
+)
+
+
+def _is_recoverable_milvus_exception(error: MilvusException) -> bool:
+    message = str(error.message)
+    message_lower = message.lower()
+    return any(
+        (
+            marker in message
+            if marker == "STREAMING_CODE_REPLICATE_VIOLATION"
+            else marker in message_lower
+        )
+        for marker in _RECOVERABLE_MILVUS_EXCEPTION_MARKERS
+    )
+
 
 @dataclass
 class ConnectionConfig:
@@ -699,7 +718,7 @@ class ConnectionManager:
             if error.code() != grpc.StatusCode.UNAVAILABLE:
                 return False
         elif isinstance(error, MilvusException):
-            if "STREAMING_CODE_REPLICATE_VIOLATION" not in str(error.message):
+            if not _is_recoverable_milvus_exception(error):
                 return False
         else:
             return False
@@ -1086,7 +1105,7 @@ class AsyncConnectionManager:
             if error.code() != grpc.StatusCode.UNAVAILABLE:
                 return False
         elif isinstance(error, MilvusException):
-            if "STREAMING_CODE_REPLICATE_VIOLATION" not in str(error.message):
+            if not _is_recoverable_milvus_exception(error):
                 return False
         else:
             return False

--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -277,6 +277,21 @@ IGNORE_RETRY_CODES = (
     grpc.StatusCode.UNIMPLEMENTED,
 )
 
+_RECOVERABLE_CHANNEL_EXCEPTION_MARKERS = ("cannot invoke rpc on closed channel",)
+
+
+def _is_recoverable_channel_exception(error: Exception) -> bool:
+    message = str(error).lower()
+    return any(marker in message for marker in _RECOVERABLE_CHANNEL_EXCEPTION_MARKERS)
+
+
+def _unexpected_error_message(error: Exception) -> str:
+    return f"Unexpected error, message=<{error!s}>"
+
+
+def _recoverable_channel_milvus_exception(error: Exception) -> MilvusException:
+    return MilvusException(message=_unexpected_error_message(error))
+
 
 def retry_on_rpc_failure(
     *,
@@ -371,6 +386,20 @@ def retry_on_rpc_failure(
                     except asyncio.TimeoutError as e:
                         raise MilvusException(message=to_msg) from e
                     except Exception as e:
+                        if (
+                            _is_recoverable_channel_exception(e)
+                            and args
+                            and hasattr(args[0], "_on_rpc_error")
+                        ):
+                            if is_timeout(start_time):
+                                raise MilvusException(
+                                    message=f"{to_msg}, message={_unexpected_error_message(e)}"
+                                ) from e
+                            recoverable_error = _recoverable_channel_milvus_exception(e)
+                            if await args[0]._on_rpc_error(recoverable_error):
+                                await asyncio.sleep(back_off)
+                                back_off = min(back_off * back_off_multiplier, max_back_off)
+                                continue
                         raise e from e
                     finally:
                         counter += 1
@@ -455,6 +484,20 @@ def retry_on_rpc_failure(
                     else:
                         raise e from e
                 except Exception as e:
+                    if (
+                        _is_recoverable_channel_exception(e)
+                        and args
+                        and hasattr(args[0], "_on_rpc_error")
+                    ):
+                        if timeout(start_time):
+                            raise MilvusException(
+                                message=f"{to_msg}, message={_unexpected_error_message(e)}"
+                            ) from e
+                        recoverable_error = _recoverable_channel_milvus_exception(e)
+                        if args[0]._on_rpc_error(recoverable_error):
+                            time.sleep(back_off)
+                            back_off = min(back_off * back_off_multiplier, max_back_off)
+                            continue
                     raise e from e
                 finally:
                     counter += 1

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -1681,6 +1681,12 @@ class TestReplicateViolationRecovery:
             "cause: non-replicate message cannot be received in secondary role",
         )
 
+    def _make_closed_channel_error(self):
+        return MilvusException(
+            code=1,
+            message="Unexpected error, message=<Cannot invoke RPC on closed channel!>",
+        )
+
     def test_replicate_violation_triggers_recovery_for_global_strategy(self):
         """Test handle_error triggers recovery on REPLICATE_VIOLATION for global connections."""
         mgr = ConnectionManager.get_instance()
@@ -1728,6 +1734,22 @@ class TestReplicateViolationRecovery:
             assert isinstance(managed.strategy, RegularStrategy)
 
             result = mgr.handle_error(handler, self._make_replicate_error())
+            assert result is True
+            handler.reconnect.assert_called_once()
+
+    def test_closed_channel_exception_triggers_recovery_for_regular_strategy(self):
+        """Wrapped closed-channel MilvusExceptions should reconnect and retry."""
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            mock_handler = _make_sync_handler()
+            mock_handler_cls.return_value = mock_handler
+
+            handler = mgr.get_or_create(config)
+
+            result = mgr.handle_error(handler, self._make_closed_channel_error())
+
             assert result is True
             handler.reconnect.assert_called_once()
 
@@ -1802,6 +1824,23 @@ class TestReplicateViolationRecovery:
             handler.reconnect.assert_called_once()
             call_kwargs = handler.reconnect.call_args
             assert call_kwargs.kwargs.get("address") == "in02.zilliz.com:19530"
+
+    @pytest.mark.asyncio
+    async def test_async_closed_channel_exception_triggers_recovery(self):
+        """Async wrapped closed-channel MilvusExceptions should reconnect and retry."""
+        mgr = AsyncConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("http://localhost:19530", token="test")
+
+        with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler") as mock_handler_cls:
+            handler = _make_async_handler()
+            mock_handler_cls.return_value = handler
+
+            await mgr.get_or_create(config)
+
+            result = await mgr.handle_error(handler, self._make_closed_channel_error())
+
+            assert result is True
+            handler.reconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_async_unrelated_milvus_exception_not_retried(self):

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 import warnings
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc
 import pytest
@@ -402,6 +402,86 @@ class TestRetryDecoratorEdgeCases:
         result = sometimes_failing_func(mock_self)
         assert result == "eventual_success"
         assert call_count == 3
+
+    def test_closed_channel_value_error_triggers_recovery_and_retry(self):
+        mock_self = MockSelfForTracing()
+        mock_self._on_rpc_error = MagicMock(return_value=True)
+        call_count = 0
+
+        @retry_on_rpc_failure(retry_times=1, initial_back_off=0.001)
+        def closed_channel_once(self_arg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("Cannot invoke RPC on closed channel!")
+            return "eventual_success"
+
+        result = closed_channel_once(mock_self)
+
+        assert result == "eventual_success"
+        assert call_count == 2
+        mock_self._on_rpc_error.assert_called_once()
+        error = mock_self._on_rpc_error.call_args.args[0]
+        assert isinstance(error, MilvusException)
+        assert "Cannot invoke RPC on closed channel" in error.message
+
+    def test_generic_value_error_still_not_retried(self):
+        mock_self = MockSelfForTracing()
+        mock_self._on_rpc_error = MagicMock(return_value=True)
+        call_count = 0
+
+        @retry_on_rpc_failure(retry_times=1, initial_back_off=0.001)
+        def generic_value_error(self_arg):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("generic client bug")
+
+        with pytest.raises(MilvusException, match="generic client bug"):
+            generic_value_error(mock_self)
+
+        assert call_count == 1
+        mock_self._on_rpc_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_closed_channel_value_error_triggers_recovery_and_retry(self):
+        mock_self = MockSelfForTracing()
+        mock_self._on_rpc_error = AsyncMock(return_value=True)
+        call_count = 0
+
+        @retry_on_rpc_failure(retry_times=1, initial_back_off=0.001)
+        async def closed_channel_once(self_arg):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("Cannot invoke RPC on closed channel!")
+            return "eventual_success"
+
+        result = await closed_channel_once(mock_self)
+
+        assert result == "eventual_success"
+        assert call_count == 2
+        mock_self._on_rpc_error.assert_awaited_once()
+        error = mock_self._on_rpc_error.await_args.args[0]
+        assert isinstance(error, MilvusException)
+        assert "Cannot invoke RPC on closed channel" in error.message
+
+    @pytest.mark.asyncio
+    async def test_async_generic_value_error_still_not_retried(self):
+        mock_self = MockSelfForTracing()
+        mock_self._on_rpc_error = AsyncMock(return_value=True)
+        call_count = 0
+
+        @retry_on_rpc_failure(retry_times=1, initial_back_off=0.001)
+        async def generic_value_error(self_arg):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("generic client bug")
+
+        with pytest.raises(MilvusException, match="generic client bug"):
+            await generic_value_error(mock_self)
+
+        assert call_count == 1
+        mock_self._on_rpc_error.assert_not_awaited()
 
     def test_deadline_exceeded_not_retried(self):
         mock_self = MockSelfForTracing()


### PR DESCRIPTION
## What

Recover PyMilvus connections when a server-side restart leaves the client with `Cannot invoke RPC on closed channel!`.

This change covers both forms seen in stability failures:
- raw `ValueError("Cannot invoke RPC on closed channel!")` raised from grpc channel usage
- wrapped `MilvusException(message="Unexpected error, message=<Cannot invoke RPC on closed channel!>")` routed through connection manager

## Why

After a Milvus component restarts, the old client channel can enter a closed state. Before this patch, `retry_on_rpc_failure` treated the raw closed-channel `ValueError` as a generic unexpected error and never notified the connection manager, while `ConnectionManager.handle_error()` ignored the wrapped `MilvusException`. As a result, the client could keep failing without reconnecting.

Related Milvus issue context: milvus-io/milvus#50329.

## Changes

- Detect closed-channel exceptions in sync and async `retry_on_rpc_failure`, notify `_on_rpc_error`, and retry when recovery succeeds.
- Treat closed-channel `MilvusException`s as recoverable in sync and async `ConnectionManager.handle_error`.
- Add sync/async decorator tests and sync/async connection-manager regression tests.
- Keep generic `ValueError`s non-retryable to avoid broadening retry behavior.

## Verification

- `python3 -m py_compile pymilvus/decorators.py pymilvus/client/connection_manager.py tests/test_decorators.py tests/test_connection_manager.py`
- `python3 -m pytest tests/test_decorators.py::TestRetryDecoratorEdgeCases::test_closed_channel_value_error_triggers_recovery_and_retry tests/test_decorators.py::TestRetryDecoratorEdgeCases::test_generic_value_error_still_not_retried tests/test_connection_manager.py::TestReplicateViolationRecovery::test_closed_channel_exception_triggers_recovery_for_regular_strategy tests/test_connection_manager.py::TestReplicateViolationRecovery::test_unrelated_milvus_exception_not_retried tests/test_connection_manager.py::TestReplicateViolationRecovery::test_replicate_violation_ignored_for_regular_strategy`

Note: this local environment does not have `pytest-asyncio`, so async pytest cases cannot run here. I verified equivalent async closed-channel decorator and manager paths with `asyncio.run(...)`.
