### PR TITLE
fix: update schema key metadata on add_field

### DIFF
--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -211,50 +211,62 @@ class CollectionSchema:
             raise ParamError(message="External collections do not support auto_id")
 
     def _update_key_field_metadata(self, field: Any):
+        primary_field = self._primary_field
+        partition_key_field = self._partition_key_field
+        clustering_key_field = self._clustering_key_field
         primary_field_name = self._kwargs.get("primary_field", None)
         partition_key_field_name = self._kwargs.get("partition_key_field", None)
         clustering_key_field_name = self._kwargs.get("clustering_key_field", None)
 
-        if primary_field_name and primary_field_name == field.name:
-            field.is_primary = True
+        try:
+            if primary_field_name and primary_field_name == field.name:
+                field.is_primary = True
 
-        if partition_key_field_name and partition_key_field_name == field.name:
-            field.is_partition_key = True
+            if partition_key_field_name and partition_key_field_name == field.name:
+                field.is_partition_key = True
 
-        if clustering_key_field_name and clustering_key_field_name == field.name:
-            field.is_clustering_key = True
+            if clustering_key_field_name and clustering_key_field_name == field.name:
+                field.is_clustering_key = True
 
-        if field.is_primary:
-            if self._primary_field is not None and self._primary_field.name != field.name:
-                msg = ExceptionsMessage.PrimaryKeyOnlyOne % (self._primary_field.name, field.name)
-                raise PrimaryKeyException(message=msg)
-            self._primary_field = field
-            if self._kwargs.get("auto_id", False):
-                self._primary_field.auto_id = True
+            if field.is_primary:
+                if self._primary_field is not None and self._primary_field.name != field.name:
+                    msg = ExceptionsMessage.PrimaryKeyOnlyOne % (
+                        self._primary_field.name,
+                        field.name,
+                    )
+                    raise PrimaryKeyException(message=msg)
+                self._primary_field = field
+                if self._kwargs.get("auto_id", False):
+                    self._primary_field.auto_id = True
 
-        if field.is_partition_key:
-            if (
-                self._partition_key_field is not None
-                and self._partition_key_field.name != field.name
-            ):
-                msg = ExceptionsMessage.PartitionKeyOnlyOne % (
-                    self._partition_key_field.name,
-                    field.name,
-                )
-                raise PartitionKeyException(message=msg)
-            self._partition_key_field = field
+            if field.is_partition_key:
+                if (
+                    self._partition_key_field is not None
+                    and self._partition_key_field.name != field.name
+                ):
+                    msg = ExceptionsMessage.PartitionKeyOnlyOne % (
+                        self._partition_key_field.name,
+                        field.name,
+                    )
+                    raise PartitionKeyException(message=msg)
+                self._partition_key_field = field
 
-        if field.is_clustering_key:
-            if (
-                self._clustering_key_field is not None
-                and self._clustering_key_field.name != field.name
-            ):
-                msg = ExceptionsMessage.ClusteringKeyOnlyOne % (
-                    self._clustering_key_field.name,
-                    field.name,
-                )
-                raise ClusteringKeyException(message=msg)
-            self._clustering_key_field = field
+            if field.is_clustering_key:
+                if (
+                    self._clustering_key_field is not None
+                    and self._clustering_key_field.name != field.name
+                ):
+                    msg = ExceptionsMessage.ClusteringKeyOnlyOne % (
+                        self._clustering_key_field.name,
+                        field.name,
+                    )
+                    raise ClusteringKeyException(message=msg)
+                self._clustering_key_field = field
+        except Exception:
+            self._primary_field = primary_field
+            self._partition_key_field = partition_key_field
+            self._clustering_key_field = clustering_key_field
+            raise
 
     def _check_functions(self):
         for function in self._functions:
@@ -529,8 +541,8 @@ class CollectionSchema:
             return self
 
         field = FieldSchema(field_name, datatype, **kwargs)
-        self._fields.append(field)
         self._update_key_field_metadata(field)
+        self._fields.append(field)
         self._mark_output_fields()
         return self
 

--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -210,6 +210,52 @@ class CollectionSchema:
         elif self._kwargs.get("auto_id", False):
             raise ParamError(message="External collections do not support auto_id")
 
