### PR TITLE
feat: client-side emb_list and hybrid (RRF) search_iterator

### DIFF
--- a/examples/iterator/emblist_hybrid_iterator.py
+++ b/examples/iterator/emblist_hybrid_iterator.py
@@ -1,0 +1,141 @@
+"""search_iterator over an emb_list (array-of-vector) field, and a hybrid
+search_iterator that fuses an emb_list modality with a dense modality via RRF.
+
+An emb_list field stores, per row, an array of vectors (ColBERT-style late
+chunking: one row per document, many paragraph vectors per row). Its similarity
+metric is MAX_SIM -- a sum-of-max over paragraph similarities -- so a query is
+itself a *list* of vectors, passed as one EmbeddingList.
+
+Run against a local milvus (http://localhost:19530).
+"""
+
+import numpy as np
+
+from pymilvus import DataType, MilvusClient
+from pymilvus.client.abstract import AnnSearchRequest
+from pymilvus.client.embedding_list import EmbeddingList
+
+COLLECTION_NAME = "emblist_iterator_demo"
+DENSE_DIM = 16
+CHUNK_DIM = 32
+NUM_ROWS = 5000
+rng = np.random.default_rng(seed=19530)
+
+
+def build_collection(client: MilvusClient):
+    if client.has_collection(COLLECTION_NAME):
+        client.drop_collection(COLLECTION_NAME)
+
+    schema = client.create_schema(auto_id=True, enable_dynamic_field=True)
+    schema.add_field("id", DataType.INT64, is_primary=True)
+    schema.add_field("title", DataType.VARCHAR, max_length=256)
+    schema.add_field("embedding", DataType.FLOAT_VECTOR, dim=DENSE_DIM)
+
+    # the emb_list field: an array of structs, each holding one chunk vector
+    chunk_schema = client.create_struct_field_schema()
+    chunk_schema.add_field("chunk_vec", DataType.FLOAT_VECTOR, dim=CHUNK_DIM)
+    schema.add_field(
+        "chunks",
+        datatype=DataType.ARRAY,
+        element_type=DataType.STRUCT,
+        struct_schema=chunk_schema,
+        max_capacity=20,
+    )
+    client.create_collection(COLLECTION_NAME, schema=schema)
+
+    index_params = client.prepare_index_params()
+    index_params.add_index(field_name="embedding", index_type="IVF_FLAT", metric_type="COSINE")
+    index_params.add_index(
+        field_name="chunks[chunk_vec]",
+        index_type="HNSW",
+        index_name="chunk_vec_index",
+        metric_type="MAX_SIM_COSINE",
+        index_params={"M": 16, "efConstruction": 200},
+    )
+    client.create_index(COLLECTION_NAME, schema=schema, index_params=index_params)
+
+    rows = []
+    for i in range(NUM_ROWS):
+        n_chunks = int(rng.integers(2, 8))
+        rows.append(
+            {
+                "title": f"doc-{i}",
+                "embedding": rng.random(DENSE_DIM, dtype=np.float32),
+                "chunks": [
+                    {"chunk_vec": rng.random(CHUNK_DIM, dtype=np.float32)}
+                    for _ in range(n_chunks)
+                ],
+            }
+        )
+    client.insert(COLLECTION_NAME, rows)
+    client.flush(COLLECTION_NAME)
+    client.load_collection(COLLECTION_NAME)
+    print(f"built {COLLECTION_NAME}: {NUM_ROWS} rows")
+
+
+def emblist_search_iterator(client: MilvusClient):
+    """Iterate an emb_list field. One query = several vectors in one EmbeddingList."""
+    query = EmbeddingList([rng.random(CHUNK_DIM, dtype=np.float32) for _ in range(4)])
+
+    iterator = client.search_iterator(
+        collection_name=COLLECTION_NAME,
+        data=[query],  # a single emb_list query
+        anns_field="chunks[chunk_vec]",
+        batch_size=200,
+        output_fields=["title"],
+    )
+    total, page_idx = 0, 0
+    while True:
+        page = iterator.next()
+        if len(page) == 0:
+            iterator.close()
+            break
+        total += len(page)
+        page_idx += 1
+        print(f"  emb_list page {page_idx}: {len(page)} hits (top: {page[0]['title']})")
+    print(f"emb_list search_iterator: {total} hits over {page_idx} pages")
+
+
+def hybrid_search_iterator(client: MilvusClient):
+    """Fuse a dense modality and the emb_list modality with RRF, streamed."""
+    dense_req = AnnSearchRequest(
+        data=[rng.random(DENSE_DIM, dtype=np.float32)],
+        anns_field="embedding",
+        param={"metric_type": "COSINE"},
+        limit=200,
+    )
+    emblist_req = AnnSearchRequest(
+        data=[EmbeddingList([rng.random(CHUNK_DIM, dtype=np.float32) for _ in range(4)])],
+        anns_field="chunks[chunk_vec]",
+        param={"metric_type": "MAX_SIM_COSINE"},
+        limit=200,
+    )
+    iterator = client.hybrid_search_iterator(
+        collection_name=COLLECTION_NAME,
+        reqs=[dense_req, emblist_req],
+        batch_size=200,
+        rrf_k=60,
+        output_fields=["title"],
+    )
+    total, page_idx = 0, 0
+    while True:
+        page = iterator.next()
+        if len(page) == 0:
+            iterator.close()
+            break
+        total += len(page)
+        page_idx += 1
+        # the emitted score is the NRA lower bound on the true RRF score
+        print(f"  hybrid page {page_idx}: {len(page)} hits (top: {page[0]['title']})")
+    print(f"hybrid search_iterator: {total} fused hits over {page_idx} pages")
+
+
+def main():
+    client = MilvusClient("http://localhost:19530")
+    build_collection(client)
+    emblist_search_iterator(client)
+    hybrid_search_iterator(client)
+
+
+if __name__ == "__main__":
+    main()

