### PR TITLE
fix: forward search group_by_fields instead of silently ignoring it

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1713,6 +1713,21 @@ class Prepare:
         if group_by_field is not None:
             search_params[GROUP_BY_FIELD] = group_by_field
 
+        # Plural group_by_fields must not be silently dropped on the search path.
+        # Mirror the singular handling above: reject the search_aggregation combination
+        # client-side, and otherwise forward the value so the proxy's group_by_fields
+        # validation and group-by search apply. See milvus-io/milvus#50960.
+        group_by_fields = kwargs.get(QUERY_GROUP_BY_FIELDS)
+        if group_by_fields is not None:
+            if not isinstance(group_by_fields, list):
+                raise ParamError(message="group_by_fields must be a list")
+            if len(group_by_fields) > 0:
+                if search_aggregation is not None:
+                    raise ParamError(
+                        message="search_aggregation and group_by_fields are mutually exclusive"
+                    )
+                search_params[QUERY_GROUP_BY_FIELDS] = ",".join(group_by_fields)
+
         group_size = kwargs.get(GROUP_SIZE)
         if group_size is not None:
             search_params[GROUP_SIZE] = group_size

--- a/tests/unit/test_async_milvus_client.py
+++ b/tests/unit/test_async_milvus_client.py
@@ -235,6 +235,17 @@ class TestAsyncMilvusClientNewFeatures:
         assert mock_handler.search.call_args.kwargs["search_aggregation"] is agg
 
     @pytest.mark.asyncio
+    async def test_search_passes_group_by_fields(self, client_and_handler):
+        # group_by_fields must be forwarded to the handler, not dropped at the
+        # high-level client boundary. See milvus-io/milvus#50960.
+        client, mock_handler = client_and_handler
+        mock_handler.search = AsyncMock(return_value=[[{"id": 1, "distance": 0.1}]])
+
+        await client.search("test_collection", data=[[0.1, 0.2]], group_by_fields=["brand"])
+
+        assert mock_handler.search.call_args.kwargs["group_by_fields"] == ["brand"]
+
+    @pytest.mark.asyncio
     async def test_hybrid_search_with_function_ranker(self, client_and_handler):
         """Test hybrid_search accepts Function type ranker"""
         client, mock_handler = client_and_handler

--- a/tests/unit/test_search_aggregation.py
+++ b/tests/unit/test_search_aggregation.py
@@ -253,6 +253,31 @@ class TestPrepareIntegration:
         with pytest.raises(ParamError, match="mutually exclusive"):
             _prepare_search(search_aggregation=_basic_agg(), group_by_field="brand")
 
+    def test_mutex_with_group_by_fields(self):
+        # Plural group_by_fields must be rejected the same way as the singular form,
+        # instead of being silently dropped. See milvus-io/milvus#50960.
+        with pytest.raises(ParamError, match="mutually exclusive"):
+            _prepare_search(search_aggregation=_basic_agg(), group_by_fields=["brand"])
+
+    def test_group_by_fields_forwarded_without_aggregation(self):
+        # Without search_aggregation, group_by_fields must reach the proxy as a
+        # comma-joined search param rather than being ignored.
+        req = _prepare_search(group_by_fields=["brand", "color"])
+        params = {kv.key: kv.value for kv in req.search_params}
+        assert params["group_by_fields"] == "brand,color"
+
+    def test_group_by_fields_empty_list_is_noop(self):
+        # An empty list carries no group-by field, so it neither conflicts with
+        # search_aggregation nor emits a group_by_fields search param.
+        req = _prepare_search(search_aggregation=_basic_agg(), group_by_fields=[])
+        params = {kv.key: kv.value for kv in req.search_params}
+        assert "group_by_fields" not in params
+        assert req.HasField("search_aggregation")
+
+    def test_group_by_fields_wrong_type(self):
+        with pytest.raises(ParamError, match="group_by_fields must be a list"):
+            _prepare_search(group_by_fields="brand")
+
     def test_wrong_type(self):
         with pytest.raises(ParamError, match="SearchAggregation instance"):
             _prepare_search(search_aggregation={"fields": ["brand"], "size": 3})


### PR DESCRIPTION
## What this PR does

Python high-level `MilvusClient.search()` silently dropped the plural
`group_by_fields` argument on the search-request prepare path. Only the
singular `group_by_field` was handled in `Prepare.search_requests_with_expr`;
`group_by_fields` was never read for search, so it was ignored — which also
bypassed the proxy's `group_by_fields` / `search_aggregation` mutual-exclusion
validation.

Mirror the existing singular `group_by_field` handling:
- reject the `search_aggregation` + `group_by_fields` combination client-side, and
- otherwise forward `group_by_fields` (comma-joined) into `search_params`, so the
  proxy's `group_by_fields` validation and group-by search apply.

The fix lives in the shared `Prepare.search_requests_with_expr`, so it covers both
the sync and async clients.

## Why

issue: milvus-io/milvus#50960

Previously `client.search(..., group_by_fields=[...], search_aggregation=...)`
succeeded and returned empty results instead of raising
`group_by_fields and search_aggregation cannot be used simultaneously`.

## Tests

`pytest tests/unit` — 331 passed. New coverage:
- `test_search_aggregation.py::TestPrepareIntegration` — plural mutex reject,
  forward-as-search-param, empty-list no-op, wrong-type guard.
- `test_async_milvus_client.py::test_search_passes_group_by_fields` — the
  high-level client forwards `group_by_fields` to the handler.

## Notes

- No proto change required.
- pymilvus-only fix. Flipping the `milvus-io/milvus` strict-xfail E2E test is a
  follow-up once a pymilvus release ships this change.