+    def _update_key_field_metadata(self, field: Any):
+        primary_field_name = self._kwargs.get("primary_field", None)
+        partition_key_field_name = self._kwargs.get("partition_key_field", None)
+        clustering_key_field_name = self._kwargs.get("clustering_key_field", None)
+
+        if primary_field_name and primary_field_name == field.name:
+            field.is_primary = True
+
+        if partition_key_field_name and partition_key_field_name == field.name:
+            field.is_partition_key = True
+
+        if clustering_key_field_name and clustering_key_field_name == field.name:
+            field.is_clustering_key = True
+
+        if field.is_primary:
+            if self._primary_field is not None and self._primary_field.name != field.name:
+                msg = ExceptionsMessage.PrimaryKeyOnlyOne % (self._primary_field.name, field.name)
+                raise PrimaryKeyException(message=msg)
+            self._primary_field = field
+            if self._kwargs.get("auto_id", False):
+                self._primary_field.auto_id = True
+
+        if field.is_partition_key:
+            if (
+                self._partition_key_field is not None
+                and self._partition_key_field.name != field.name
+            ):
+                msg = ExceptionsMessage.PartitionKeyOnlyOne % (
+                    self._partition_key_field.name,
+                    field.name,
+                )
+                raise PartitionKeyException(message=msg)
+            self._partition_key_field = field
+
+        if field.is_clustering_key:
+            if (
+                self._clustering_key_field is not None
+                and self._clustering_key_field.name != field.name
+            ):
+                msg = ExceptionsMessage.ClusteringKeyOnlyOne % (
+                    self._clustering_key_field.name,
+                    field.name,
+                )
+                raise ClusteringKeyException(message=msg)
+            self._clustering_key_field = field
+
     def _check_functions(self):
         for function in self._functions:
             for output_field_name in function.output_field_names:
@@ -484,6 +530,7 @@ class CollectionSchema:
 
         field = FieldSchema(field_name, datatype, **kwargs)
         self._fields.append(field)
+        self._update_key_field_metadata(field)
         self._mark_output_fields()
         return self
 

--- a/tests/unit/orm/test_schema.py
+++ b/tests/unit/orm/test_schema.py
@@ -628,6 +628,30 @@ class TestCollectionSchemaAddField:
         assert field.max_length == 256
         assert field.nullable is True
 
+    def test_add_field_updates_key_field_metadata(self):
+        """Test adding key fields updates schema metadata for incremental schema building."""
+        schema = CollectionSchema(
+            [],
+            check_fields=False,
+            auto_id=True,
+            primary_field="id",
+            partition_key_field="category",
+            clustering_key_field="timestamp",
+        )
+        schema.add_field("id", DataType.INT64)
+        schema.add_field("category", DataType.VARCHAR, max_length=256)
+        schema.add_field("timestamp", DataType.INT64)
+        schema.add_field("vec", DataType.FLOAT_VECTOR, dim=128)
+
+        assert schema.primary_field.name == "id"
+        assert schema.primary_field.is_primary is True
+        assert schema.primary_field.auto_id is True
+        assert schema.auto_id is True
+        assert schema.partition_key_field.name == "category"
+        assert schema.partition_key_field.is_partition_key is True
+        assert schema._clustering_key_field.name == "timestamp"
+        assert schema._clustering_key_field.is_clustering_key is True
+
     def test_add_struct_field_missing_struct_schema(self):
         """Test adding struct field without struct_schema raises error."""
         schema = CollectionSchema(

--- a/tests/unit/orm/test_schema.py
+++ b/tests/unit/orm/test_schema.py
@@ -652,6 +652,49 @@ class TestCollectionSchemaAddField:
         assert schema._clustering_key_field.name == "timestamp"
         assert schema._clustering_key_field.is_clustering_key is True
 
+    @pytest.mark.parametrize(
+        "fields,field_name,datatype,kwargs,error_type",
+        [
+            pytest.param(
+                [FieldSchema("id1", DataType.INT64, is_primary=True)],
+                "id2",
+                DataType.INT64,
+                {"is_primary": True},
+                PrimaryKeyException,
+                id="primary",
+            ),
+            pytest.param(
+                [
+                    FieldSchema("id", DataType.INT64, is_primary=True),
+                    FieldSchema("cat1", DataType.VARCHAR, max_length=100, is_partition_key=True),
+                ],
+                "cat2",
+                DataType.VARCHAR,
+                {"max_length": 100, "is_partition_key": True},
+                PartitionKeyException,
+                id="partition_key",
+            ),
+            pytest.param(
+                [
+                    FieldSchema("id", DataType.INT64, is_primary=True),
+                    FieldSchema("ts1", DataType.INT64, is_clustering_key=True),
+                ],
+                "ts2",
+                DataType.INT64,
+                {"is_clustering_key": True},
+                ClusteringKeyException,
+                id="clustering_key",
+            ),
+        ],
+    )
+    def test_add_field_rejects_multiple_key_fields(
+        self, fields, field_name, datatype, kwargs, error_type
+    ):
+        """Test add_field rejects adding a second key field of the same kind."""
+        schema = CollectionSchema(fields)
+        with pytest.raises(error_type, match="only one"):
+            schema.add_field(field_name, datatype, **kwargs)
+
     def test_add_struct_field_missing_struct_schema(self):
         """Test adding struct field without struct_schema raises error."""
         schema = CollectionSchema(

--- a/tests/unit/orm/test_schema.py
+++ b/tests/unit/orm/test_schema.py
@@ -692,8 +692,35 @@ class TestCollectionSchemaAddField:
     ):
         """Test add_field rejects adding a second key field of the same kind."""
         schema = CollectionSchema(fields)
+        fields_before = [field.to_dict() for field in schema.fields]
+        key_fields_before = (
+            schema.primary_field.name if schema.primary_field else None,
+            schema.partition_key_field.name if schema.partition_key_field else None,
+            schema._clustering_key_field.name if schema._clustering_key_field else None,
+        )
+
         with pytest.raises(error_type, match="only one"):
             schema.add_field(field_name, datatype, **kwargs)
+
+        assert [field.to_dict() for field in schema.fields] == fields_before
+        assert (
+            schema.primary_field.name if schema.primary_field else None,
+            schema.partition_key_field.name if schema.partition_key_field else None,
+            schema._clustering_key_field.name if schema._clustering_key_field else None,
+        ) == key_fields_before
+
+    def test_add_field_rolls_back_key_metadata_when_later_validation_fails(self):
+        """Test a failed add_field leaves fields and key metadata unchanged."""
+        schema = CollectionSchema([], check_fields=False)
+        schema.add_field("category", DataType.VARCHAR, max_length=100, is_partition_key=True)
+        fields_before = [field.to_dict() for field in schema.fields]
+
+        with pytest.raises(PartitionKeyException, match="only one"):
+            schema.add_field("id", DataType.INT64, is_primary=True, is_partition_key=True)
+
+        assert [field.to_dict() for field in schema.fields] == fields_before
+        assert schema.primary_field is None
+        assert schema.partition_key_field.name == "category"
 
     def test_add_struct_field_missing_struct_schema(self):
         """Test adding struct field without struct_schema raises error."""

--- a/tests/unit/test_local_bulk_writer.py
+++ b/tests/unit/test_local_bulk_writer.py
@@ -13,6 +13,7 @@ from pymilvus.bulk_writer.constants import MB, BulkFileType
 from pymilvus.bulk_writer.local_bulk_writer import LocalBulkWriter
 from pymilvus.client.types import DataType
 from pymilvus.exceptions import MilvusException
+from pymilvus.milvus_client import MilvusClient
 from pymilvus.orm.schema import CollectionSchema, FieldSchema, StructFieldSchema
 
 
@@ -115,6 +116,37 @@ class TestLocalBulkWriter:
         )
 
         assert writer._buffer.row_count == 1
