### PR TITLE
Add namespace request and lifecycle support

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -875,6 +875,7 @@ class AsyncGrpcHandler:
                 fields_info,
                 partial_update=partial_update,
                 field_ops=field_ops,
+                namespace=kwargs.get("namespace"),
             )
         )
 
@@ -938,6 +939,7 @@ class AsyncGrpcHandler:
             partial_update=partial_update,
             schema_timestamp=schema_timestamp,
             field_ops=field_ops,
+            namespace=kwargs.get("namespace"),
         )
 
     @retry_on_rpc_failure()

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -1053,7 +1053,13 @@ class GrpcHandler:
         return (
             param
             if param
-            else Prepare.batch_insert_param(collection_name, entities, partition_name, fields_info)
+            else Prepare.batch_insert_param(
+                collection_name,
+                entities,
+                partition_name,
+                fields_info,
+                namespace=kwargs.get("namespace"),
+            )
         )
 
     @retry_on_rpc_failure()
@@ -1187,6 +1193,7 @@ class GrpcHandler:
                 fields_info,
                 partial_update=partial_update,
                 field_ops=field_ops,
+                namespace=kwargs.get("namespace"),
             )
         )
 
@@ -1268,6 +1275,7 @@ class GrpcHandler:
             schema_timestamp=schema_timestamp,
             partial_update=partial_update,
             field_ops=field_ops,
+            namespace=kwargs.get("namespace"),
         )
 
     @retry_on_rpc_failure()

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1268,6 +1268,7 @@ class Prepare:
         schema_timestamp: int = 0,
         partial_update: bool = False,
         field_ops: FieldOpsInput = None,
+        namespace: Optional[str] = None,
     ):
         if not fields_info:
             raise ParamError(message="Missing collection meta to validate entities")
@@ -1284,6 +1285,7 @@ class Prepare:
             num_rows=len(entities),
             schema_timestamp=schema_timestamp,
             partial_update=effective_partial_update,
+            namespace=namespace,
         )
 
         request = cls._parse_upsert_row_request(
@@ -1407,10 +1409,15 @@ class Prepare:
         entities: List,
         partition_name: str,
         fields_info: Any,
+        namespace: Optional[str] = None,
     ):
         location = cls._pre_insert_batch_check(entities, fields_info)
         tag = partition_name if isinstance(partition_name, str) else ""
-        request = milvus_types.InsertRequest(collection_name=collection_name, partition_name=tag)
+        request = milvus_types.InsertRequest(
+            collection_name=collection_name,
+            partition_name=tag,
+            namespace=namespace,
+        )
 
         return cls._parse_batch_request(
             request,
@@ -1428,6 +1435,7 @@ class Prepare:
         fields_info: Any,
         partial_update: bool = False,
         field_ops: FieldOpsInput = None,
+        namespace: Optional[str] = None,
     ):
         ops = normalize_field_ops(field_ops)
         # Non-REPLACE ops imply partial_update semantics; auto-promote before
@@ -1440,6 +1448,7 @@ class Prepare:
             collection_name=collection_name,
             partition_name=tag,
             partial_update=effective_partial_update,
+            namespace=namespace,
         )
 
         request = cls._parse_batch_request(request, entities, fields_info, location)
@@ -1484,6 +1493,7 @@ class Prepare:
             expr=filter,
             consistency_level=get_consistency_level(consistency_level),
             expr_template_values=cls.prepare_expression_template(kwargs.get("expr_params", {})),