--- a/pymilvus/client/search_iterator.py
+++ b/pymilvus/client/search_iterator.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 from typing import Callable, Dict, List, Optional, Union
 
 from pymilvus.client import entity_helper, utils
+from pymilvus.client.abstract import AnnSearchRequest
 from pymilvus.client.constants import (
     COLLECTION_ID,
     GUARANTEE_TIMESTAMP,
@@ -12,6 +13,7 @@ from pymilvus.client.constants import (
     ITER_SEARCH_V2_KEY,
     ITERATOR_FIELD,
 )
+from pymilvus.client.embedding_list import EmbeddingList
 from pymilvus.client.search_result import Hit, Hits
 from pymilvus.exceptions import ExceptionsMessage, ParamError, ServerVersionIncompatibleException
 from pymilvus.orm.connections import Connections
@@ -43,6 +45,14 @@ class SearchIteratorV2:
         **kwargs,
     ):
         self._check_params(batch_size, data, kwargs)
+
+        # An emb_list (array-of-vector) query is one EmbeddingList holding that
+        # query's multiple vectors. Flatten it for the wire and flag it -- exactly
+        # as MilvusClient.search does -- so the server reads it as a single emb_list
+        # query rather than as many single-vector queries.
+        if isinstance(data, list) and data and isinstance(data[0], EmbeddingList):
+            data = [emb_list.to_flat_array() for emb_list in data]
+            kwargs["is_embedding_list"] = True
 
         # for compatibility, support limit, deprecate in future
         if limit != UNLIMITED:
@@ -212,3 +222,302 @@ class SearchIteratorV2:
             res = res[: self._left_res_cnt]
         self._left_res_cnt -= cur_len
         return SearchPage(res)