+
+    def test_init_with_milvus_client_schema(self, temp_dir):
+        schema = MilvusClient.create_schema(auto_id=False)
+        struct_schema = MilvusClient.create_struct_field_schema()
+        struct_schema.add_field("score", DataType.FLOAT)
+        schema.add_field(
+            "chunks",
+            DataType.ARRAY,
+            element_type=DataType.STRUCT,
+            struct_schema=struct_schema,
+            max_capacity=2,
+        )
+        schema.add_field("id", DataType.INT64, is_primary=True)
+        schema.add_field("vector", DataType.FLOAT_VECTOR, dim=4)
+
+        with LocalBulkWriter(
+            schema=schema,
+            local_path=temp_dir,
+            chunk_size=128 * MB,
+            file_type=BulkFileType.PARQUET,
+        ) as writer:
+            writer.append_row(
+                {
+                    "id": 1,
+                    "vector": [0.1, 0.2, 0.3, 0.4],
+                    "chunks": [{"score": 0.9}],
+                }
+            )
+            writer.commit()
+
+            assert writer.batch_files
 
     def test_context_manager(self, simple_schema, temp_dir):
         with LocalBulkWriter(


### PR DESCRIPTION
## What this PR does

Fixes key-field metadata for schemas built incrementally with `MilvusClient.create_schema()` / `CollectionSchema.add_field()`.

`add_field(..., is_primary=True)` now updates `schema.primary_field` immediately, and key fields configured through schema kwargs are also reflected when their fields are added later. This lets BulkWriter accept schemas created through `MilvusClient.create_schema()`.

Fixes #3648.

## Changes

- Update `CollectionSchema.add_field()` to refresh primary, partition, and clustering key metadata.
- Preserve `auto_id=True` propagation to the primary field for incrementally built schemas.
- Add regression coverage for `MilvusClient.create_schema()` with `LocalBulkWriter`.

## Verification

```bash
uv run pytest tests/unit/orm/test_schema.py tests/unit/test_local_bulk_writer.py -q
uv run ruff check pymilvus/orm/schema.py tests/unit/orm/test_schema.py tests/unit/test_local_bulk_writer.py
```
