### PR TITLE
enhance: surface error classification on MilvusException

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -483,7 +483,7 @@ class AsyncGrpcHandler:
         if is_successful(status):
             return CollectionSchema(raw=response).dict()
 
-        raise DescribeCollectionException(status.code, status.reason, status.error_code)
+        raise DescribeCollectionException.from_status(status)
 
     @retry_on_rpc_failure()
     async def has_collection(
@@ -514,7 +514,7 @@ class AsyncGrpcHandler:
         if reply.status.code == ErrorCode.COLLECTION_NOT_FOUND:
             return False
 
-        raise MilvusException(reply.status.code, reply.status.reason, reply.status.error_code)
+        raise MilvusException.from_status(reply.status)
 
     @retry_on_rpc_failure()
     async def list_collections(
@@ -1760,7 +1760,7 @@ class AsyncGrpcHandler:
             return response.index_descriptions
         if status.code == ErrorCode.INDEX_NOT_FOUND or status.error_code == Status.INDEX_NOT_EXIST:
             return []
-        raise MilvusException(status.code, status.reason, status.error_code)
+        raise MilvusException.from_status(status)
 
     @retry_on_rpc_failure()
     async def describe_index(

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -780,7 +780,7 @@ class GrpcHandler:
         if reply.status.code == ErrorCode.COLLECTION_NOT_FOUND:
             return False
 
-        raise MilvusException(reply.status.code, reply.status.reason, reply.status.error_code)
+        raise MilvusException.from_status(reply.status)
 
     @retry_on_rpc_failure()
     def describe_collection(
@@ -800,7 +800,7 @@ class GrpcHandler:
         if is_successful(status):
             return CollectionSchema(raw=response).dict()
 
-        raise DescribeCollectionException(status.code, status.reason, status.error_code)
+        raise DescribeCollectionException.from_status(status)
 
     @retry_on_rpc_failure()
     def list_collections(
@@ -1731,7 +1731,7 @@ class GrpcHandler:
             return response.index_descriptions
         if status.code == ErrorCode.INDEX_NOT_FOUND or status.error_code == Status.INDEX_NOT_EXIST:
             return []
-        raise MilvusException(status.code, status.reason, status.error_code)
+        raise MilvusException.from_status(status)
 
     @retry_on_rpc_failure()
     def describe_index(

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -74,7 +74,7 @@ def check_status(status: common_pb2.Status):
     if status.code != 0 or status.error_code != 0:
         if status.error_code == common_pb2.SchemaMismatch:
             raise SchemaMismatchRetryableException(status.reason)
-        raise MilvusException(status.code, status.reason, status.error_code)
+        raise MilvusException.from_status(status)
 
 
 def is_successful(status: common_pb2.Status):

--- a/pymilvus/exceptions.py
+++ b/pymilvus/exceptions.py
@@ -30,12 +30,17 @@ class MilvusException(Exception):
         code: int = ErrorCode.UNEXPECTED_ERROR,
         message: str = "",
         compatible_code: int = common_pb2.UnexpectedError,
+        *,
+        is_input_error: bool = False,
+        retriable: bool = False,
     ) -> None:
         super().__init__()
         self._code = code
         self._message = message
         # for compatibility, remove it after 2.4.0
         self._compatible_code = compatible_code
+        self._is_input_error = is_input_error
+        self._retriable = retriable
 
     @property
     def code(self):
@@ -48,6 +53,33 @@ class MilvusException(Exception):
     @property
     def compatible_code(self):
         return self._compatible_code
+
+    @property
+    def is_input_error(self) -> bool:
+        """Whether the server classified this as a caller-input error.
+
+        An input error means the request itself was malformed, so it is the
+        caller's responsibility to fix; the server never retries or fails it
+        over to another replica, and forces it non-retriable.
+        """
+        return self._is_input_error
+
+    @property
+    def retriable(self) -> bool:
+        """Whether blindly retrying the same request may succeed."""
+        return self._retriable
+
+    @classmethod
+    def from_status(cls, status: common_pb2.Status) -> "MilvusException":
+        """Build an exception from a server Status, carrying its error code and
+        the (is_input_error, retriable) classification."""
+        return cls(
+            status.code,
+            status.reason,
+            status.error_code,
+            is_input_error=status.extra_info.get("is_input_error") == "true",
+            retriable=status.retriable,
+        )
 
     def __str__(self) -> str:
         return f"<{type(self).__name__}: (code={self.code}, message={self.message})>"

--- a/tests/unit/test_error_classification.py
+++ b/tests/unit/test_error_classification.py
@@ -1,0 +1,84 @@
+"""Cover the handler raise sites that surface the error classification
+(is_input_error / retriable) via MilvusException.from_status."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pymilvus.exceptions import DescribeCollectionException, MilvusException
+from pymilvus.grpc_gen import common_pb2
+
+COLLECTION = "test_collection"
+
+
+def _input_error_status():
+    # An error status that is NOT any of the not-found special cases the
+    # handlers short-circuit on, so the code falls through to the raise.
+    return common_pb2.Status(
+        code=1100,
+        reason="invalid parameter",
+        extra_info={"is_input_error": "true"},
+        retriable=False,
+    )
+
+
+def _error_response():
+    resp = MagicMock()
+    resp.status = _input_error_status()
+    return resp
+
+
+class TestSyncHandlerClassification:
+    def test_describe_collection_surfaces_classification(self, mock_grpc_handler):
+        mock_grpc_handler._stub.DescribeCollection = MagicMock(return_value=_error_response())
+        with pytest.raises(DescribeCollectionException) as exc:
+            mock_grpc_handler.describe_collection(COLLECTION)
+        assert exc.value.code == 1100
+        assert exc.value.is_input_error is True
+        assert exc.value.retriable is False
+
+    def test_has_collection_surfaces_classification(self, mock_grpc_handler):
+        mock_grpc_handler._stub.DescribeCollection = MagicMock(return_value=_error_response())
+        with pytest.raises(MilvusException) as exc:
+            mock_grpc_handler.has_collection(COLLECTION)
+        assert exc.value.code == 1100
+        assert exc.value.is_input_error is True
+
+    def test_list_indexes_surfaces_classification(self, mock_grpc_handler):
+        mock_grpc_handler._stub.DescribeIndex = MagicMock(return_value=_error_response())
+        with pytest.raises(MilvusException) as exc:
+            mock_grpc_handler.list_indexes(COLLECTION)
+        assert exc.value.code == 1100
+        assert exc.value.is_input_error is True
+
+
+class TestAsyncHandlerClassification:
+    @pytest.mark.asyncio
+    async def test_describe_collection_surfaces_classification(self, mock_async_grpc_handler):
+        mock_async_grpc_handler._async_stub.DescribeCollection = AsyncMock(
+            return_value=_error_response()
+        )
+        with pytest.raises(DescribeCollectionException) as exc:
+            await mock_async_grpc_handler.describe_collection(COLLECTION)
+        assert exc.value.code == 1100
+        assert exc.value.is_input_error is True
+        assert exc.value.retriable is False
+
+    @pytest.mark.asyncio
+    async def test_has_collection_surfaces_classification(self, mock_async_grpc_handler):
+        mock_async_grpc_handler._async_stub.DescribeCollection = AsyncMock(
+            return_value=_error_response()
+        )
+        with pytest.raises(MilvusException) as exc:
+            await mock_async_grpc_handler.has_collection(COLLECTION)
+        assert exc.value.code == 1100
+        assert exc.value.is_input_error is True
+
+    @pytest.mark.asyncio
+    async def test_list_indexes_surfaces_classification(self, mock_async_grpc_handler):
+        mock_async_grpc_handler._async_stub.DescribeIndex = AsyncMock(
+            return_value=_error_response()
+        )
+        with pytest.raises(MilvusException) as exc:
+            await mock_async_grpc_handler.list_indexes(COLLECTION)
+        assert exc.value.code == 1100
+        assert exc.value.is_input_error is True

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,7 +7,7 @@ from pymilvus.client import utils
 from pymilvus.client.constants import LOGICAL_BITS, LOGICAL_BITS_MASK
 from pymilvus.client.types import DataType
 from pymilvus.client.utils import immutable_message_to_dict, replicate_checkpoint_to_dict
-from pymilvus.exceptions import MilvusException, ParamError
+from pymilvus.exceptions import DescribeCollectionException, MilvusException, ParamError
 from pymilvus.grpc_gen import common_pb2
 
 
@@ -491,3 +491,55 @@ class TestImmutableMessageToDict:
             "payload": b"",
             "properties": {},
         }
+
+
+class TestCheckStatusClassification:
+    def test_input_error_surfaced(self):
+        status = common_pb2.Status(
+            code=1100,
+            reason="invalid parameter",
+            error_code=common_pb2.IllegalArgument,
+            retriable=False,
+            extra_info={"is_input_error": "true"},
+        )
+        with pytest.raises(MilvusException) as exc_info:
+            utils.check_status(status)
+        e = exc_info.value
+        assert e.code == 1100
+        assert e.is_input_error is True
+        assert e.retriable is False
+
+    def test_system_error_retriable(self):
+        status = common_pb2.Status(
+            code=2,
+            reason="service unavailable",
+            retriable=True,
+        )
+        with pytest.raises(MilvusException) as exc_info:
+            utils.check_status(status)
+        e = exc_info.value
+        assert e.code == 2
+        assert e.is_input_error is False
+        assert e.retriable is True
+
+    def test_defaults_when_unset(self):
+        # A bare error status (no extra_info, no retriable) defaults to a
+        # non-input, non-retriable system error.
+        status = common_pb2.Status(code=500, reason="boom")
+        with pytest.raises(MilvusException) as exc_info:
+            utils.check_status(status)
+        e = exc_info.value
+        assert e.is_input_error is False
+        assert e.retriable is False
+
+    def test_from_status_preserves_subclass(self):
+        status = common_pb2.Status(
+            code=0,
+            reason="can't find collection",
+            error_code=common_pb2.CollectionNotExists,
+            extra_info={"is_input_error": "true"},
+        )
+        e = DescribeCollectionException.from_status(status)
+        assert isinstance(e, DescribeCollectionException)
+        assert e.is_input_error is True
+        assert e.compatible_code == common_pb2.CollectionNotExists


### PR DESCRIPTION
## What

Expose the server's error classification on `MilvusException`:

- `is_input_error` — the request itself was malformed (caller's fault); the server never retries it or fails it over, and forces it non-retriable.
- `retriable` — whether blindly retrying the same request may succeed.

Both are populated by a new `MilvusException.from_status(status)` classmethod, which all status-based raise sites now use: `check_status` plus the `describe_collection` / `has_collection`-style custom raises in both the sync and async gRPC handlers.

## Why

Since Milvus standardized error handling, a server error carries a structured classification beyond its message: `Status.ExtraInfo["is_input_error"]` and `Status.retriable`. The SDK discarded both, so callers (and the test suites) could only match on the error message — which is not a stable contract and breaks on harmless rewording.

## Compatibility

`from_status` defaults a bare error (no `extra_info`, no `retriable`) to a non-input, non-retriable system error, so behavior is unchanged against servers that do not set these fields. The new constructor params are keyword-only with defaults, so existing `MilvusException(code, message, compatible_code)` callers are unaffected.

## Test

Added `TestCheckStatusClassification` in `tests/unit/test_utils.py` covering input-error surfacing, retriable system error, unset defaults, and subclass preservation through `from_status`. `ruff` and `black` clean. Also validated end-to-end against a local standalone: `search`/`create` on a bad request surface `is_input_error=True`, and `describe` on a missing collection now carries the classification too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
