### PR TITLE
fix: preserve connection timeout during recovery

### DIFF
--- a/pymilvus/client/connection_manager.py
+++ b/pymilvus/client/connection_manager.py
@@ -182,6 +182,7 @@ class ManagedConnection:
         created_at: Unix timestamp when connection was created
         last_used_at: Unix timestamp when connection was last accessed
         clients: WeakSet of MilvusClient instances using this connection
+        connect_timeout: Timeout used for initial connection and later recovery
     """
 
     handler: "GrpcHandler"
@@ -191,6 +192,7 @@ class ManagedConnection:
     last_used_at: float = field(default_factory=time.time)
     clients: weakref.WeakSet = field(default_factory=weakref.WeakSet)
     recovery_gen: int = 0
+    connect_timeout: Optional[float] = None
 
     def touch(self) -> None:
         """Update last_used_at to current time."""
@@ -527,6 +529,7 @@ class ConnectionManager:
             handler=handler,
             config=config,
             strategy=strategy,
+            connect_timeout=timeout,
         )
         if client:
             managed.add_client(client)
@@ -552,6 +555,7 @@ class ConnectionManager:
             handler=handler,
             config=config,
             strategy=strategy,
+            connect_timeout=timeout,
         )
         if client:
             managed.add_client(client)
@@ -665,7 +669,7 @@ class ConnectionManager:
         """
         try:
             new_address = managed.strategy.get_recovery_address(managed)
-            managed.handler.reconnect(address=new_address)
+            managed.handler.reconnect(address=new_address, timeout=managed.connect_timeout)
             managed.recovery_gen += 1
             managed.touch()
         except Exception:
@@ -965,6 +969,7 @@ class AsyncConnectionManager:
             handler=handler,
             config=config,
             strategy=strategy,
+            connect_timeout=timeout,
         )
         if client:
             managed.add_client(client)
@@ -989,6 +994,7 @@ class AsyncConnectionManager:
             handler=handler,
             config=config,
             strategy=strategy,
+            connect_timeout=timeout,
         )
         if client:
             managed.add_client(client)
@@ -1121,7 +1127,7 @@ class AsyncConnectionManager:
         """
         try:
             new_address = managed.strategy.get_recovery_address(managed)
-            await managed.handler.reconnect(address=new_address)
+            await managed.handler.reconnect(address=new_address, timeout=managed.connect_timeout)
             managed.recovery_gen += 1
             managed.touch()
         except Exception:

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -1936,6 +1936,21 @@ class TestInPlaceRecovery:
             call_kwargs = handler.reconnect.call_args
             assert call_kwargs.kwargs.get("address") is None
 
+    def test_recovery_reuses_initial_connection_timeout(self):
+        """Recovery should reuse the timeout configured when the connection was created."""
+        mgr = ConnectionManager.get_instance()
+        config = ConnectionConfig.from_uri("https://remote.example.com:443", token="test")
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler") as mock_handler_cls:
+            handler = _make_sync_handler()
+            mock_handler_cls.return_value = handler
+
+            mgr.get_or_create(config, timeout=60)
+            mgr.handle_error(handler, _MockRpcError())
+
+            call_kwargs = handler.reconnect.call_args
+            assert call_kwargs.kwargs["timeout"] == 60
+
     def test_global_recovery_warns_when_no_topology(self):
         """GlobalStrategy logs warning when get_recovery_address returns None.
 


### PR DESCRIPTION
## What this PR does

Fixes #3603.

ConnectionManager now stores the timeout used when a connection is created and reuses it during automatic reconnect recovery. This keeps `MilvusClient(uri=..., timeout=60)` from falling back to `GrpcHandler.reconnect`'s 10 second default after a transient `UNAVAILABLE` recovery.