### PR TITLE
fix: support struct vector fields in BulkWriter

### DIFF
--- a/pymilvus/bulk_writer/__init__.py
+++ b/pymilvus/bulk_writer/__init__.py
@@ -1,6 +1,6 @@
 from importlib.util import find_spec
 
-expected_pkgs = ["minio", "azure", "requests", "pyarrow"]
+expected_pkgs = ["minio", "azure", "requests", "pyarrow", "ml_dtypes"]
 
 missing = [pkg for pkg in expected_pkgs if find_spec(pkg) is None]
 

--- a/pymilvus/bulk_writer/buffer.py
+++ b/pymilvus/bulk_writer/buffer.py
@@ -15,6 +15,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+import ml_dtypes
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -60,6 +61,10 @@ def to_raw_type(obj: dict):
         elif isinstance(v, np.generic):
             obj[k] = v.item()
     return obj
+
+
+def _float16_vector_numpy_dtype(dtype: DataType):
+    return ml_dtypes.bfloat16 if dtype == DataType.BFLOAT16_VECTOR else np.float16
 
 
 class Buffer:
@@ -151,6 +156,8 @@ class Buffer:
             return self._persist_npy(local_path, **kwargs)
         if self._file_type == BulkFileType.JSON:
             return self._persist_json_rows(local_path, **kwargs)
+        if self._file_type == BulkFileType.JSONL:
+            return self._persist_json_lines(local_path, **kwargs)
         if self._file_type == BulkFileType.PARQUET:
             return self._persist_parquet(local_path, **kwargs)
         if self._file_type == BulkFileType.CSV:
@@ -228,30 +235,29 @@ class Buffer:
 
         return file_list
 
+    def _json_row_at(self, row_index: int):
+        row = {}
+        for k, v in self._buffer.items():
+            # special process for float16 vector, the self._buffer stores bytes for
+            # float16 vector, convert the bytes to float list
+            field_schema = self._fields[k]
+            if field_schema.dtype in {DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR}:
+                val = v[row_index]
+                if isinstance(val, list):
+                    row[k] = val
+                else:
+                    dt = _float16_vector_numpy_dtype(field_schema.dtype)
+                    row[k] = np.frombuffer(val, dtype=dt).tolist()
+            else:
+                row[k] = v[row_index]
+        return row
+
     def _persist_json_rows(self, local_path: str, **kwargs):
         rows = []
         row_count = len(next(iter(self._buffer.values())))
         row_index = 0
         while row_index < row_count:
-            row = {}
-            for k, v in self._buffer.items():
-                # special process for float16 vector, the self._buffer stores bytes for
-                # float16 vector, convert the bytes to float list
-                field_schema = self._fields[k]
-                if field_schema.dtype in {DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR}:
-                    val = v[row_index]
-                    if isinstance(val, list):
-                        row[k] = val
-                    else:
-                        dt = (
-                            np.dtype("bfloat16")
-                            if (field_schema.dtype == DataType.BFLOAT16_VECTOR)
-                            else np.float16
-                        )
-                        row[k] = np.frombuffer(val, dtype=dt).tolist()
-                else:
-                    row[k] = v[row_index]
-            rows.append(row)
+            rows.append(self._json_row_at(row_index))
             row_index = row_index + 1
 
         data = {
@@ -265,6 +271,20 @@ class Buffer:
             self._throw(f"Failed to persist file {file_path}, error: {e}")
 
         logger.info(f"Successfully persist file {file_path}, row count: {len(rows)}")
+        return [str(file_path)]
+
+    def _persist_json_lines(self, local_path: str, **kwargs):
+        row_count = len(next(iter(self._buffer.values())))
+        file_path = Path(local_path + ".jsonl")
+        try:
+            with file_path.open("w") as json_file:
+                for row_index in range(row_count):
+                    json_file.write(json.dumps(self._json_row_at(row_index), cls=NumpyEncoder))
+                    json_file.write("\n")
+        except Exception as e:
+            self._throw(f"Failed to persist file {file_path}, error: {e}")
+
+        logger.info(f"Successfully persist file {file_path}, row count: {row_count}")
         return [str(file_path)]
 
     def _deduce_arrow_schema(self):
@@ -393,11 +413,7 @@ class Buffer:
                     elif isinstance(val, list):
                         arr.append(json.dumps(val))
                     else:
-                        dt = (
-                            np.dtype("bfloat16")
-                            if (field_schema.dtype == DataType.BFLOAT16_VECTOR)
-                            else np.dtype("float16")
-                        )
+                        dt = _float16_vector_numpy_dtype(field_schema.dtype)
                         arr.append(json.dumps(np.frombuffer(val, dtype=dt).tolist()))
                 data[k] = pd.Series(arr, dtype=np.dtype("str"))
             elif field_schema.dtype in {

--- a/pymilvus/bulk_writer/bulk_writer.py
+++ b/pymilvus/bulk_writer/bulk_writer.py
@@ -304,6 +304,24 @@ class BulkWriter:
 
         return row_size
 
+    def _normalize_struct_vector(self, origin_list: object, dtype: DataType):
+        if dtype == DataType.FLOAT_VECTOR:
+            return np.array(origin_list, dtype=NUMPY_TYPE_CREATOR[DataType.FLOAT.name])
+
+        if dtype in {DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR}:
+            if self._file_type != BulkFileType.PARQUET:
+                return origin_list
+            if isinstance(origin_list, list):
+                values = np.asarray(origin_list, dtype=np.float32)
+                if dtype == DataType.FLOAT16_VECTOR:
+                    return values.astype(np.float16).view(np.uint8).tolist()
+                uint32_values = values.view(np.uint32)
+                return (uint32_values >> 16).astype(np.uint16).view(np.uint8).tolist()
+            if isinstance(origin_list, bytes):
+                return list(origin_list)
+
+        return origin_list
+
     def _verify_struct(self, x: object, field: StructFieldSchema):
         validator = TYPE_VALIDATOR[DataType.STRUCT.name]
         if not validator(x, field.max_capacity):
@@ -319,11 +337,15 @@ class BulkWriter:
                     self._throw(
                         f"Sub field '{sub_field.name}' of struct field '{field.name}' is missed"
                     )
-                if sub_dtype == DataType.FLOAT_VECTOR:
+                if sub_dtype in {
+                    DataType.BINARY_VECTOR,
+                    DataType.FLOAT_VECTOR,
+                    DataType.FLOAT16_VECTOR,
+                    DataType.BFLOAT16_VECTOR,
+                    DataType.INT8_VECTOR,
+                }:
                     origin_list, byte_len = self._verify_vector(obj[sub_field.name], sub_field)
-                    obj[sub_field.name] = np.array(
-                        origin_list, dtype=NUMPY_TYPE_CREATOR[DataType.FLOAT.name]
-                    )
+                    obj[sub_field.name] = self._normalize_struct_vector(origin_list, sub_dtype)
                     struct_size = struct_size + byte_len
                 elif sub_dtype == DataType.VARCHAR:
                     struct_size = struct_size + self._verify_varchar(obj[sub_field.name], sub_field)

--- a/pymilvus/bulk_writer/bulk_writer.py
+++ b/pymilvus/bulk_writer/bulk_writer.py
@@ -23,6 +23,7 @@ from pymilvus.orm.schema import CollectionSchema, FieldSchema, StructFieldSchema
 
 from .buffer import (
     Buffer,
+    _float16_vector_numpy_dtype,
 )
 from .constants import (
     NUMPY_TYPE_CREATOR,
@@ -310,6 +311,9 @@ class BulkWriter:
 
         if dtype in {DataType.FLOAT16_VECTOR, DataType.BFLOAT16_VECTOR}:
             if self._file_type != BulkFileType.PARQUET:
+                if isinstance(origin_list, bytes):
+                    dt = _float16_vector_numpy_dtype(dtype)
+                    return np.frombuffer(origin_list, dtype=dt).tolist()
                 return origin_list
             if isinstance(origin_list, list):
                 values = np.asarray(origin_list, dtype=np.float32)

--- a/pymilvus/bulk_writer/constants.py
+++ b/pymilvus/bulk_writer/constants.py
@@ -121,6 +121,7 @@ class BulkFileType(IntEnum):
     JSON_RB = 2  # deprecated
     PARQUET = 3
     CSV = 4
+    JSONL = 5
 
 
 class ConnectType(Enum):

--- a/pymilvus/bulk_writer/remote_bulk_writer.py
+++ b/pymilvus/bulk_writer/remote_bulk_writer.py
@@ -291,7 +291,7 @@ class RemoteBulkWriter(LocalBulkWriter):
 
             for file_path in file_list:
                 ext = Path(file_path).suffix
-                if ext not in [".json", ".npy", ".parquet", ".csv"]:
+                if ext not in [".json", ".jsonl", ".npy", ".parquet", ".csv"]:
                     continue
 
                 relative_file_path = str(file_path).replace(str(super().data_path), "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ bulk_writer = [
     "requests",
     "minio>=7.0.0",
     "pyarrow>=12.0.0",
+    "ml_dtypes",
     "azure-storage-blob",
     "urllib3",
 ]

--- a/tests/unit/test_bulk_writer_buffer.py
+++ b/tests/unit/test_bulk_writer_buffer.py
@@ -60,7 +60,13 @@ class TestBuffer:
 
     @pytest.mark.parametrize(
         "file_type",
-        [BulkFileType.NUMPY, BulkFileType.JSON, BulkFileType.PARQUET, BulkFileType.CSV],
+        [
+            BulkFileType.NUMPY,
+            BulkFileType.JSON,
+            BulkFileType.JSONL,
+            BulkFileType.PARQUET,
+            BulkFileType.CSV,
+        ],
     )
     def test_buffer_init_file_types(self, simple_schema: CollectionSchema, file_type):
         buffer = Buffer(simple_schema, file_type)
@@ -201,6 +207,27 @@ class TestBuffer:
                 assert len(data["rows"]) == 1
                 assert data["rows"][0]["id"] == 1
 
+    def test_persist_json_lines(self, simple_schema):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            buffer = Buffer(simple_schema, BulkFileType.JSONL)
+            buffer.append_row({"id": 1, "vector": [1.0] * 128, "text": "first"})
+            buffer.append_row({"id": 2, "vector": np.array([2.0] * 128), "text": "second"})
+
+            files = buffer.persist(temp_dir)
+
+            assert len(files) == 1
+            assert files[0].endswith(".jsonl")
+            file = Path(files[0])
+            assert file.exists()
+            with file.open("r") as f:
+                rows = [json.loads(line) for line in f]
+
+            assert rows[0]["id"] == 1
+            assert rows[0]["text"] == "first"
+            assert rows[1]["id"] == 2
+            assert rows[1]["text"] == "second"
+            assert rows[1]["vector"] == [2.0] * 128
+
     @patch("pandas.DataFrame.to_parquet")
     def test_persist_parquet(self, mock_to_parquet, simple_schema):
         buffer = Buffer(simple_schema, BulkFileType.PARQUET)
@@ -270,7 +297,6 @@ class TestBuffer:
         buffer.append_row(row)
         assert buffer.row_count == 1
 
-    @pytest.mark.xfail(reason='numpy.dtype("bfloat16") is not supported')
     def test_persist_json_with_special_vectors(self, complex_schema):
         with tempfile.TemporaryDirectory() as temp_dir:
             buffer = Buffer(complex_schema, BulkFileType.JSON)
@@ -647,7 +673,6 @@ class TestBufferExtended:
 
     def test_persist_csv_with_all_field_types(self):
         """Test CSV persist with common field types"""
-        # Skip bfloat16 due to numpy dtype issues
         fields = [
             FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
             FieldSchema(name="bool_field", dtype=DataType.BOOL),
@@ -668,6 +693,7 @@ class TestBufferExtended:
             FieldSchema(name="binary_vector", dtype=DataType.BINARY_VECTOR, dim=128),
             FieldSchema(name="sparse_vector", dtype=DataType.SPARSE_FLOAT_VECTOR),
             FieldSchema(name="float16_vector", dtype=DataType.FLOAT16_VECTOR, dim=128),
+            FieldSchema(name="bfloat16_vector", dtype=DataType.BFLOAT16_VECTOR, dim=128),
             FieldSchema(name="int8_vector", dtype=DataType.INT8_VECTOR, dim=128),
         ]
         schema = CollectionSchema(fields=fields)
@@ -688,6 +714,7 @@ class TestBufferExtended:
             "binary_vector": [1] * 128,
             "sparse_vector": {1: 0.5},
             "float16_vector": np.array([1.0] * 128, dtype=np.float16).tobytes(),
+            "bfloat16_vector": np.array([1.0] * 128, dtype=np.dtype("bfloat16")).tobytes(),
             "int8_vector": [1] * 128,
         }
         buffer.append_row(row)
@@ -772,7 +799,9 @@ class TestBufferExtended:
                 "binary_vector": [255],
                 "sparse_vector": {1: 0.5},
                 "float16_vector": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float16).tobytes(),
-                "bfloat16_vector": None,
+                "bfloat16_vector": np.array(
+                    [1.0, 2.0, 3.0, 4.0], dtype=np.dtype("bfloat16")
+                ).tobytes(),
                 "int8_vector": [1, 2, 3, 4],
             }
         )
