### PR TITLE
fix: preserve struct array fields from schema dict

### DIFF
--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -265,11 +265,15 @@ class CollectionSchema:
 
     @classmethod
     def construct_from_dict(cls, raw: Dict):
-        fields = [FieldSchema.construct_from_dict(field_raw) for field_raw in raw["fields"]]
+        fields = []
+        struct_fields = []
+        for field_raw in raw["fields"]:
+            if cls._is_struct_array_field_dict(field_raw):
+                struct_fields.append(StructFieldSchema.construct_from_dict(field_raw))
+            else:
+                fields.append(FieldSchema.construct_from_dict(field_raw))
 
-        struct_fields = None
         if raw.get("struct_fields"):
-            struct_fields = []
             for struct_field_raw in raw["struct_fields"]:
                 struct_fields.append(StructFieldSchema.construct_from_dict(struct_field_raw))
 
@@ -277,7 +281,6 @@ class CollectionSchema:
             converted_struct_fields = convert_struct_fields_to_user_format(
                 raw["struct_array_fields"]
             )
-            struct_fields = []
             for struct_field_dict in converted_struct_fields:
                 struct_fields.append(StructFieldSchema.construct_from_dict(struct_field_dict))
 
@@ -298,6 +301,23 @@ class CollectionSchema:
             enable_namespace=enable_namespace,
             external_source=raw.get("external_source", ""),
             external_spec=raw.get("external_spec", ""),
+        )
+
+    @staticmethod
+    def _is_struct_array_field_dict(field_raw: Any):
+        if not isinstance(field_raw, dict):
+            return False
+
+        try:
+            field_type = DataType(field_raw.get("type"))
+            element_type = DataType(field_raw.get("element_type"))
+        except (TypeError, ValueError):
+            return False
+
+        return (
+            field_type == DataType.ARRAY
+            and element_type == DataType.STRUCT
+            and "struct_fields" in field_raw
         )
 
     @property

--- a/tests/unit/orm/test_schema.py
+++ b/tests/unit/orm/test_schema.py
@@ -770,6 +770,48 @@ class TestCollectionSchemaToDict:
         schema = CollectionSchema.construct_from_dict(d)
         assert len(schema.struct_fields) == 1
 
+    def test_construct_with_user_struct_array_field_format(self):
+        """Test constructing schema from MilvusClient.describe_collection struct array format."""
+        d = {
+            "description": "",
+            "fields": [
+                {"name": "id", "type": DataType.INT64, "is_primary": True},
+                {
+                    "field_id": 100,
+                    "name": "metadata",
+                    "description": "struct values",
+                    "type": DataType.ARRAY,
+                    "element_type": DataType.STRUCT,
+                    "nullable": True,
+                    "params": {"max_capacity": 10, "mmap_enabled": True},
+                    "struct_fields": [
+                        {"field_id": 101, "name": "score", "type": DataType.FLOAT},
+                        {
+                            "field_id": 102,
+                            "name": "embedding",
+                            "type": DataType.FLOAT_VECTOR,
+                            "params": {"dim": 4},
+                        },
+                    ],
+                },
+            ],
+        }
+
+        schema = CollectionSchema.construct_from_dict(d)
+
+        assert [field.name for field in schema.fields] == ["id"]
+        assert schema.primary_field.name == "id"
+        assert len(schema.struct_fields) == 1
+        struct = schema.struct_fields[0]
+        assert struct.name == "metadata"
+        assert struct.description == "struct values"
+        assert struct.nullable is True
+        assert struct.max_capacity == 10
+        assert struct.params["mmap_enabled"] is True
+        assert [field.name for field in struct.fields] == ["score", "embedding"]
+        assert struct.fields[1].dtype == DataType.FLOAT_VECTOR
+        assert struct.fields[1].params["dim"] == 4
+
 
 class TestCollectionSchemaProperties:
     """Tests for CollectionSchema properties."""

--- a/tests/unit/test_local_bulk_writer.py
+++ b/tests/unit/test_local_bulk_writer.py
@@ -77,6 +77,45 @@ class TestLocalBulkWriter:
         )
         assert w._chunk_size == 256 * MB
 
+    def test_init_with_describe_collection_struct_array_schema(self, temp_dir):
+        raw_schema = {
+            "description": "",
+            "fields": [
+                {"name": "id", "type": DataType.INT64, "is_primary": True},
+                {"name": "vector", "type": DataType.FLOAT_VECTOR, "params": {"dim": 2}},
+                {
+                    "name": "metadata",
+                    "type": DataType.ARRAY,
+                    "element_type": DataType.STRUCT,
+                    "params": {"max_capacity": 2},
+                    "struct_fields": [
+                        {"name": "score", "type": DataType.FLOAT},
+                        {"name": "embedding", "type": DataType.FLOAT_VECTOR, "params": {"dim": 2}},
+                    ],
+                },
+            ],
+        }
+        schema = CollectionSchema.construct_from_dict(raw_schema)
+        writer = LocalBulkWriter(
+            schema=schema,
+            local_path=temp_dir,
+            chunk_size=128 * MB,
+            file_type=BulkFileType.PARQUET,
+        )
+
+        writer.append_row(
+            {
+                "id": 1,
+                "vector": [0.1, 0.2],
+                "metadata": [
+                    {"score": 1.0, "embedding": [0.3, 0.4]},
+                    {"score": 2.0, "embedding": [0.5, 0.6]},
+                ],
+            }
+        )
+
+        assert writer._buffer.row_count == 1
+
     def test_context_manager(self, simple_schema, temp_dir):
         with LocalBulkWriter(
             schema=simple_schema,


### PR DESCRIPTION
## What

Fix `CollectionSchema.construct_from_dict()` so it preserves struct array fields from the user-facing schema dict returned by `MilvusClient.describe_collection()`.

When a field dict has `type=ARRAY`, `element_type=STRUCT`, and nested `struct_fields`, it is now reconstructed as a `StructFieldSchema` in `schema.struct_fields` instead of a normal `FieldSchema` in `schema.fields`.

Fixes #3650

## Why

Without this, users cannot reliably build a BulkWriter schema from `describe_collection()` for collections containing struct array fields. BulkWriter sees the field as a normal ARRAY with STRUCT element type and rejects rows as unsupported.

## Tests

```bash
uv run pytest tests/unit/orm/test_schema.py::TestCollectionSchemaToDict::test_construct_with_user_struct_array_field_format tests/unit/test_local_bulk_writer.py::TestLocalBulkWriter::test_init_with_describe_collection_struct_array_schema -q
uv run pytest tests/unit/orm/test_schema.py tests/unit/test_local_bulk_writer.py -q
uv run black --check pymilvus/orm/schema.py tests/unit/orm/test_schema.py tests/unit/test_local_bulk_writer.py
uv run ruff check pymilvus/orm/schema.py tests/unit/orm/test_schema.py tests/unit/test_local_bulk_writer.py
```