+            namespace=kwargs.get("namespace"),
         )
 
     @classmethod

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -428,6 +428,62 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    async def create_namespace(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ):
+        """Create a partition-backed namespace for a collection using namespace.mode=partition."""
+        return await self.create_partition(
+            collection_name, namespace_name, timeout=timeout, **kwargs
+        )
+
+    async def drop_namespace(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ):
+        """Drop a partition-backed namespace for a collection using namespace.mode=partition."""
+        return await self.drop_partition(collection_name, namespace_name, timeout=timeout, **kwargs)
+
+    async def has_namespace(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ) -> bool:
+        """Check whether a partition-backed namespace exists."""
+        return await self.has_partition(collection_name, namespace_name, timeout=timeout, **kwargs)
+
+    async def list_namespaces(
+        self,
+        collection_name: str,
+        timeout: Optional[float] = None,
+        *,
+        prefix: Optional[str] = None,
+        page_token: Optional[str] = "",
+        page_size: Optional[int] = None,
+        **kwargs,
+    ) -> Dict:
+        """List partition-backed namespaces for a collection using namespace.mode=partition.
+
+        Args:
+            collection_name: Name of the collection.
+            timeout: Operation timeout.
+            prefix: Optional namespace name prefix to filter results.
+            page_token: Token returned by the previous page. Empty starts from the first page.
+            page_size: Maximum number of namespaces to return. If unset, returns all matches.
+
+        Returns:
+            Dict containing `namespaces` and `next_page_token`.
+        """
+        offset = self._parse_namespace_page_args(prefix, page_token, page_size)
+        namespaces = await self.list_partitions(collection_name, timeout=timeout, **kwargs)
+        return self._format_namespace_page(
+            namespaces, prefix, page_token, page_size, offset=offset
+        )
+
+    async def get_namespace_stats(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ) -> Dict:
+        """Return stats for a partition-backed namespace."""
+        return await self.get_partition_stats(
+            collection_name, namespace_name, timeout=timeout, **kwargs
+        )
+
     async def insert(
         self,
         collection_name: str,

--- a/pymilvus/milvus_client/base.py
+++ b/pymilvus/milvus_client/base.py
@@ -1,10 +1,11 @@
 """Base class for Milvus clients."""
 
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from pymilvus.client.call_context import CallContext
 from pymilvus.client.constants import CLUSTER_ID
+from pymilvus.exceptions import ParamError
 from pymilvus.orm.collection import CollectionSchema, FieldSchema
 from pymilvus.orm.schema import StructFieldSchema
 from pymilvus.orm.types import DataType
@@ -27,6 +28,68 @@ class BaseMilvusClient:
         if cluster_id:
             kwargs.setdefault(CLUSTER_ID, cluster_id)
         return kwargs
+
+    @staticmethod
+    def _format_namespace_page(
+        namespaces: List[str],
+        prefix: Optional[str] = None,
+        page_token: Optional[str] = "",
+        page_size: Optional[int] = None,
+        *,
+        offset: Optional[int] = None,
+    ) -> Dict:
+        """Apply namespace list prefix filtering and token pagination."""
+        if offset is None:
+            offset = BaseMilvusClient._parse_namespace_page_args(prefix, page_token, page_size)
+
+        matching_namespaces = list(namespaces)
+        if prefix:
+            matching_namespaces = [
+                namespace for namespace in matching_namespaces if namespace.startswith(prefix)
+            ]
+
+        if page_size is None:
+            page = matching_namespaces[offset:]
+            next_page_token = ""
+        else:
+            next_offset = offset + page_size
+            page = matching_namespaces[offset:next_offset]
+            next_page_token = str(next_offset) if next_offset < len(matching_namespaces) else ""
+
+        return {"namespaces": page, "next_page_token": next_page_token}
+
+    @staticmethod
+    def _parse_namespace_page_args(
+        prefix: Optional[str] = None,
+        page_token: Optional[str] = "",
+        page_size: Optional[int] = None,
+    ) -> int:
+        """Validate namespace list pagination arguments and return the page offset."""
+        if prefix is not None and not isinstance(prefix, str):
+            raise ParamError(message="prefix must be a string")
+
+        if page_token in (None, ""):
+            offset = 0
+        elif isinstance(page_token, str):
+            try:
+                offset = int(page_token)
+            except ValueError as exc:
+                raise ParamError(
+                    message="page_token must be empty or a non-negative integer string"
+                ) from exc
+        else:
+            raise ParamError(message="page_token must be a string")
+
+        if offset < 0:
+            raise ParamError(message="page_token must be a non-negative integer string")
+
+        if page_size is not None:
+            if isinstance(page_size, bool) or not isinstance(page_size, int):
+                raise ParamError(message="page_size must be a positive integer")
+            if page_size <= 0:
+                raise ParamError(message="page_size must be a positive integer")
+
+        return offset
 
     @classmethod
     def create_schema(cls, **kwargs):

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -1582,6 +1582,58 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    def create_namespace(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ):
+        """Create a partition-backed namespace for a collection using namespace.mode=partition."""
+        return self.create_partition(collection_name, namespace_name, timeout=timeout, **kwargs)
+
+    def drop_namespace(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ):
+        """Drop a partition-backed namespace for a collection using namespace.mode=partition."""
+        return self.drop_partition(collection_name, namespace_name, timeout=timeout, **kwargs)
+
+    def has_namespace(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ) -> bool:
+        """Check whether a partition-backed namespace exists."""
+        return self.has_partition(collection_name, namespace_name, timeout=timeout, **kwargs)
+
+    def list_namespaces(
+        self,
+        collection_name: str,
+        timeout: Optional[float] = None,
+        *,
+        prefix: Optional[str] = None,
+        page_token: Optional[str] = "",
+        page_size: Optional[int] = None,
+        **kwargs,
+    ) -> Dict:
+        """List partition-backed namespaces for a collection using namespace.mode=partition.
+
+        Args:
+            collection_name: Name of the collection.
+            timeout: Operation timeout.
+            prefix: Optional namespace name prefix to filter results.
+            page_token: Token returned by the previous page. Empty starts from the first page.
+            page_size: Maximum number of namespaces to return. If unset, returns all matches.
+
+        Returns:
+            Dict containing `namespaces` and `next_page_token`.
+        """
+        offset = self._parse_namespace_page_args(prefix, page_token, page_size)
+        namespaces = self.list_partitions(collection_name, timeout=timeout, **kwargs)
+        return self._format_namespace_page(
+            namespaces, prefix, page_token, page_size, offset=offset
+        )
+
+    def get_namespace_stats(
+        self, collection_name: str, namespace_name: str, timeout: Optional[float] = None, **kwargs
+    ) -> Dict:
+        """Return stats for a partition-backed namespace."""
+        return self.get_partition_stats(collection_name, namespace_name, timeout=timeout, **kwargs)
+
     def load_partitions(
         self,
         collection_name: str,

--- a/tests/unit/async_grpc_handler/test_async_data.py
+++ b/tests/unit/async_grpc_handler/test_async_data.py
@@ -143,6 +143,67 @@ class TestAsyncGrpcHandlerDataOps:
             assert result is not None
 
     @pytest.mark.asyncio
+    async def test_prepare_row_upsert_request_forwards_namespace(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._get_schema = AsyncMock(
+            return_value=(
+                {
+                    "fields": [
+                        {"name": "id", "type": DataType.INT64, "is_primary": True},
+                        {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
+                    ],
+                    "struct_array_fields": [],
+                    "enable_dynamic_field": False,
+                },
+                0,
+            )
+        )
+
+        with patch(
+            "pymilvus.client.async_grpc_handler.Prepare.row_upsert_param",
+            return_value=MagicMock(),
+        ) as mock_prepare:
+            await handler._prepare_row_upsert_request(
+                "test_coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                namespace="tenant_a",
+            )
+
+        assert mock_prepare.call_args.kwargs["namespace"] == "tenant_a"
+
+    @pytest.mark.asyncio
+    async def test_prepare_batch_upsert_request_forwards_namespace(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._get_schema = AsyncMock(
+            return_value=(
+                {
+                    "fields": [
+                        {"name": "id", "type": DataType.INT64, "is_primary": True},
+                        {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
+                    ],
+                    "enable_dynamic_field": False,
+                },
+                0,
+            )
+        )
+
+        with patch(
+            "pymilvus.client.async_grpc_handler.Prepare.batch_upsert_param",
+            return_value=MagicMock(),
+        ) as mock_prepare:
+            await handler._prepare_batch_upsert_request(
+                "test_coll",
+                [[1], [[0.1, 0.2, 0.3, 0.4]]],
+                namespace="tenant_a",
+            )
+
+        assert mock_prepare.call_args.kwargs["namespace"] == "tenant_a"
+
+    @pytest.mark.asyncio
     async def test_get_persistent_segment_infos(self) -> None:
         """Test get_persistent_segment_infos async API"""
         mock_channel = MagicMock()

--- a/tests/unit/grpc_handler/test_data.py
+++ b/tests/unit/grpc_handler/test_data.py
@@ -40,6 +40,18 @@ class TestGrpcHandlerDataOps:
             result = handler.upsert_rows("coll", [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}])
             assert result.insert_count == 1
 
+    def test_prepare_row_upsert_request_forwards_namespace(self, handler, mock_schema):
+        with patch.object(handler, "_get_schema", return_value=(mock_schema, 0)), patch(
+            "pymilvus.client.grpc_handler.Prepare.row_upsert_param", return_value=MagicMock()
+        ) as mock_prepare:
+            handler._prepare_row_upsert_request(
+                "coll",
+                [{"id": 1, "vector": [0.1, 0.2, 0.3, 0.4]}],
+                namespace="tenant_a",
+            )
+
+        assert mock_prepare.call_args.kwargs["namespace"] == "tenant_a"
+
     def test_batch_insert_sync_raises_on_exception(self, handler):
         handler._stub.Insert.future.return_value.result.side_effect = RuntimeError("rpc error")
         with patch.object(handler, "_prepare_batch_insert_request", return_value=MagicMock()):
@@ -56,6 +68,15 @@ class TestGrpcHandlerDataOps:
         with patch.object(handler, "_prepare_batch_upsert_request", return_value=MagicMock()):
             with pytest.raises(MilvusException):
                 handler.upsert("coll", [])
+
+    def test_prepare_batch_upsert_request_forwards_namespace(self, handler, mock_schema):
+        entities = [[1], [[0.1, 0.2, 0.3, 0.4]]]
+        with patch.object(handler, "describe_collection", return_value=mock_schema), patch(
+            "pymilvus.client.grpc_handler.Prepare.batch_upsert_param", return_value=MagicMock()
+        ) as mock_prepare:
+            handler._prepare_batch_upsert_request("coll", entities, namespace="tenant_a")
+
+        assert mock_prepare.call_args.kwargs["namespace"] == "tenant_a"
 
     def test_delete_sync(self, handler):
         mock_resp = MagicMock()
@@ -319,6 +340,16 @@ class TestGrpcHandlerBatchInsert:
                 mock_prepare.return_value = MagicMock()
                 handler._prepare_batch_insert_request("coll", entities)
                 mock_prepare.assert_called_once()
+
+    def test_prepare_batch_insert_request_forwards_namespace(self, handler, mock_schema):
+        """Test _prepare_batch_insert_request forwards namespace."""
+        entities = [[1], [[0.1, 0.2, 0.3, 0.4]]]
+        with patch.object(handler, "describe_collection", return_value=mock_schema), patch(
+            "pymilvus.client.grpc_handler.Prepare.batch_insert_param", return_value=MagicMock()
+        ) as mock_prepare:
+            handler._prepare_batch_insert_request("coll", entities, namespace="tenant_a")
+
+        assert mock_prepare.call_args.kwargs["namespace"] == "tenant_a"
 
     def test_prepare_batch_insert_invalid_param(self, handler):
         """Test _prepare_batch_insert_request with invalid insert_param."""

--- a/tests/unit/prepare/test_data.py
+++ b/tests/unit/prepare/test_data.py
@@ -403,6 +403,24 @@ class TestRowUpsertParam:
         )
         assert req.num_rows == 1
 
+    def test_upsert_with_namespace(self):
+        """Test row upsert carries namespace."""
+        schema = CollectionSchema(
+            [
+                FieldSchema("pk", DataType.INT64, is_primary=True),
+                FieldSchema("vector", DataType.FLOAT_VECTOR, dim=4),
+            ]
+        )
+        req = Prepare.row_upsert_param(
+            "test_coll",
+            [{"pk": 1, "vector": [1.0, 2.0, 3.0, 4.0]}],
+            "",
+            fields_info=make_fields_info(schema),
+            namespace="tenant_a",
+        )
+        assert req.HasField("namespace")
+        assert req.namespace == "tenant_a"
+
     def test_upsert_non_nullable_struct_missing_raises(self):
         """Test upsert rejects missing non-nullable struct."""
         schema = CollectionSchema(
@@ -549,6 +567,20 @@ class TestBatchInsertParam:
         with pytest.raises(ParamError):
             Prepare.batch_insert_param("coll", entities, "", fields_info)
 
+    def test_batch_insert_with_namespace(self):
+        """Test batch insert carries namespace."""
+        entities = [
+            {"name": "id", "values": [1], "type": DataType.INT64},
+            {"name": "vector", "values": [[1.0, 2.0]], "type": DataType.FLOAT_VECTOR},
+        ]
+        fields_info = [
+            {"name": "id", "type": DataType.INT64, "is_primary": True},
+            {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 2}},
+        ]
+        req = Prepare.batch_insert_param("coll", entities, "", fields_info, namespace="tenant_a")
+        assert req.HasField("namespace")
+        assert req.namespace == "tenant_a"
+
 
 class TestBatchUpsertParam:
     """Tests for batch_upsert_param."""
@@ -573,6 +605,20 @@ class TestBatchUpsertParam:
         # This should work with partial_update=True
         req = Prepare.batch_upsert_param("coll", entities, "", fields_info, partial_update=True)
         assert req.partial_update is True
+
+    def test_batch_upsert_with_namespace(self):
+        """Test batch upsert carries namespace."""
+        entities = [
+            {"name": "id", "values": [1], "type": DataType.INT64},
+            {"name": "vector", "values": [[1.0, 2.0]], "type": DataType.FLOAT_VECTOR},
+        ]
+        fields_info = [
+            {"name": "id", "type": DataType.INT64, "is_primary": True},
+            {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 2}},
+        ]
+        req = Prepare.batch_upsert_param("coll", entities, "", fields_info, namespace="tenant_a")
+        assert req.HasField("namespace")
+        assert req.namespace == "tenant_a"
 
 
 class TestDeleteRequest:
@@ -613,6 +659,12 @@ class TestDeleteRequest:
         )
         assert req.collection_name == "coll"
         assert req.expr == "id in {ids}"
+
+    def test_delete_with_namespace(self):
+        """Test delete carries namespace."""
+        req = Prepare.delete_request("coll", "id > 0", None, 0, namespace="tenant_a")
+        assert req.HasField("namespace")
+        assert req.namespace == "tenant_a"
 
 
 class TestStructFieldProcessing:

--- a/tests/unit/test_async_milvus_client_ops.py
+++ b/tests/unit/test_async_milvus_client_ops.py
@@ -103,6 +103,76 @@ class TestAsyncClientIndexOps:
 
 class TestAsyncClientPartitionOps:
     @pytest.mark.asyncio
+    async def test_namespace_lifecycle_delegates_to_partition_ops(self):
+        client, handler = _make_client()
+        handler.has_partition.return_value = True
+        handler.list_partitions.return_value = ["_default", "tenant_a"]
+        stat = MagicMock()
+        stat.key = "row_count"
+        stat.value = "100"
+        handler.get_partition_stats.return_value = [stat]
+
+        await client.create_namespace("col", "tenant_a", timeout=10, trace_id="t1")
+        await client.drop_namespace("col", "tenant_a", timeout=11, trace_id="t2")
+        assert await client.has_namespace("col", "tenant_a", timeout=12, trace_id="t3") is True
+        assert await client.list_namespaces("col", timeout=13, trace_id="t4") == {
+            "namespaces": ["_default", "tenant_a"],
+            "next_page_token": "",
+        }
+        assert await client.get_namespace_stats("col", "tenant_a", timeout=14, trace_id="t5") == {
+            "row_count": 100
+        }
+
+        handler.create_partition.assert_awaited_once_with(
+            "col", "tenant_a", timeout=10, context=ANY, trace_id="t1"
+        )
+        handler.drop_partition.assert_awaited_once_with(
+            "col", "tenant_a", timeout=11, context=ANY, trace_id="t2"
+        )
+        handler.has_partition.assert_awaited_once_with(
+            "col", "tenant_a", timeout=12, context=ANY, trace_id="t3"
+        )
+        handler.list_partitions.assert_awaited_once_with(
+            "col", timeout=13, context=ANY, trace_id="t4"
+        )
+        handler.get_partition_stats.assert_awaited_once_with(
+            "col", "tenant_a", timeout=14, context=ANY, trace_id="t5"
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_namespaces_supports_prefix_and_page_token(self):
+        client, handler = _make_client()
+        handler.list_partitions.return_value = ["_default", "tenant_a", "tenant_b", "team_a"]
+
+        first_page = await client.list_namespaces("col", prefix="tenant_", page_size=1)
+        second_page = await client.list_namespaces(
+            "col", prefix="tenant_", page_size=1, page_token=first_page["next_page_token"]
+        )
+
+        assert first_page == {"namespaces": ["tenant_a"], "next_page_token": "1"}
+        assert second_page == {"namespaces": ["tenant_b"], "next_page_token": ""}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"page_token": "bad"},
+            {"page_token": "-1"},
+            {"page_size": 0},
+            {"page_size": True},
+            {"prefix": 1},
+        ],
+    )
+    async def test_list_namespaces_rejects_invalid_pagination_params(self, kwargs):
+        client, handler = _make_client()
+        handler.list_partitions.return_value = ["_default", "tenant_a"]
+
+        with pytest.raises(ParamError):
+            await client.list_namespaces("col", **kwargs)
+
+        handler.list_partitions.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_load_partitions_str_converts(self):
         client, handler = _make_client()
         await client.load_partitions("col", "part1")

