### PR TITLE
fix: handle 1D scipy sparse arrays from csr_array iteration (Fixes #2942)

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -92,7 +92,9 @@ def entity_is_sparse_matrix(entity: Any):
             return False
         for item in entity:
             if SciPyHelper.is_scipy_sparse(item):
-                return item.shape[0] == 1
+                # Accept both 2D arrays with shape (1, N) and 1D arrays (single row
+                # from iterating a csr_array)
+                return item.ndim == 1 or item.shape[0] == 1
             if not isinstance(item, dict) and not isinstance(item, list):
                 return False
             pairs = item.items() if isinstance(item, dict) else item
@@ -143,6 +145,10 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
         dim = 0
         for row_data in data:
             if SciPyHelper.is_scipy_sparse(row_data):
+                # Accept 1D sparse arrays (from iterating a csr_array) by
+                # reshaping to (1, N) so downstream code handles them correctly
+                if row_data.ndim == 1:
+                    row_data = row_data.reshape(1, -1)
                 if row_data.shape[0] != 1:
                     raise ParamError(message="invalid input for sparse float vector: expect 1 row")
                 dim = max(dim, row_data.shape[1])
@@ -602,6 +608,10 @@ def _pack_sparse_vector_row(
 
         if not SciPyHelper.is_scipy_sparse(value):
             value = [value]
+        elif value.ndim == 1:
+            # 1D sparse array from iterating a csr_array — reshape to (1, N)
+            # so the shape[0] == 1 check and protobuf conversion work correctly
+            value = value.reshape(1, -1)
         elif value.shape[0] != 1:
             raise ParamError(message="invalid input for sparse float vector: expect 1 row")
         if not entity_is_sparse_matrix(value):

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -94,7 +94,7 @@ def entity_is_sparse_matrix(entity: Any):
             if SciPyHelper.is_scipy_sparse(item):
                 # Accept both 2D arrays with shape (1, N) and 1D arrays (single row
                 # from iterating a csr_array)
-                return item.ndim == 1 or item.shape[0] == 1
+                return getattr(item, 'ndim', None) == 1 or item.shape[0] == 1
             if not isinstance(item, dict) and not isinstance(item, list):
                 return False
             pairs = item.items() if isinstance(item, dict) else item
@@ -147,12 +147,13 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
             if SciPyHelper.is_scipy_sparse(row_data):
                 # Accept 1D sparse arrays (from iterating a csr_array) by
                 # reshaping to (1, N) so downstream code handles them correctly
-                if row_data.ndim == 1:
-                    row_data = row_data.reshape(1, -1)
-                if row_data.shape[0] != 1:
+                squeezed = row_data
+                if getattr(row_data, 'ndim', None) == 1:
+                    squeezed = row_data.reshape(1, -1)
+                if squeezed.shape[0] != 1:
                     raise ParamError(message="invalid input for sparse float vector: expect 1 row")
-                dim = max(dim, row_data.shape[1])
-                result.contents.append(sparse_float_row_to_bytes(row_data.indices, row_data.data))
+                dim = max(dim, squeezed.shape[1])
+                result.contents.append(sparse_float_row_to_bytes(squeezed.indices, squeezed.data))
             else:
                 indices = []
                 values = []
@@ -608,7 +609,7 @@ def _pack_sparse_vector_row(
 
         if not SciPyHelper.is_scipy_sparse(value):
             value = [value]
-        elif value.ndim == 1:
+        elif getattr(value, 'ndim', None) == 1:
             # 1D sparse array from iterating a csr_array — reshape to (1, N)
             # so the shape[0] == 1 check and protobuf conversion work correctly
             value = value.reshape(1, -1)

--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -94,7 +94,7 @@ def entity_is_sparse_matrix(entity: Any):
             if SciPyHelper.is_scipy_sparse(item):
                 # Accept both 2D arrays with shape (1, N) and 1D arrays (single row
                 # from iterating a csr_array)
-                return getattr(item, 'ndim', None) == 1 or item.shape[0] == 1
+                return getattr(item, "ndim", None) == 1 or item.shape[0] == 1
             if not isinstance(item, dict) and not isinstance(item, list):
                 return False
             pairs = item.items() if isinstance(item, dict) else item
@@ -148,7 +148,7 @@ def sparse_rows_to_proto(data: SparseMatrixInputType) -> schema_types.SparseFloa
                 # Accept 1D sparse arrays (from iterating a csr_array) by
                 # reshaping to (1, N) so downstream code handles them correctly
                 squeezed = row_data
-                if getattr(row_data, 'ndim', None) == 1:
+                if getattr(row_data, "ndim", None) == 1:
                     squeezed = row_data.reshape(1, -1)
                 if squeezed.shape[0] != 1:
                     raise ParamError(message="invalid input for sparse float vector: expect 1 row")
@@ -609,7 +609,7 @@ def _pack_sparse_vector_row(
 
         if not SciPyHelper.is_scipy_sparse(value):
             value = [value]
-        elif getattr(value, 'ndim', None) == 1:
+        elif getattr(value, "ndim", None) == 1:
             # 1D sparse array from iterating a csr_array — reshape to (1, N)
             # so the shape[0] == 1 check and protobuf conversion work correctly
             value = value.reshape(1, -1)


### PR DESCRIPTION
Fixes #2942

## Problem

`MilvusClient.insert()` with scipy `csr_array` raises `ParamError: invalid input for sparse float vector: expect 1 row` when iterating over a `csr_array` to build insert data. This is triggered by:

```python
sparse_vectors = csr_array((values, (rows, cols)), shape=(1, 3))
client.insert(collection_name, [{"sparse": vec} for vec in sparse_vectors])
```

## Root Cause

Iterating a scipy `csr_array` (scipy >=1.12) yields **1D sparse arrays** of shape `(N,)` for each row, whereas the existing validation logic (`shape[0] == 1`) only accepts **2D** arrays of shape `(1, N)`. The 1D array's `shape[0]` is the data dimension (e.g., 3), not the row count, so the check `row_data.shape[0] != 1` evaluates to True and raises `ParamError`.

This affects scipy >=1.12 where `csr_array` (the modern sparse array API) is the default — `csr_matrix` (which returns 2D rows on iteration) still works fine.

## Solution

Three targeted fixes in `pymilvus/client/entity_helper.py`:

1. **`entity_is_sparse_matrix()`** (line 95): Accept 1D sparse arrays (`ndim == 1`) as valid single-row matrices alongside existing 2D check (`shape[0] == 1`).

2. **`sparse_rows_to_proto()`** (line 146): Reshape 1D sparse arrays to `(1, N)` before the existing shape check, so downstream protobuf conversion works unchanged.

3. **`_pack_sparse_vector_row()`** (line 605): Same reshape before the shape[0] check, ensuring the row is processed correctly as a single sparse vector.

## Verification

```python
from scipy.sparse import csr_array

values = [0.8, 1.5, 1.3]
rows = [0, 0, 0]
cols = [0, 2, 1]
sv = csr_array((values, (rows, cols)), shape=(1, 3))

# 1D row from iteration — was the bug trigger
vec = next(iter(sv))  # shape (3,), ndim=1
assert entity_is_sparse_matrix([vec])  # now passes

# Existing 2D usage still works
assert entity_is_sparse_matrix(sv)
assert entity_is_sparse_matrix([{0: 0.8, 2: 1.5, 1: 1.3}])
```

Existing sparse vector workflows (dict-based, `csr_matrix`-based) are unaffected.

## Changelog

| Date | Change | Author |
|------|--------|--------|
| 2026-06-27 | Handle 1D scipy sparse arrays from csr_array iteration in entity_is_sparse_matrix, sparse_rows_to_proto, and _pack_sparse_vector_row | rtmalikian |

### Files Changed
- `pymilvus/client/entity_helper.py` — Add ndim == 1 check in entity_is_sparse_matrix; reshape 1D sparse arrays to (1, N) in sparse_rows_to_proto and _pack_sparse_vector_row

### Verification
- Validated with scipy 1.17.1 that 1D csr_array rows pass entity_is_sparse_matrix and reshape correctly
- Existing 2D sparse arrays and dict format continue to work
- Syntax verified with ast.parse

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **DeepSeek V4 Flash** (deepseek) via **Hermes Agent** (nousresearch). All changes were reviewed, tested against the actual codebase, and verified for correctness.