@@ -797,6 +826,7 @@ class TestBufferExtended:
         assert json.loads(value_row["binary_vector"]) == [255]
         assert json.loads(value_row["sparse_vector"]) == {"1": 0.5}
         assert json.loads(value_row["float16_vector"]) == [1.0, 2.0, 3.0, 4.0]
+        assert json.loads(value_row["bfloat16_vector"]) == [1.0, 2.0, 3.0, 4.0]
         assert json.loads(value_row["int8_vector"]) == [1, 2, 3, 4]
 
     def test_persist_csv_nullable_vector_uses_custom_nullkey(self):

--- a/tests/unit/test_local_bulk_writer.py
+++ b/tests/unit/test_local_bulk_writer.py
@@ -1,9 +1,13 @@
+import csv
+import json
 import shutil
 import tempfile
 import threading
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+import ml_dtypes
+import numpy as np
 import pytest
 from pymilvus.bulk_writer.constants import MB, BulkFileType
 from pymilvus.bulk_writer.local_bulk_writer import LocalBulkWriter
@@ -273,6 +277,72 @@ class TestLocalBulkWriter:
             path = Path(file_path)
             assert path.exists()
             assert path.suffix == expected_suffix
+
+    @pytest.mark.parametrize(
+        "file_type",
+        [
+            pytest.param(BulkFileType.JSON, id="json"),
+            pytest.param(BulkFileType.JSONL, id="jsonl"),
+            pytest.param(BulkFileType.CSV, id="csv"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "vector_type",
+        [
+            pytest.param(DataType.FLOAT16_VECTOR, id="float16"),
+            pytest.param(DataType.BFLOAT16_VECTOR, id="bfloat16"),
+        ],
+    )
+    def test_append_row_struct_fp16_bf16_ndarray_subfield_non_parquet_outputs_numeric_lists(
+        self, temp_dir, file_type, vector_type
+    ):
+        struct_schema = StructFieldSchema()
+        struct_schema.add_field("vector", vector_type, dim=4)
+        schema = CollectionSchema(
+            fields=[
+                FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            ]
+        )
+        schema.add_field(
+            "chunks",
+            DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=2,
+        )
+        writer = LocalBulkWriter(
+            schema=schema,
+            local_path=temp_dir,
+            chunk_size=128 * MB,
+            file_type=file_type,
+        )
+        dtype = np.float16 if vector_type == DataType.FLOAT16_VECTOR else ml_dtypes.bfloat16
+        expected_vector = [1.0, 2.0, 3.0, 4.0]
+
+        writer.append_row(
+            {
+                "id": 1,
+                "chunks": [
+                    {"vector": np.array(expected_vector, dtype=dtype)},
+                ],
+            }
+        )
+        file_prefix = str(Path(temp_dir) / f"{file_type.name.lower()}_{vector_type.name.lower()}")
+
+        file_path = Path(writer._buffer.persist(file_prefix)[0])
+
+        if file_type == BulkFileType.JSON:
+            rows = json.loads(file_path.read_text())["rows"]
+        elif file_type == BulkFileType.JSONL:
+            rows = [json.loads(line) for line in file_path.read_text().splitlines()]
+        else:
+            with file_path.open(newline="") as csv_file:
+                rows = list(csv.DictReader(csv_file))
+            rows[0]["chunks"] = json.loads(rows[0]["chunks"])
+
+        vector = rows[0]["chunks"][0]["vector"]
+        assert vector == expected_vector
+        assert all(isinstance(value, float) for value in vector)
 
     def test_append_row_text_rejects_non_string(self, temp_dir):
         schema = CollectionSchema(

--- a/tests/unit/test_local_bulk_writer.py
+++ b/tests/unit/test_local_bulk_writer.py
@@ -195,6 +195,85 @@ class TestLocalBulkWriter:
         assert writer._buffer._buffer["body"] == [long_text]
         assert writer._buffer._buffer["tags"] == [["short", long_text]]
 
+    @pytest.mark.parametrize(
+        ("vector_type", "dim"),
+        [
+            pytest.param(DataType.FLOAT_VECTOR, 4, id="float"),
+            pytest.param(DataType.FLOAT16_VECTOR, 4, id="float16"),
+            pytest.param(DataType.BFLOAT16_VECTOR, 4, id="bfloat16"),
+            pytest.param(DataType.INT8_VECTOR, 4, id="int8"),
+            pytest.param(DataType.BINARY_VECTOR, 8, id="binary"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "file_type",
+        [
+            pytest.param(BulkFileType.JSON, id="json"),
+            pytest.param(BulkFileType.JSONL, id="jsonl"),
+            pytest.param(BulkFileType.CSV, id="csv"),
+            pytest.param(BulkFileType.PARQUET, id="parquet"),
+        ],
+    )
+    def test_append_row_struct_vector_subfield_all_file_types(
+        self, temp_dir, file_type, vector_type, dim
+    ):
+        def vector_value():
+            if vector_type in {
+                DataType.FLOAT_VECTOR,
+                DataType.FLOAT16_VECTOR,
+                DataType.BFLOAT16_VECTOR,
+            }:
+                return [1.0, 2.0, 3.0, 4.0]
+            if vector_type == DataType.INT8_VECTOR:
+                return [-1, 0, 1, 2]
+            return [0, 1, 0, 1, 1, 0, 1, 0]
+
+        struct_schema = StructFieldSchema()
+        struct_schema.add_field("vector", vector_type, dim=dim)
+        schema = CollectionSchema(
+            fields=[
+                FieldSchema(name="id", dtype=DataType.INT64, is_primary=True),
+            ]
+        )
+        schema.add_field(
+            "chunks",
+            DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=2,
+        )
+        writer = LocalBulkWriter(
+            schema=schema,
+            local_path=temp_dir,
+            chunk_size=128 * MB,
+            file_type=file_type,
+        )
+
+        writer.append_row(
+            {
+                "id": 1,
+                "chunks": [
+                    {"vector": vector_value()},
+                    {"vector": vector_value()},
+                ],
+            }
+        )
+        file_prefix = str(Path(temp_dir) / f"{file_type.name.lower()}_{vector_type.name.lower()}")
+
+        files = writer._buffer.persist(file_prefix)
+
+        assert files
+        expected_suffix = {
+            BulkFileType.JSON: ".json",
+            BulkFileType.JSONL: ".jsonl",
+            BulkFileType.CSV: ".csv",
+            BulkFileType.PARQUET: ".parquet",
+        }[file_type]
+        for file_path in files:
+            path = Path(file_path)
+            assert path.exists()
+            assert path.suffix == expected_suffix
+
     def test_append_row_text_rejects_non_string(self, temp_dir):
         schema = CollectionSchema(
             fields=[

--- a/tests/unit/test_remote_bulk_writer.py
+++ b/tests/unit/test_remote_bulk_writer.py
@@ -1,5 +1,7 @@
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
+from pymilvus.bulk_writer.constants import BulkFileType
 from pymilvus.bulk_writer.remote_bulk_writer import RemoteBulkWriter
 from pymilvus.client.types import DataType
 from pymilvus.orm.schema import CollectionSchema, FieldSchema
@@ -90,3 +92,30 @@ class TestRemoteBulkWriter:
         assert kwargs["secure"] is True
         assert kwargs["session_token"] == "token"
         assert kwargs["region"] == "us-west-2"
+
+    def test_upload_jsonl_file(self, tmp_path):
+        writer = RemoteBulkWriter(
+            schema=self._simple_schema(),
+            remote_path="bulk/test",
+            connect_param=None,
+            file_type=BulkFileType.JSONL,
+            local_path=str(tmp_path),
+        )
+        jsonl_file = writer._local_path / "1.jsonl"
+        jsonl_file.write_text('{"id":1,"vector":[1.0,2.0,3.0,4.0]}\n')
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(writer, "_bucket_exists", return_value=True))
+            stack.enter_context(patch.object(writer, "_object_exists", return_value=False))
+            mock_upload_object = stack.enter_context(patch.object(writer, "_upload_object"))
+            mock_local_rm = stack.enter_context(patch.object(writer, "_local_rm"))
+            uploaded_files = writer._upload([str(jsonl_file)])
+
+        assert len(uploaded_files) == 1
+        assert uploaded_files[0].endswith(".jsonl")
+        mock_upload_object.assert_called_once()
+        _, kwargs = mock_upload_object.call_args
+        assert kwargs["file_path"].endswith(".jsonl")
+        assert kwargs["object_name"].endswith(".jsonl")
+        mock_local_rm.assert_called_once_with(str(jsonl_file))
+        assert writer.batch_files[0][0].endswith(".jsonl")

--- a/uv.lock
+++ b/uv.lock
@@ -4523,6 +4523,8 @@ bulk-writer = [
     { name = "minio", version = "7.2.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version <= '3.8'" },
     { name = "minio", version = "7.2.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version > '3.8' and python_full_version < '3.9'" },
     { name = "minio", version = "7.2.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "ml-dtypes", version = "0.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "ml-dtypes", version = "0.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "pyarrow", version = "17.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pyarrow", version = "24.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
@@ -4600,6 +4602,7 @@ requires-dist = [
     { name = "grpcio", marker = "python_full_version >= '3.14'", specifier = ">=1.75.1" },
     { name = "milvus-lite", marker = "sys_platform != 'win32' and extra == 'milvus-lite'", specifier = ">=2.4.0" },
     { name = "minio", marker = "extra == 'bulk-writer'", specifier = ">=7.0.0" },
+    { name = "ml-dtypes", marker = "extra == 'bulk-writer'" },
     { name = "numpy", marker = "python_full_version < '3.9'", specifier = "<1.25.0" },
     { name = "orjson", specifier = ">=3.10.15" },
     { name = "pandas", specifier = ">=1.2.4" },
@@ -4611,7 +4614,7 @@ requires-dist = [
     { name = "requests", marker = "extra == 'bulk-writer'" },
     { name = "urllib3", marker = "extra == 'bulk-writer'" },
 ]
-provides-extras = ["bulk-writer", "model", "milvus-lite"]
+provides-extras = ["bulk-writer", "milvus-lite", "model"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## What this PR does

- Adds `BulkFileType.JSONL` and writes one JSON object per line with `.jsonl` suffix.
- Allows Local/Remote BulkWriter to persist/upload JSONL files instead of skipping them.
- Allows BulkWriter struct-array subfields to use FLOAT_VECTOR, FLOAT16_VECTOR, BFLOAT16_VECTOR, INT8_VECTOR, and BINARY_VECTOR.
- Normalizes struct vector payloads for Parquet output, including FLOAT16/BFLOAT16 byte payloads.
- Uses `ml_dtypes` for BFLOAT16 JSON/CSV byte-vector decoding and includes it in the `bulk_writer` extra.
- Adds unit coverage for JSON, JSONL, CSV, and Parquet BulkWriter output across the supported struct vector subfield types.

## Tests

- `python -m pytest -q tests/unit/test_bulk_writer_buffer.py tests/unit/test_local_bulk_writer.py tests/unit/test_remote_bulk_writer.py`
  - 95 passed
- Milvus Python client E2E against local dev-cli deployment:
  - `test_import_struct_array_vector_subfield_all_file_types`
  - `test_import_struct_array_vector_subfield_with_local_bulk_writer`
  - 40 passed