--- a/tests/unit/test_milvus_client.py
+++ b/tests/unit/test_milvus_client.py
@@ -1518,6 +1518,80 @@ class TestMilvusClientRoleDescription:
 
 
 class TestMilvusClientCollectionMgmt:
+    def test_namespace_lifecycle_delegates_to_partition_ops(self):
+        handler = _make_handler()
+        handler.has_partition.return_value = True
+        handler.list_partitions.return_value = ["_default", "tenant_a"]
+        stat = MagicMock()
+        stat.key = "row_count"
+        stat.value = "100"
+        handler.get_partition_stats.return_value = [stat]
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+
+            client.create_namespace("col", "tenant_a", timeout=10, trace_id="t1")
+            client.drop_namespace("col", "tenant_a", timeout=11, trace_id="t2")
+            assert client.has_namespace("col", "tenant_a", timeout=12, trace_id="t3") is True
+            assert client.list_namespaces("col", timeout=13, trace_id="t4") == {
+                "namespaces": ["_default", "tenant_a"],
+                "next_page_token": "",
+            }
+            assert client.get_namespace_stats("col", "tenant_a", timeout=14, trace_id="t5") == {
+                "row_count": 100
+            }
+
+        handler.create_partition.assert_called_once_with(
+            "col", "tenant_a", timeout=10, context=ANY, trace_id="t1"
+        )
+        handler.drop_partition.assert_called_once_with(
+            "col", "tenant_a", timeout=11, context=ANY, trace_id="t2"
+        )
+        handler.has_partition.assert_called_once_with(
+            "col", "tenant_a", timeout=12, context=ANY, trace_id="t3"
+        )
+        handler.list_partitions.assert_called_once_with("col", timeout=13, context=ANY, trace_id="t4")
+        handler.get_partition_stats.assert_called_once_with(
+            "col", "tenant_a", timeout=14, context=ANY, trace_id="t5"
+        )
+
+    def test_list_namespaces_supports_prefix_and_page_token(self):
+        handler = _make_handler()
+        handler.list_partitions.return_value = ["_default", "tenant_a", "tenant_b", "team_a"]
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+
+            first_page = client.list_namespaces("col", prefix="tenant_", page_size=1)
+            second_page = client.list_namespaces(
+                "col", prefix="tenant_", page_size=1, page_token=first_page["next_page_token"]
+            )
+
+        assert first_page == {"namespaces": ["tenant_a"], "next_page_token": "1"}
+        assert second_page == {"namespaces": ["tenant_b"], "next_page_token": ""}
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"page_token": "bad"},
+            {"page_token": "-1"},
+            {"page_size": 0},
+            {"page_size": True},
+            {"prefix": 1},
+        ],
+    )
+    def test_list_namespaces_rejects_invalid_pagination_params(self, kwargs):
+        handler = _make_handler()
+        handler.list_partitions.return_value = ["_default", "tenant_a"]
+
+        with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
+            client = MilvusClient()
+
+            with pytest.raises(ParamError):
+                client.list_namespaces("col", **kwargs)
+
+        handler.list_partitions.assert_not_called()
+
     def test_alter_collection_field(self):
         handler = _make_handler()
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):


### PR DESCRIPTION
## Summary
- Propagate namespace through request preparation and handler paths.
- Add sync and async namespace lifecycle helpers backed by partition operations.
- Make list_namespaces return paginated namespaces and next_page_token results with prefix, page_token, and page_size support.

## Test Plan
- [x] uv run pytest tests/unit/test_milvus_client.py::TestMilvusClientCollectionMgmt tests/unit/test_async_milvus_client_ops.py::TestAsyncClientPartitionOps
- [x] uv run pytest tests/unit/grpc_handler/test_data.py tests/unit/prepare/test_data.py tests/unit/prepare/test_collection.py tests/unit/async_grpc_handler/test_async_data.py -k namespace
- [x] uv run ruff check pymilvus/milvus_client/base.py pymilvus/milvus_client/milvus_client.py pymilvus/milvus_client/async_milvus_client.py tests/unit/test_milvus_client.py tests/unit/test_async_milvus_client_ops.py
- [x] git diff --check