+
+
+# Reciprocal-rank-fusion constant (Cormack et al. 2009); see SPEC 6.6 / Appendix A.3.
+_DEFAULT_RRF_K = 60
+# Soft bound on the NRA in-flight (seen-but-not-emitted) map. The map is bounded by
+# dense/sparse stream skew (SPEC R4). On overflow the fuser force-flushes its best
+# in-flight document rather than failing the iteration -- client-side memory is cheap.
+_DEFAULT_INFLIGHT_CAP = 100000
+
+
+class _StreamCursor:
+    """Item-by-item, lazily-refilled view over one batched, score-descending stream.
+
+    `fetch_batch` returns the next batch as a list of (doc_id, score) pairs, or an
+    empty list once the stream is exhausted.
+    """
+
+    def __init__(self, fetch_batch: Callable[[], List]):
+        self._fetch_batch = fetch_batch
+        self._buf: List = []
+        self._pos = 0
+        self.reads = 0
+        self.exhausted = False
+
+    def advance(self):
+        """Consume and return the next (doc_id, score), or None when exhausted."""
+        if self._pos >= len(self._buf):
+            if self.exhausted:
+                return None
+            batch = self._fetch_batch() or []
+            self._buf, self._pos = list(batch), 0
+            if not self._buf:
+                self.exhausted = True
+                return None
+        item = self._buf[self._pos]
+        self._pos += 1
+        self.reads += 1
+        return item
+
+
+class _RrfHybridFuser:
+    """Incremental RRF fusion of N score-descending streams via the NRA algorithm.
+
+    Fagin/Lotem/Naor 2003 (NRA threshold algorithm) + Cormack et al. 2009 (RRF).
+    See SPEC 6.6 and Appendix A.3. RRF is rank-based: a stream's contribution to any
+    not-yet-seen document is 1 / (K + reads_so_far + 1), independent of raw scores.
+    The fuser advances the least-read live stream and settles a document once no
+    in-flight or unseen document can overtake it. State (the `seen` map, the `emitted`
+    set and per-stream read counts) persists across next_batch() calls for the
+    lifetime of the iterator.
+
+    Emission order is exact: each emitted document provably out-ranks every
+    not-yet-emitted document by true RRF score. The emitted *score*, however, is a
+    lower bound -- a document is settled with the partial RRF score (`worst`) of the
+    streams it has been seen in so far; if it later resurfaces in a not-yet-consumed
+    stream, that document is already emitted and the extra rank is dropped (it cannot
+    change the ranking). Callers that need the exact RRF score must re-score.
+    """
+
+    def __init__(
+        self,
+        fetch_batches: List[Callable[[], List]],
+        rrf_k: int = _DEFAULT_RRF_K,
+        inflight_cap: int = _DEFAULT_INFLIGHT_CAP,
+    ):
+        self._cursors = [_StreamCursor(fb) for fb in fetch_batches]
+        self._k = rrf_k
+        self._inflight_cap = inflight_cap
+        # doc_id -> {stream_idx: rank}; the NRA in-flight (seen-but-not-emitted) map
+        self._seen: Dict = {}
+        # doc_ids already emitted -- a stream resurfacing one must not re-add it to
+        # `seen` (that would re-emit it; deep skewed streams hit this readily)
+        self._emitted: set = set()
+
+    def _contribution(self, cursor: _StreamCursor) -> float:
+        # an exhausted stream can never produce another rank -> contributes 0
+        if cursor.exhausted:
+            return 0.0
+        return 1.0 / (self._k + cursor.reads + 1)
+
+    def _worst(self, ranks: Dict) -> float:
+        # RRF score from the ranks already known for a document
+        return sum(1.0 / (self._k + rank) for rank in ranks.values())
+
+    def _advance_least_read(self):
+        """Advance the least-read live stream by one item (largest RRF contribution)."""
+        live = [(i, c) for i, c in enumerate(self._cursors) if not c.exhausted]
+        if not live:
+            return
+        idx, cursor = min(live, key=lambda ic: ic[1].reads)
+        item = cursor.advance()
+        if item is not None:
+            doc_id = item[0]
+            # an already-emitted doc resurfacing in another stream is dropped --
+            # it is ranked; re-adding it to `seen` would emit a duplicate
+            if doc_id not in self._emitted:
+                self._seen.setdefault(doc_id, {}).setdefault(idx, cursor.reads)
+
+    def _settled(self):
+        """Return (doc_id, rrf_score) if the best in-flight doc is provably the next
+        global result, else None."""
+        if not self._seen:
+            return None
+        tau = sum(self._contribution(c) for c in self._cursors)
+        worsts = {doc: self._worst(ranks) for doc, ranks in self._seen.items()}
+        cand = max(worsts, key=worsts.get)
+        cand_worst = worsts[cand]
+        # an unseen document could still outrank cand
+        if cand_worst < tau:
+            return None
+        # an in-flight document could still outrank cand
+        for doc, ranks in self._seen.items():
+            if doc == cand:
+                continue
+            best = worsts[doc] + sum(
+                self._contribution(self._cursors[i])
+                for i in range(len(self._cursors))
+                if i not in ranks
+            )
+            if best > cand_worst:
+                return None
+        return cand, cand_worst
+
+    def _emit(self, out: List, doc_id: Union[int, str], score: float):
+        del self._seen[doc_id]
+        self._emitted.add(doc_id)
+        out.append((doc_id, score))
+
+    def next_batch(self, batch_size: int) -> List:
+        """Fuse and return up to batch_size (doc_id, rrf_score) pairs.
+
+        Emitted RRF-descending; the score is a lower bound on the true RRF score
+        (see the class docstring).
+        """
+        out: List = []
+        while len(out) < batch_size:
+            settled = self._settled()
+            if settled is not None:
+                self._emit(out, settled[0], settled[1])
+                continue
+            if all(c.exhausted for c in self._cursors):
+                # no stream can advance; _settled() has already drained `seen`
+                break
+            self._advance_least_read()
+            # adjustment 1: force-flush the best in-flight doc on overflow -- bound
+            # memory on skewed streams without failing the iteration
+            if self._inflight_cap and len(self._seen) > self._inflight_cap:
+                worsts = {doc: self._worst(r) for doc, r in self._seen.items()}
+                cand = max(worsts, key=worsts.get)
+                self._emit(out, cand, worsts[cand])
+        return out
+
+
+class HybridSearchIteratorV2:
+    """Hybrid search_iterator: client-side RRF fusion of per-modality search_iterators.
+
+    Per SPEC 6.6 (corrected by the R3 spike), hybrid iteration is done in the SDK:
+    each request becomes a stateless single-modality SearchIteratorV2, and their
+    score-descending streams are fused with RRF via the NRA threshold algorithm
+    (_RrfHybridFuser). One guarantee_timestamp is pinned for the whole hybrid
+    iterator and shared by every sub-iterator, so the fusion is over a single
+    consistent snapshot.
+
+    `reqs` is a list of per-modality requests -- each an `AnnSearchRequest` or a plain
+    dict {"data", "anns_field", "param", "expr"}. A request's `data` may be an
+    `EmbeddingList` (one emb_list query); the sub-iterator flattens it (see
+    SearchIteratorV2). A per-request `limit` is not used -- the iterator streams in
+    `batch_size` chunks.
+
+    next() returns the fused batch as a SearchPage of Hits, RRF-descending. The emitted
+    score is the NRA lower bound (see _RrfHybridFuser); the `output_fields` requested on
+    the hybrid iterator are forwarded to every sub-iterator and carried back through the
+    fusion onto each fused Hit's `entity`.
+    """
+
+    def __init__(
+        self,
+        connection: Connections,
+        collection_name: str,
+        reqs: List[Union[Dict, AnnSearchRequest]],
+        batch_size: int = 1000,
+        limit: Optional[int] = UNLIMITED,
+        rrf_k: int = _DEFAULT_RRF_K,
+        output_fields: Optional[List[str]] = None,
+        timeout: Optional[float] = None,
+        partition_names: Optional[List[str]] = None,
+        pk_name: str = "id",
+        guarantee_timestamp: Optional[int] = None,
+        **kwargs,
+    ):
+        if not reqs:
+            raise ParamError(message="hybrid search_iterator requires at least one request")
+        if batch_size < 0 or batch_size > MAX_BATCH_SIZE:
+            raise ParamError(message=f"batch_size must be in [0, {MAX_BATCH_SIZE}]")
+        reqs = [self._normalize_req(req) for req in reqs]
+
+        self._batch_size = batch_size
+        self._pk_name = pk_name
+        self._left_res_cnt = None if limit == UNLIMITED else limit
+        # doc_id -> the sub-iterator Hit it was last fetched in, so next() can carry
+        # the requested output_fields back through the fusion (see _make_fetch_batch)
+        self._hits_by_id: Dict = {}
+
+        # adjustment 3: pin ONE snapshot timestamp and share it with every
+        # sub-iterator, so the fused result is over one consistent snapshot
+        pinned_ts = guarantee_timestamp if guarantee_timestamp else fall_back_to_latest_session_ts()
+
+        self._subs: List[SearchIteratorV2] = []
+        for req in reqs:
+            sub = SearchIteratorV2(
+                connection=connection,
+                collection_name=collection_name,
+                data=req["data"],
+                batch_size=batch_size,
+                filter=req.get("expr"),
+                output_fields=output_fields,
+                search_params=req.get("param") or {},
+                timeout=timeout,
+                partition_names=partition_names,
+                anns_field=req.get("anns_field") or "",
+                **{GUARANTEE_TIMESTAMP: pinned_ts},
+                **kwargs,
+            )
+            self._subs.append(sub)
+
+        self._fuser = _RrfHybridFuser(
+            [self._make_fetch_batch(sub) for sub in self._subs], rrf_k=rrf_k
+        )
+
+    @staticmethod
+    def _normalize_req(req: Union[Dict, AnnSearchRequest]) -> Dict:
+        """Accept an AnnSearchRequest or a plain dict; return the internal dict form.
+
+        A per-request `limit` is intentionally dropped -- a hybrid sub-iterator
+        streams in `batch_size` chunks, governed by the hybrid iterator's batch_size.
+        """
+        if isinstance(req, AnnSearchRequest):
+            return {
+                "data": req.data,
+                "anns_field": req.anns_field,
+                "param": req.param,
+                "expr": req.expr,
+            }
+        return req
+
+    def _make_fetch_batch(self, sub: "SearchIteratorV2") -> Callable[[], List]:
+        """Adapt a SearchIteratorV2 into a () -> [(doc_id, score)] batch source.
+
+        Each hit's full record is stashed in `_hits_by_id` so next() can carry the
+        requested output_fields back through the fusion; the stash entry is dropped
+        when the doc is emitted (see next()).
+        """
+
+        def fetch_batch() -> List:
+            page = sub.next()
+            if page is None or len(page) == 0:
+                return []
+            out = []
+            for hit in page:
+                pk = hit[self._pk_name]
+                self._hits_by_id[pk] = hit
+                out.append((pk, float(hit["distance"])))
+            return out
+
+        return fetch_batch
+
+    def next(self) -> SearchPage:
+        """Return the next fused batch as a SearchPage, RRF-descending."""
+        if self._left_res_cnt is not None and self._left_res_cnt <= 0:
+            return SearchPage(None)
+        target = self._batch_size
+        if self._left_res_cnt is not None:
+            target = min(self._batch_size, self._left_res_cnt)
+
+        fused = self._fuser.next_batch(target)
+        if self._left_res_cnt is not None:
+            self._left_res_cnt -= len(fused)
+
+        pks = [doc for doc, _ in fused]
+        scores = [score for _, score in fused]
+        hits = Hits(len(fused), pks, scores, {}, [], self._pk_name)
+        # carry the requested output_fields back through the fusion: copy each
+        # emitted doc's entity from its stashed sub-iterator hit, then drop the stash
+        for hit, doc_id in zip(hits, pks):
+            src = self._hits_by_id.pop(doc_id, None)
+            if src is not None:
+                entity = src.get("entity")
+                if entity:
+                    hit["entity"] = dict(entity)
+        # A doc can resurface in another stream after it was emitted: the fuser skips
+        # it (its _emitted set) but fetch_batch still stashed the hit. Drop those
+        # stragglers so _hits_by_id stays bounded by dense/sparse stream skew.
+        emitted = self._fuser._emitted
+        self._hits_by_id = {pk: hit for pk, hit in self._hits_by_id.items() if pk not in emitted}
+        return SearchPage(hits)
+
+    def close(self):
+        for sub in self._subs:
+            sub.close()

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -7,7 +7,7 @@ from pymilvus.client.abstract import AnnSearchRequest, BaseRanker
 from pymilvus.client.connection_manager import ConnectionConfig, ConnectionManager
 from pymilvus.client.constants import DEFAULT_CONSISTENCY_LEVEL
 from pymilvus.client.embedding_list import EmbeddingList
