### PR TITLE
fix: materialize array query results as Python lists

### DIFF
--- a/pymilvus/client/entity_helper.py
+++ b/pymilvus/client/entity_helper.py
@@ -724,21 +724,15 @@ def extract_array_rows(field_data: Any, entity_rows: List[Dict], row_count: int,
     if row_count == 0:
         return
     field_name = field_data.field_name
-    array_data = field_data.scalars.array_data
-    data = array_data.data
-    element_type = array_data.element_type
-
-    attr = type_info.get_array_element_attr(element_type)
-    if attr is None:
-        raise MilvusException(message=f"Unsupported data type: {element_type}")
-
     valid_data = field_data.valid_data
     if has_valid:
         for i in range(row_count):
-            entity_rows[i][field_name] = getattr(data[i], attr).data if valid_data[i] else None
+            entity_rows[i][field_name] = (
+                field_data_extractors.decode_array_cell(field_data, i) if valid_data[i] else None
+            )
     else:
         for i in range(row_count):
-            entity_rows[i][field_name] = getattr(data[i], attr).data
+            entity_rows[i][field_name] = field_data_extractors.decode_array_cell(field_data, i)
 
 
 def extract_row_data_from_fields_data_v2(

--- a/pymilvus/client/field_data_extractors.py
+++ b/pymilvus/client/field_data_extractors.py
@@ -116,7 +116,7 @@ def decode_array_cell(field_data: Any, logical_index: int) -> Any:
     attr = type_info.get_array_element_attr(array_data.element_type)
     if attr is None:
         raise MilvusException(message=f"Unsupported data type: {array_data.element_type}")
-    return getattr(array_data.data[logical_index], attr).data
+    return list(getattr(array_data.data[logical_index], attr).data)
 
 
 def decode_vector_array_cell(

--- a/tests/unit/test_client_entity_helper.py
+++ b/tests/unit/test_client_entity_helper.py
@@ -1347,6 +1347,27 @@ class TestEmptyResultArrayField:
         extract_array_rows(fd, entity_rows, 0, has_valid=True)
 
 
+class TestArrayResultMaterialization:
+    def test_extract_row_data_v2_materializes_array_as_python_list(self):
+        fd = schema_types.FieldData()
+        fd.type = DataType.ARRAY
+        fd.field_name = "arr_field"
+        fd.scalars.array_data.element_type = DataType.INT64
+        fd.scalars.array_data.data.append(
+            schema_types.ScalarField(long_data=schema_types.LongArray(data=[1, 2]))
+        )
+        fd.scalars.array_data.data.append(
+            schema_types.ScalarField(long_data=schema_types.LongArray(data=[3, 4]))
+        )
+
+        entity_rows: List[Dict] = [{}, {}]
+        extract_row_data_from_fields_data_v2(fd, entity_rows)
+
+        assert entity_rows == [{"arr_field": [1, 2]}, {"arr_field": [3, 4]}]
+        assert isinstance(entity_rows[0]["arr_field"], list)
+        assert isinstance(entity_rows[1]["arr_field"], list)
+
+
 class TestLogicalTypeRowInsertPaths:
     @staticmethod
     def _byte_vector_payload(dtype, dim, seed=0):

--- a/tests/unit/test_field_data_extractors.py
+++ b/tests/unit/test_field_data_extractors.py
@@ -73,7 +73,9 @@ def test_decode_scalar_json_and_array_cells():
     assert get_field_data(scalar) == ["a", "b"]
     assert decode_range(scalar, 0, 2) == ["a", None]
     assert decode_cell(json_field, 0) == {"x": 1}
-    assert decode_cell(array_field, 0) == [1, 2]
+    decoded_array = decode_cell(array_field, 0)
+    assert decoded_array == [1, 2]
+    assert isinstance(decoded_array, list)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What
- Materialize ARRAY result cells as Python `list` values instead of exposing protobuf repeated containers.
- Reuse the shared ARRAY decoder in query row extraction so query/search result paths stay consistent.
- Add unit coverage that asserts ARRAY outputs are native lists.

## Why
PyMilvus query/search results for ARRAY fields could expose `google._upb._message.RepeatedScalarContainer` values. They compare equal to lists but fail user code that checks `isinstance(value, list)` or serializes strict Python values.

## Tests
- `uv run --group dev pytest tests/unit/test_field_data_extractors.py tests/unit/test_client_entity_helper.py`
- `uv run --group dev ruff check pymilvus/client/field_data_extractors.py pymilvus/client/entity_helper.py tests/unit/test_field_data_extractors.py tests/unit/test_client_entity_helper.py`
- `uv run --group dev black --check pymilvus/client/field_data_extractors.py pymilvus/client/entity_helper.py tests/unit/test_field_data_extractors.py tests/unit/test_client_entity_helper.py`