### PR TITLE
fix(bulk_writer): preserve remote upload prefixes on Windows

### DIFF
--- a/pymilvus/bulk_writer/remote_bulk_writer.py
+++ b/pymilvus/bulk_writer/remote_bulk_writer.py
@@ -295,11 +295,12 @@ class RemoteBulkWriter(LocalBulkWriter):
                     continue
 
                 relative_file_path = (
-                    Path(file_path).resolve().relative_to(super().data_path).as_posix()
+                    Path(file_path)
+                    .resolve()
+                    .relative_to(Path(super().data_path).resolve())
+                    .as_posix()
                 )
-                minio_file_path = (
-                    f"{self._remote_path.as_posix().strip('/')}/{relative_file_path}"
-                )
+                minio_file_path = f"{self._remote_path.as_posix().strip('/')}/{relative_file_path}"
 
                 if self._object_exists(minio_file_path):
                     logger.info(

--- a/pymilvus/bulk_writer/remote_bulk_writer.py
+++ b/pymilvus/bulk_writer/remote_bulk_writer.py
@@ -294,10 +294,12 @@ class RemoteBulkWriter(LocalBulkWriter):
                 if ext not in [".json", ".jsonl", ".npy", ".parquet", ".csv"]:
                     continue
 
-                relative_file_path = str(file_path).replace(str(super().data_path), "")
-                minio_file_path = str(
-                    Path.joinpath(self._remote_path, relative_file_path.lstrip("/"))
-                ).lstrip("/")
+                relative_file_path = (
+                    Path(file_path).resolve().relative_to(super().data_path).as_posix()
+                )
+                minio_file_path = (
+                    f"{self._remote_path.as_posix().strip('/')}/{relative_file_path}"
+                )
 
                 if self._object_exists(minio_file_path):
                     logger.info(

--- a/tests/unit/test_remote_bulk_writer.py
+++ b/tests/unit/test_remote_bulk_writer.py
@@ -112,10 +112,13 @@ class TestRemoteBulkWriter:
             uploaded_files = writer._upload([str(jsonl_file)])
 
         assert len(uploaded_files) == 1
-        assert uploaded_files[0].endswith(".jsonl")
+        assert uploaded_files[0].endswith("/1.jsonl")
         mock_upload_object.assert_called_once()
         _, kwargs = mock_upload_object.call_args
         assert kwargs["file_path"].endswith(".jsonl")
-        assert kwargs["object_name"].endswith(".jsonl")
+        assert kwargs["object_name"] == uploaded_files[0]
+        assert kwargs["object_name"].endswith("/1.jsonl")
+        assert "bulk/test/" in kwargs["object_name"]
+        assert "\\" not in kwargs["object_name"]
         mock_local_rm.assert_called_once_with(str(jsonl_file))
-        assert writer.batch_files[0][0].endswith(".jsonl")
+        assert writer.batch_files[0][0] == uploaded_files[0]

--- a/tests/unit/test_remote_bulk_writer.py
+++ b/tests/unit/test_remote_bulk_writer.py
@@ -1,4 +1,5 @@
 from contextlib import ExitStack
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from pymilvus.bulk_writer.constants import BulkFileType
@@ -122,3 +123,31 @@ class TestRemoteBulkWriter:
         assert "\\" not in kwargs["object_name"]
         mock_local_rm.assert_called_once_with(str(jsonl_file))
         assert writer.batch_files[0][0] == uploaded_files[0]
+
+    def test_upload_jsonl_file_with_relative_local_path(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        relative_local_path = Path("relative-bulk")
+
+        writer = RemoteBulkWriter(
+            schema=self._simple_schema(),
+            remote_path="bulk/test",
+            connect_param=None,
+            file_type=BulkFileType.JSONL,
+            local_path=str(relative_local_path),
+        )
+        jsonl_file = writer._local_path / "1.jsonl"
+        jsonl_file.write_text('{"id":1,"vector":[1.0,2.0,3.0,4.0]}\n')
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(writer, "_bucket_exists", return_value=True))
+            stack.enter_context(patch.object(writer, "_object_exists", return_value=False))
+            mock_upload_object = stack.enter_context(patch.object(writer, "_upload_object"))
+            stack.enter_context(patch.object(writer, "_local_rm"))
+            uploaded_files = writer._upload([str(jsonl_file)])
+
+        assert len(uploaded_files) == 1
+        _, kwargs = mock_upload_object.call_args
+        assert kwargs["object_name"] == uploaded_files[0]
+        assert kwargs["object_name"].endswith("/1.jsonl")
+        assert "bulk/test/" in kwargs["object_name"]
+        assert "\\" not in kwargs["object_name"]


### PR DESCRIPTION
﻿﻿Normalize RemoteBulkWriter object-key construction so Windows path separators cannot drop the configured remote upload prefix.

## What Problem This Solves

`RemoteBulkWriter._upload()` converts each generated local bulk file into the object key that is sent to S3/MinIO or Azure Blob Storage. That object key is later also stored in `batch_files`, so this path is both the upload target and the path Milvus uses for bulk import.

The current code derives the local suffix with string replacement and then feeds that suffix back into `Path.joinpath()`:

```python
relative_file_path = str(file_path).replace(str(super().data_path), "")
minio_file_path = str(Path.joinpath(self._remote_path, relative_file_path.lstrip("/"))).lstrip("/")
```

This mixes two different path domains:

- `file_path` and `super().data_path` are local filesystem paths, so on Windows they use `\` separators.
- `minio_file_path` is an object-storage key, so it should use stable POSIX-style `/` separators regardless of the client OS.

On Windows, a generated file such as:

```text
C:\tmp\bulk_writer\<uuid>\1.jsonl
```

can produce this suffix after string replacement:

```text
\1.jsonl
```

The code only calls `.lstrip("/")`, so the leading Windows backslash remains. When that value is passed to `Path.joinpath(self._remote_path, "\1.jsonl")`, Windows treats `"\1.jsonl"` as a rooted path. A rooted path resets the join, so the configured remote prefix is discarded.

Local reproduction before the fix:

```text
remote_base: \bulk\test\00000000-0000-0000-0000-000000000001
relative_file_path: '\\1.jsonl'
joined_object_key: \1.jsonl
expected_prefix_present: False
```

That means a Windows upload configured for:

```text
bulk/test/<uuid>/1.jsonl
```

can instead send and record:

```text
\1.jsonl
```

The practical impact is that the blob is uploaded outside the intended `bulk/test/<uuid>/` object-key prefix, and `batch_files` records the same wrong path for later bulk import. The generated file itself is valid; the bug is in translating a local Windows file path into a remote object-storage key.

## Change

Build remote object names as POSIX object-key strings instead of host filesystem paths.

The fix keeps the two path domains separate:

- use `Path(...).resolve().relative_to(super().data_path)` only to compute the local file path relative to the local bulk writer directory
- convert that relative local path with `.as_posix()` so nested bulk files become stable object-key suffixes such as `1.jsonl` or `1/part.parquet`
- combine the configured remote prefix with the relative suffix as a POSIX string, not with `Path.joinpath()`

After the change, Windows local paths are normalized before they become object-storage keys:

```text
local file path:     C:\tmp\bulk_writer\<uuid>\1.jsonl
relative suffix:     1.jsonl
remote object key:   bulk/test/<uuid>/1.jsonl
```

This keeps bucket/container checks, overwrite behavior, supported file extensions, upload client selection, `batch_files` shape, and local cleanup unchanged. It only changes the object-key construction step inside `RemoteBulkWriter._upload()`.

## Evidence

The focused unit test now verifies the bug boundary directly at the upload call. It creates a `RemoteBulkWriter` with `remote_path="bulk/test"`, writes a local `.jsonl` file under the writer's local data directory, and patches the storage calls so no real S3/Azure service is contacted.

The test asserts that `_upload_object(object_name=...)` receives a remote object key that:

- equals the path stored in `uploaded_files`
- retains the configured `bulk/test/<uuid>/` prefix
- ends with `/1.jsonl`
- contains no Windows backslashes

Expected object key after the fix:

```text
bulk/test/<uuid>/1.jsonl
```

This proves the path translation layer now treats the remote upload target as an object-storage key rather than a host filesystem path.

## Possible call chain / impact

```text
RemoteBulkWriter.commit(...)
  -> LocalBulkWriter.commit(call_back=self._upload)
    -> LocalBulkWriter._flush(...)
      -> persists generated bulk files under the local writer directory
    -> RemoteBulkWriter._upload(file_list)
      -> computes object_name from the local file path
      -> _object_exists(object_name)
      -> _upload_object(object_name=...)
      -> batch_files records the uploaded object key
```

The affected path is narrow: only `RemoteBulkWriter`'s conversion from a local generated file path to the remote S3/Azure object key is changed. In practice, this matters for Windows clients because the local file separator can otherwise leak into object-key construction.

Everything around that path stays the same. This PR does not change how bulk files are generated, how schemas or file extensions are validated, how S3/MinIO or Azure clients are initialized, how bucket/container existence and overwrite checks work, or how local files are cleaned up after upload.

## Validation

- `mamba run -n prw-pymilvus-py3.11 python -m pytest tests/unit/test_remote_bulk_writer.py -q` - passed, 4 tests
- `mamba run -n prw-pymilvus-py3.11 python -m ruff check pymilvus/bulk_writer/remote_bulk_writer.py tests/unit/test_remote_bulk_writer.py` - passed
- `git diff --check` - passed