-from pymilvus.client.search_iterator import SearchIteratorV2
+from pymilvus.client.search_iterator import HybridSearchIteratorV2, SearchIteratorV2
 from pymilvus.client.types import (
     CompactionPlans,
     ExceptionsMessage,
@@ -588,8 +588,10 @@ class MilvusClient(BaseMilvusClient):
 
         Args:
             collection_name (str): Name of the collection to search in.
-            data (Union[List[list], list]): Vector data to search with. For V2, only single vector
-                search is supported.
+            data (Union[List[list], list]): Vector data to search with. For V2, only a
+                single query is supported. To iterate an emb_list (array-of-vector)
+                field, pass that query's multiple vectors as one ``EmbeddingList`` in a
+                list: ``data=[EmbeddingList([vec1, vec2, ...])]``.
             batch_size (int, optional): Number of results to fetch per batch. Defaults to 1000.
                 Must be between 1 and MAX_BATCH_SIZE.
             filter (str, optional): Filtering expression to filter the results. Defaults to None.
@@ -618,6 +620,15 @@ class MilvusClient(BaseMilvusClient):
             >>> iterator = client.search_iterator(
             ...     collection_name="my_collection",
             ...     data=[[0.1, 0.2]],
+            ...     batch_size=100
+            ... )
+            >>> # Iterate an emb_list (array-of-vector) field: one query's vectors
+            >>> # are wrapped in a single EmbeddingList
+            >>> from pymilvus.client.embedding_list import EmbeddingList
+            >>> iterator = client.search_iterator(
+            ...     collection_name="my_collection",
+            ...     data=[EmbeddingList([[0.1, 0.2], [0.3, 0.4]])],
+            ...     anns_field="struct_field[struct_float_vec]",
             ...     batch_size=100
             ... )
         """
@@ -718,6 +729,65 @@ class MilvusClient(BaseMilvusClient):
             timeout=timeout,
             round_decimal=round_decimal,
             schema=schema_dict,
+            context=self._generate_call_context(**kwargs),
+            **kwargs,
+        )
+
+    def hybrid_search_iterator(
+        self,
+        collection_name: str,
+        reqs: List[Union[AnnSearchRequest, dict]],
+        batch_size: Optional[int] = 1000,
+        limit: Optional[int] = UNLIMITED,
+        rrf_k: int = 60,
+        output_fields: Optional[List[str]] = None,
+        timeout: Optional[float] = None,
+        partition_names: Optional[List[str]] = None,
+        pk_name: str = "id",
+        **kwargs,
+    ) -> HybridSearchIteratorV2:
+        """Creates an iterator that fuses several per-modality searches with RRF.
+
+        Each request in ``reqs`` is run as its own stateless single-modality
+        search_iterator; the score-descending streams are fused client-side with
+        Reciprocal Rank Fusion via the NRA threshold algorithm (SPEC 6.6 / A.3).
+        One snapshot timestamp is pinned for the whole hybrid iterator.
+
+        Args:
+            collection_name (str): Name of the collection to search in.
+            reqs (List[Union[AnnSearchRequest, dict]]): Per-modality requests. Each is
+                an ``AnnSearchRequest`` or a dict with keys ``data``, ``anns_field``,
+                ``param`` (search params) and optional ``expr`` (filter). A request's
+                ``data`` may be an ``EmbeddingList`` for an emb_list (array-of-vector)
+                field. A per-request ``limit`` is not used -- the iterator streams in
+                ``batch_size`` chunks.
+            batch_size (int, optional): Fused results per batch. Defaults to 1000.
+            limit (int, optional): Total fused results to return. Defaults to UNLIMITED.
+            rrf_k (int, optional): RRF constant ``k``. Defaults to 60.
+            output_fields (List[str], optional): Entity fields to return. Forwarded to
+                every sub-iterator and carried back through the fusion onto each fused
+                hit's ``entity``.
+            timeout (float, optional): Timeout in seconds for each RPC call.
+            partition_names (List[str], optional): Partitions to search in.
+            pk_name (str, optional): Primary-key field name. Defaults to "id".
+
+        Returns:
+            HybridSearchIteratorV2: An iterator yielding RRF-fused batches. Each
+            ``next()`` returns a SearchPage of hits in RRF-descending order; the
+            emitted score is the NRA lower bound on the true RRF score (re-score if
+            an exact RRF score is required).
+        """
+        return HybridSearchIteratorV2(
+            connection=self._get_connection(),
+            collection_name=collection_name,
+            reqs=reqs,
+            batch_size=batch_size,
+            limit=limit,
+            rrf_k=rrf_k,
+            output_fields=output_fields,
+            timeout=timeout,
+            partition_names=partition_names,
+            pk_name=pk_name,
             context=self._generate_call_context(**kwargs),
             **kwargs,
         )

--- a/tests/test_hybrid_search_iterator.py
+++ b/tests/test_hybrid_search_iterator.py
@@ -1,0 +1,411 @@
+"""Unit tests for the client-side hybrid search_iterator RRF fusion layer.
+
+PR 5 added the NRA/RRF fuser (`_RrfHybridFuser`); PR 6a finished the SDK wiring --
+`AnnSearchRequest` requests, `output_fields` passthrough through the fusion, and
+`EmbeddingList` emb_list queries. Everything here exercises that over mock streams /
+a fake connection -- no live milvus (the end-to-end run is the §10 acceptance stage).
+"""
+
+import pytest
+from pymilvus.client.abstract import AnnSearchRequest
+from pymilvus.client.constants import COLLECTION_ID
+from pymilvus.client.embedding_list import EmbeddingList
+from pymilvus.client.search_iterator import (
+    HybridSearchIteratorV2,
+    SearchIteratorV2,
+    _RrfHybridFuser,
+    _StreamCursor,
+)
+from pymilvus.client.search_result import Hit
+from pymilvus.exceptions import ParamError
+
+_SUB_TARGET = "pymilvus.client.search_iterator.SearchIteratorV2"
+
+
+def make_source(items, batch_size=4):
+    """A () -> [(doc_id, score)] batch source serving `items` in fixed-size batches."""
+    batches = [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+    it = iter(batches)
+
+    def fetch_batch():
+        return next(it, [])
+
+    return fetch_batch
+
+
+def reference_rrf(streams, k):
+    """Brute-force RRF: score(d) = sum over streams where d appears of 1/(k+rank)."""
+    ranks = {}
+    for si, stream in enumerate(streams):
+        for rank, (doc, _score) in enumerate(stream, start=1):
+            ranks.setdefault(doc, {})[si] = rank
+    scored = [
+        (doc, sum(1.0 / (k + r) for r in by_stream.values())) for doc, by_stream in ranks.items()
+    ]
+    scored.sort(key=lambda x: -x[1])
+    return scored
+
+
+def drain(fuser, batch_size):
+    out = []
+    while True:
+        batch = fuser.next_batch(batch_size)
+        if not batch:
+            break
+        out.extend(batch)
+    return out
+
+
+def assert_valid_rrf(fused, streams, k):
+    """`fused` is a correct RRF fusion of `streams`.
+
+    NRA emits each document with a *lower-bound* RRF score (the partial score of the
+    streams it had been seen in when it settled -- see _RrfHybridFuser). So the checks
+    are: complete, deduplicated; emitted in true-RRF-descending order; each emitted
+    score a lower bound on the true RRF score; and the emitted lower bounds are
+    themselves non-increasing.
+    """
+    ref_score = dict(reference_rrf(streams, k))
+
+    ids = [doc for doc, _ in fused]
+    assert len(ids) == len(set(ids)), "duplicate doc id in fused output"
+    assert set(ids) == set(ref_score), "fused id set != reference"
+
+    # emitted in true-RRF-descending order (the NRA emission rule guarantees this)
+    true_seq = [ref_score[doc] for doc, _ in fused]
+    for a, b in zip(true_seq, true_seq[1:]):
+        assert a >= b - 1e-9, "fused output is not in true-RRF-descending order"
+
+    # each emitted score is a lower bound on the true RRF score, and the emitted
+    # lower bounds are non-increasing
+    emitted = [s for _, s in fused]
+    for a, b in zip(emitted, emitted[1:]):
+        assert a >= b - 1e-9, "emitted scores are not non-increasing"
+    for doc, score in fused:
+        assert score <= ref_score[doc] + 1e-9, "emitted score exceeds true RRF score"
+
+
+class TestRrfHybridFuser:
+    K = 60
+
+    def test_disjoint_streams(self):
+        s0 = [(f"a{i}", 1.0 - i * 0.01) for i in range(10)]
+        s1 = [(f"b{i}", 1.0 - i * 0.01) for i in range(10)]
+        fuser = _RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K)
+        assert_valid_rrf(drain(fuser, 5), [s0, s1], self.K)
+
+    def test_overlapping_doc_sums_both_ranks(self):
+        # "x" is rank 1 in s0 and rank 1 in s1 -> highest RRF (2/(K+1))
+        s0 = [("x", 0.9), ("a", 0.8), ("b", 0.7)]
+        s1 = [("x", 0.5), ("c", 0.4), ("d", 0.3)]
+        fuser = _RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K)
+        fused = drain(fuser, 10)
+        assert_valid_rrf(fused, [s0, s1], self.K)
+        assert fused[0][0] == "x"
+        assert fused[0][1] == pytest.approx(2.0 / (self.K + 1), abs=1e-9)
+
+    def test_full_overlap(self):
+        # same docs, reversed order in each stream: doc d_i is rank i+1 in s0 and
+        # rank 8-i in s1, so RRF pairs d_i with d_{7-i} at equal scores.
+        s0 = [(f"d{i}", 1.0 - i * 0.1) for i in range(8)]
+        s1 = [(f"d{i}", 1.0 - i * 0.1) for i in reversed(range(8))]
+        fuser = _RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K)
+        fused = drain(fuser, 3)
+        assert_valid_rrf(fused, [s0, s1], self.K)
+        assert len(fused) == 8
+
+    def test_skewed_deep_shared_doc_emitted_once(self):
+        # The blocker case (deep skewed hybrid iteration). s0 is a single-item
+        # stream holding `shared`; once s0 is exhausted `shared` settles and is
+        # emitted -- long before the long stream s1 reaches `shared` at rank 51.
+        # Without the _emitted set, s1 re-yielding `shared` re-adds it to `seen`
+        # and it is emitted a second time.
+        shared = "shared"
+        s0 = [(shared, 1.0)]
+        s1 = (
+            [(f"b{i}", 0.9 - i * 0.001) for i in range(50)]
+            + [(shared, 0.5)]
+            + [(f"b{i}", 0.4 - i * 0.001) for i in range(50, 90)]
+        )
+        fuser = _RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K)
+        fused = drain(fuser, 5)
+
+        ids = [d for d, _ in fused]
+        assert ids.count(shared) == 1, "shared doc emitted more than once"
+        assert len(ids) == len(set(ids)) == 91  # shared + 90 distinct b's
+
+        # `shared` settled from its rank-1 sighting in s0 before s1 reached it,
+        # so its emitted score is the lower bound 1/(K+1) -- not the true RRF
+        # score 1/(K+1) + 1/(K+51)
+        shared_score = dict(fused)[shared]
+        assert shared_score == pytest.approx(1.0 / (self.K + 1), abs=1e-9)
+        true_shared = 1.0 / (self.K + 1) + 1.0 / (self.K + 51)
+        assert shared_score < true_shared
+
+        assert_valid_rrf(fused, [s0, s1], self.K)
+
+    def test_one_stream_empty(self):
+        s0 = [(f"a{i}", 1.0 - i * 0.01) for i in range(12)]
+        s1 = []
+        fuser = _RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K)
+        assert_valid_rrf(drain(fuser, 5), [s0, s1], self.K)
+
+    def test_uneven_stream_lengths(self):
+        s0 = [(f"a{i}", 1.0 - i * 0.001) for i in range(50)]
+        s1 = [(f"b{i}", 1.0 - i * 0.001) for i in range(7)]
+        s1[3] = ("a10", 0.5)  # one shared doc
+        fuser = _RrfHybridFuser([make_source(s0, 8), make_source(s1, 3)], rrf_k=self.K)
+        assert_valid_rrf(drain(fuser, 6), [s0, s1], self.K)
+
+    def test_batching_is_consistent(self):
+        s0 = [(f"a{i}", 1.0 - i * 0.01) for i in range(20)]
+        s1 = [(f"b{i}", 1.0 - i * 0.01) for i in range(20)]
+        s1[5] = ("a3", 0.5)
+        s1[9] = ("a7", 0.4)
+        one_shot = drain(_RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K), 10_000)
+        small_batches = drain(_RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K), 3)
+        assert one_shot == small_batches
+
+    def test_force_flush_under_tiny_cap(self):
+        # a tiny in-flight cap must still yield every doc exactly once, no error
+        s0 = [(f"a{i}", 1.0 - i * 0.001) for i in range(40)]
+        s1 = [(f"b{i}", 1.0 - i * 0.001) for i in range(40)]
+        fuser = _RrfHybridFuser([make_source(s0), make_source(s1)], rrf_k=self.K, inflight_cap=4)
+        fused = drain(fuser, 7)
+        ids = [d for d, _ in fused]
+        assert len(ids) == len(set(ids)) == 80
+
+    def test_empty_both_streams(self):
+        fuser = _RrfHybridFuser([make_source([]), make_source([])], rrf_k=self.K)
+        assert fuser.next_batch(10) == []
+
+
+class TestStreamCursor:
+    def test_lazy_refill_and_exhaustion(self):
+        cursor = _StreamCursor(make_source([(i, 1.0) for i in range(5)], batch_size=2))
+        got = []
+        while True:
+            item = cursor.advance()
+            if item is None:
+                break
+            got.append(item[0])
+        assert got == [0, 1, 2, 3, 4]
+        assert cursor.reads == 5
+        assert cursor.exhausted
+        assert cursor.advance() is None  # stays exhausted
+
+
+# --- PR 6a: HybridSearchIteratorV2 SDK wiring over fake sub-iterators -----------
+
+
+class _FakeSub:
+    """Stand-in for SearchIteratorV2: replays the pages handed in as `data`.
+
+    `HybridSearchIteratorV2.__init__` builds one SearchIteratorV2 per request; in
+    these tests `SearchIteratorV2` is monkeypatched to this class and the request's
+    `data` carries that modality's page stream (a list of pages, each a list of Hit).
+    """
+
+    def __init__(self, **kwargs):
+        self._pages = iter(kwargs["data"] or [])
+        self.output_fields = kwargs.get("output_fields")
+        self.closed = False
+
+    def next(self):
+        return next(self._pages, None)
+
+    def close(self):
+        self.closed = True
+
+
+def _page(items, pk_name="id"):
+    """Build one result page (list of Hit) from (id, score) or (id, score, entity)."""
+    page = []
+    for it in items:
+        doc, score = it[0], it[1]
+        entity = it[2] if len(it) > 2 else {}
+        page.append(Hit({pk_name: doc, "distance": score, "entity": entity}, pk_name=pk_name))
+    return page
+
+
+def _stream_to_pages(items, batch_size=4):
+    """Chunk a flat (id, score[, entity]) stream into a list of result pages."""
+    return [_page(items[i : i + batch_size]) for i in range(0, len(items), batch_size)]
+
+
+def _make_hybrid(monkeypatch, streams, *, as_ann_request=False, **kwargs):
+    """Construct a HybridSearchIteratorV2 whose sub-iterators replay `streams`.
+
+    `streams` is a list of page-stream lists, one per modality.
+    """
+    monkeypatch.setattr(_SUB_TARGET, _FakeSub)
+    reqs = []
+    for i, pages in enumerate(streams):
+        if as_ann_request:
+            reqs.append(AnnSearchRequest(data=pages, anns_field=f"f{i}", param={}, limit=10))
+        else:
+            reqs.append({"data": pages, "anns_field": f"f{i}", "param": {}})
+    return HybridSearchIteratorV2(connection=None, collection_name="c", reqs=reqs, **kwargs)
+
+
+def _drain_hybrid(it):
+    """Drain a HybridSearchIteratorV2, returning the flat list of fused Hits."""
+    out = []
+    while True:
+        page = it.next()
+        if page is None or len(page) == 0:
+            break
+        out.extend(page)
+    return out
+
+
+class TestHybridSearchIteratorWiring:
+    K = 60
+
+    def test_dict_and_annsearchrequest_reqs_are_equivalent(self, monkeypatch):
+        # the same streams, expressed as plain dicts vs AnnSearchRequest objects,
+        # must fuse to the identical result -- _normalize_req unifies them
+        s0 = [(f"a{i}", 1.0 - i * 0.01) for i in range(12)]
+        s1 = [(f"b{i}", 1.0 - i * 0.01) for i in range(12)]
+        s1[4] = ("a3", 0.5)
+
+        as_dict = _drain_hybrid(
+            _make_hybrid(monkeypatch, [_stream_to_pages(s0), _stream_to_pages(s1)], batch_size=5)
+        )
+        as_ann = _drain_hybrid(
+            _make_hybrid(
+                monkeypatch,
+                [_stream_to_pages(s0), _stream_to_pages(s1)],
+                as_ann_request=True,
+                batch_size=5,
+            )
+        )
+        assert [(h.id, h.distance) for h in as_dict] == [(h.id, h.distance) for h in as_ann]
+        assert len(as_dict) == 23  # 12 + 12 - 1 shared
+
+    def test_output_fields_carried_through_fusion(self, monkeypatch):
+        # each emitted fused hit carries the entity of its source sub-iterator hit
+        s0 = [(f"a{i}", 1.0 - i * 0.01, {"tag": f"a{i}", "src": "dense"}) for i in range(8)]
+        s1 = [(f"b{i}", 1.0 - i * 0.01, {"tag": f"b{i}", "src": "sparse"}) for i in range(8)]
+        it = _make_hybrid(
+            monkeypatch,
+            [_stream_to_pages(s0), _stream_to_pages(s1)],
+            output_fields=["tag", "src"],
+            batch_size=4,
+        )
+        fused = _drain_hybrid(it)
+        assert len(fused) == 16
+        for hit in fused:
+            expected_src = "dense" if hit.id.startswith("a") else "sparse"
+            assert hit["entity"] == {"tag": hit.id, "src": expected_src}
+            assert hit["tag"] == hit.id  # Hit field access falls through to entity
+
+    def test_output_fields_for_doc_shared_by_both_streams(self, monkeypatch):
+        # a doc in both modalities still carries its entity exactly once
+        ent = {"tag": "x", "body": "shared doc"}
+        s0 = [("x", 0.9, ent), ("a", 0.8, {"tag": "a"})]
+        s1 = [("x", 0.5, ent), ("c", 0.4, {"tag": "c"})]
+        it = _make_hybrid(
+            monkeypatch,
+            [_stream_to_pages(s0), _stream_to_pages(s1)],
+            output_fields=["tag", "body"],
+            batch_size=10,
+        )
+        fused = _drain_hybrid(it)
+        ids = [h.id for h in fused]
+        assert ids.count("x") == 1
+        x_hit = next(h for h in fused if h.id == "x")
+        assert x_hit["entity"] == ent
+
+    def test_hit_map_drains_fully_no_leak(self, monkeypatch):
+        # after a full drain every stashed hit has been emitted or pruned
+        s0 = [(f"a{i}", 1.0 - i * 0.001, {"tag": i}) for i in range(40)]
+        s1 = [(f"b{i}", 1.0 - i * 0.001, {"tag": i}) for i in range(40)]
+        s1[7] = ("a5", 0.5, {"tag": 5})
+        it = _make_hybrid(monkeypatch, [_stream_to_pages(s0), _stream_to_pages(s1)], batch_size=6)
+        _drain_hybrid(it)
+        assert it._hits_by_id == {}
+
+    def test_hit_map_bounded_when_doc_resurfaces_after_emission(self, monkeypatch):
+        # the skewed-deep blocker (cf. test_skewed_deep_shared_doc_emitted_once):
+        # `shared` settles from a short stream long before the deep stream reaches
+        # it. The deep stream re-yields it post-emission; fetch_batch re-stashes the
+        # hit, but next() prunes it against the fuser's _emitted set -> no leak.
+        shared_ent = {"tag": "shared"}
+        s0 = [("shared", 1.0, shared_ent)]
+        s1 = (
+            [(f"b{i}", 0.9 - i * 0.001, {"tag": i}) for i in range(50)]
+            + [("shared", 0.5, shared_ent)]
+            + [(f"b{i}", 0.4 - i * 0.001, {"tag": i}) for i in range(50, 90)]
+        )
+        it = _make_hybrid(monkeypatch, [_stream_to_pages(s0), _stream_to_pages(s1)], batch_size=5)
+        fused = _drain_hybrid(it)
+        ids = [h.id for h in fused]
+        assert ids.count("shared") == 1
+        assert len(ids) == len(set(ids)) == 91
+        assert it._hits_by_id == {}
+
+    def test_close_propagates_to_sub_iterators(self, monkeypatch):
+        it = _make_hybrid(
+            monkeypatch,
+            [_stream_to_pages([("a", 0.9)]), _stream_to_pages([("b", 0.8)])],
+        )
+        it.close()
+        assert all(sub.closed for sub in it._subs)
+
+
+# --- PR 6a: SearchIteratorV2 accepts EmbeddingList emb_list queries ------------
+
+
+class _FakeIterInfo:
+    token = "iter-token"
+    last_bound = 0.0
+
+
+class _FakeProbeResult:
+    def get_search_iterator_v2_results_info(self):
+        return _FakeIterInfo()
+
+    def get_session_ts(self):
+        return 12345
+
+
+class _FakeConn:
+    """Minimal connection: enough for SearchIteratorV2 construction + the probe."""
+
+    def __init__(self):
+        self.last_search_params = None
+
+    def describe_collection(self, collection_name, **kwargs):
+        return {COLLECTION_ID: 7}
+
+    def search(self, **params):
+        self.last_search_params = params
+        return _FakeProbeResult()
+
+
+class TestSearchIteratorV2EmbList:
+    def test_embedding_list_query_is_flattened_and_flagged(self):
+        conn = _FakeConn()
+        query = EmbeddingList([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
+        it = SearchIteratorV2(connection=conn, collection_name="c", data=[query], anns_field="emb")
+        # the EmbeddingList was flattened to one wire vector and flagged emb_list
+        assert it._params["is_embedding_list"] is True
+        sent = it._params["data"]
+        assert len(sent) == 1
+        assert list(sent[0]) == pytest.approx([0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+        # and the flag reached the server call (the compatibility probe)
+        assert conn.last_search_params["is_embedding_list"] is True
+
+    def test_plain_single_vector_query_is_untouched(self):
+        conn = _FakeConn()
+        it = SearchIteratorV2(
+            connection=conn, collection_name="c", data=[[0.1, 0.2]], anns_field="emb"
+        )
+        assert "is_embedding_list" not in it._params
+
+    def test_multiple_embedding_lists_rejected_as_multi_query(self):
+        conn = _FakeConn()
+        two = [EmbeddingList([[0.1, 0.2]]), EmbeddingList([[0.3, 0.4]])]
+        with pytest.raises(ParamError):
+            SearchIteratorV2(connection=conn, collection_name="c", data=two, anns_field="emb")


### PR DESCRIPTION
Adds SDK support for:
  - search_iterator() over an emb_list (ArrayOfVector) field (query passed as an EmbeddingList).
  - a client-side hybrid search_iterator fusing dense + emb_list (or sparse) modalities via
    RRF over the streamed per-modality results, with a bounded in-flight map.

  Pairs with the Milvus server-side emb_list iterator (milvus-io/milvus#49906). Full pymilvus
  suite green, zero regressions (3908 passed; +19 new iterator tests).
  Tests: tests/test_hybrid_search_iterator.py. Targets 2.6; can retarget master. Draft.