### PR TITLE
fix(bulk_writer): normalize volume remote paths on Windows

### DIFF
--- a/pymilvus/bulk_writer/local_bulk_writer.py
+++ b/pymilvus/bulk_writer/local_bulk_writer.py
@@ -63,6 +63,9 @@ class LocalBulkWriter(BulkWriter):
         self._exit()
 
     def _exit(self):
+        if not hasattr(self, "_working_thread"):
+            return
+
         # wait flush thread
         if len(self._working_thread) > 0:
             for k, th in self._working_thread.items():

--- a/pymilvus/bulk_writer/volume_bulk_writer.py
+++ b/pymilvus/bulk_writer/volume_bulk_writer.py
@@ -1,5 +1,5 @@
 import logging
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional
 
 from pymilvus.bulk_writer.volume_file_manager import VolumeFileManager
@@ -30,8 +30,8 @@ class VolumeBulkWriter(LocalBulkWriter):
         local_path = Path.cwd() / "bulk_writer"
         super().__init__(schema, str(local_path), chunk_size, file_type, config, **kwargs)
 
-        remote_dir_path = Path(remote_path) / super().uuid
-        self._remote_path = str(remote_dir_path) + "/"
+        remote_dir_path = PurePosixPath(remote_path.replace("\\", "/").strip("/")) / super().uuid
+        self._remote_path = f"{remote_dir_path.as_posix()}/"
         self._remote_files: List[List[str]] = []
         self._volume_name = volume_name
         self._volume_file_manager = VolumeFileManager(
@@ -110,5 +110,8 @@ class VolumeBulkWriter(LocalBulkWriter):
 
     def _upload_object(self, file_path: str, object_name: str):
         logger.info(f"Prepare to upload '{file_path}' to '{object_name}'")
-        self._volume_file_manager.upload_file_to_volume(file_path, self._remote_path)
+        target_volume_path = PurePosixPath(object_name).parent.as_posix()
+        if target_volume_path == ".":
+            target_volume_path = self._remote_path.rstrip("/")
+        self._volume_file_manager.upload_file_to_volume(file_path, target_volume_path)
         logger.info(f"Uploaded file '{file_path}' to '{object_name}'")

--- a/pymilvus/bulk_writer/volume_bulk_writer.py
+++ b/pymilvus/bulk_writer/volume_bulk_writer.py
@@ -11,6 +11,14 @@ from .local_bulk_writer import LocalBulkWriter
 logger = logging.getLogger(__name__)
 
 
+def _normalize_volume_remote_path(remote_path: str) -> str:
+    posix_path = remote_path.replace("\\", "/").strip("/")
+    if any(part in {".", ".."} for part in posix_path.split("/")):
+        msg = "remote_path must not contain '.' or '..' segments"
+        raise ValueError(msg)
+    return PurePosixPath(posix_path).as_posix()
+
+
 class VolumeBulkWriter(LocalBulkWriter):
     """VolumeBulkWriter handles writing local bulk files to a remote volume."""
 
@@ -27,10 +35,11 @@ class VolumeBulkWriter(LocalBulkWriter):
         connect_type: ConnectType = ConnectType.AUTO,
         **kwargs,
     ):
+        remote_base_path = _normalize_volume_remote_path(remote_path)
         local_path = Path.cwd() / "bulk_writer"
         super().__init__(schema, str(local_path), chunk_size, file_type, config, **kwargs)
 
-        remote_dir_path = PurePosixPath(remote_path.replace("\\", "/").strip("/")) / super().uuid
+        remote_dir_path = PurePosixPath(remote_base_path) / super().uuid
         self._remote_path = f"{remote_dir_path.as_posix()}/"
         self._remote_files: List[List[str]] = []
         self._volume_name = volume_name

--- a/pymilvus/bulk_writer/volume_bulk_writer.py
+++ b/pymilvus/bulk_writer/volume_bulk_writer.py
@@ -12,7 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 def _normalize_volume_remote_path(remote_path: str) -> str:
-    posix_path = remote_path.replace("\\", "/").strip("/")
+    if "\\" in remote_path:
+        msg = "remote_path must be a POSIX path and must not contain backslashes"
+        raise ValueError(msg)
+
+    posix_path = remote_path.strip("/")
     if any(part in {".", ".."} for part in posix_path.split("/")):
         msg = "remote_path must not contain '.' or '..' segments"
         raise ValueError(msg)
@@ -120,7 +124,5 @@ class VolumeBulkWriter(LocalBulkWriter):
     def _upload_object(self, file_path: str, object_name: str):
         logger.info(f"Prepare to upload '{file_path}' to '{object_name}'")
         target_volume_path = PurePosixPath(object_name).parent.as_posix()
-        if target_volume_path == ".":
-            target_volume_path = self._remote_path.rstrip("/")
         self._volume_file_manager.upload_file_to_volume(file_path, target_volume_path)
         logger.info(f"Uploaded file '{file_path}' to '{object_name}'")

--- a/tests/unit/test_bulk_writer_stage.py
+++ b/tests/unit/test_bulk_writer_stage.py
@@ -862,9 +862,9 @@ class TestVolumeBulkWriter:
         assert volume_bulk_writer._volume_name == "test_volume"
         assert isinstance(volume_bulk_writer._volume_file_manager, MagicMock)
 
-    def test_init_normalizes_windows_remote_path(self, simple_schema: CollectionSchema) -> None:
-        with patch("pymilvus.bulk_writer.volume_bulk_writer.VolumeFileManager"):
-            writer = VolumeBulkWriter(
+    def test_init_rejects_windows_remote_path(self, simple_schema: CollectionSchema) -> None:
+        with pytest.raises(ValueError, match="remote_path must be a POSIX path"):
+            VolumeBulkWriter(
                 schema=simple_schema,
                 remote_path=r"test\data",
                 cloud_endpoint="https://api.cloud.zilliz.com",
@@ -873,10 +873,6 @@ class TestVolumeBulkWriter:
                 chunk_size=1024,
                 file_type=BulkFileType.PARQUET,
             )
-
-        assert writer._remote_path.startswith("test/data/")
-        assert writer._remote_path.endswith("/")
-        assert "\\" not in writer._remote_path
 
     @pytest.mark.parametrize("remote_path", ["test/../data", "test/./data"])
     def test_init_rejects_dot_segments(
@@ -958,14 +954,6 @@ class TestVolumeBulkWriter:
         volume_bulk_writer._upload_object("local_file.parquet", object_name)
         volume_bulk_writer._volume_file_manager.upload_file_to_volume.assert_called_once_with(
             "local_file.parquet", f"{volume_bulk_writer._remote_path.rstrip('/')}/1"
-        )
-
-    def test_upload_object_uses_remote_path_for_bare_file_name(
-        self, volume_bulk_writer: VolumeBulkWriter
-    ) -> None:
-        volume_bulk_writer._upload_object("local_file.parquet", "remote_file.parquet")
-        volume_bulk_writer._volume_file_manager.upload_file_to_volume.assert_called_once_with(
-            "local_file.parquet", volume_bulk_writer._remote_path.rstrip("/")
         )
 
     def test_context_manager(self, simple_schema: CollectionSchema) -> None:

--- a/tests/unit/test_bulk_writer_stage.py
+++ b/tests/unit/test_bulk_writer_stage.py
@@ -862,9 +862,7 @@ class TestVolumeBulkWriter:
         assert volume_bulk_writer._volume_name == "test_volume"
         assert isinstance(volume_bulk_writer._volume_file_manager, MagicMock)
 
-    def test_init_normalizes_windows_remote_path(
-        self, simple_schema: CollectionSchema
-    ) -> None:
+    def test_init_normalizes_windows_remote_path(self, simple_schema: CollectionSchema) -> None:
         with patch("pymilvus.bulk_writer.volume_bulk_writer.VolumeFileManager"):
             writer = VolumeBulkWriter(
                 schema=simple_schema,
@@ -879,6 +877,21 @@ class TestVolumeBulkWriter:
         assert writer._remote_path.startswith("test/data/")
         assert writer._remote_path.endswith("/")
         assert "\\" not in writer._remote_path
+
+    @pytest.mark.parametrize("remote_path", ["test/../data", "test/./data"])
+    def test_init_rejects_dot_segments(
+        self, remote_path: str, simple_schema: CollectionSchema
+    ) -> None:
+        with pytest.raises(ValueError, match="remote_path must not contain"):
+            VolumeBulkWriter(
+                schema=simple_schema,
+                remote_path=remote_path,
+                cloud_endpoint="https://api.cloud.zilliz.com",
+                api_key="test_api_key",
+                volume_name="test_volume",
+                chunk_size=1024,
+                file_type=BulkFileType.PARQUET,
+            )
 
     def test_append_row(self, volume_bulk_writer: VolumeBulkWriter) -> None:
         volume_bulk_writer.append_row({"id": 1, "vector": [1.0] * 128, "text": "test text"})
@@ -945,6 +958,14 @@ class TestVolumeBulkWriter:
         volume_bulk_writer._upload_object("local_file.parquet", object_name)
         volume_bulk_writer._volume_file_manager.upload_file_to_volume.assert_called_once_with(
             "local_file.parquet", f"{volume_bulk_writer._remote_path.rstrip('/')}/1"
+        )
+
+    def test_upload_object_uses_remote_path_for_bare_file_name(
+        self, volume_bulk_writer: VolumeBulkWriter
+    ) -> None:
+        volume_bulk_writer._upload_object("local_file.parquet", "remote_file.parquet")
+        volume_bulk_writer._volume_file_manager.upload_file_to_volume.assert_called_once_with(
+            "local_file.parquet", volume_bulk_writer._remote_path.rstrip("/")
         )
 
     def test_context_manager(self, simple_schema: CollectionSchema) -> None:

--- a/tests/unit/test_bulk_writer_stage.py
+++ b/tests/unit/test_bulk_writer_stage.py
@@ -857,8 +857,28 @@ class TestVolumeBulkWriter:
 
     def test_init(self, volume_bulk_writer: VolumeBulkWriter) -> None:
         assert volume_bulk_writer._remote_path.endswith("/")
+        assert volume_bulk_writer._remote_path.startswith("test/data/")
+        assert "\\" not in volume_bulk_writer._remote_path
         assert volume_bulk_writer._volume_name == "test_volume"
         assert isinstance(volume_bulk_writer._volume_file_manager, MagicMock)
+
+    def test_init_normalizes_windows_remote_path(
+        self, simple_schema: CollectionSchema
+    ) -> None:
+        with patch("pymilvus.bulk_writer.volume_bulk_writer.VolumeFileManager"):
+            writer = VolumeBulkWriter(
+                schema=simple_schema,
+                remote_path=r"test\data",
+                cloud_endpoint="https://api.cloud.zilliz.com",
+                api_key="test_api_key",
+                volume_name="test_volume",
+                chunk_size=1024,
+                file_type=BulkFileType.PARQUET,
+            )
+
+        assert writer._remote_path.startswith("test/data/")
+        assert writer._remote_path.endswith("/")
+        assert "\\" not in writer._remote_path
 
     def test_append_row(self, volume_bulk_writer: VolumeBulkWriter) -> None:
         volume_bulk_writer.append_row({"id": 1, "vector": [1.0] * 128, "text": "test text"})
@@ -887,6 +907,7 @@ class TestVolumeBulkWriter:
         result = volume_bulk_writer.get_volume_upload_result()
         assert result["volume_name"] == "test_volume"
         assert "path" in result
+        assert "\\" not in result["path"]
 
     @patch("pymilvus.bulk_writer.volume_bulk_writer.Path")
     def test_local_rm(self, mock_path: Mock, volume_bulk_writer: VolumeBulkWriter) -> None:
@@ -911,15 +932,19 @@ class TestVolumeBulkWriter:
         result = volume_bulk_writer._upload(["test_file.parquet"])
         assert len(result) == 1
         mock_upload_object.assert_called_once()
+        _, kwargs = mock_upload_object.call_args
+        assert kwargs["object_name"].endswith("/test.parquet")
+        assert "\\" not in kwargs["object_name"]
         assert mock_rm.called
 
     @patch.object(VolumeFileManager, "upload_file_to_volume")
     def test_upload_object(
         self, mock_upload_to_volume: Mock, volume_bulk_writer: VolumeBulkWriter
     ) -> None:
-        volume_bulk_writer._upload_object("local_file.parquet", "remote_file.parquet")
+        object_name = f"{volume_bulk_writer._remote_path}1/local_file.parquet"
+        volume_bulk_writer._upload_object("local_file.parquet", object_name)
         volume_bulk_writer._volume_file_manager.upload_file_to_volume.assert_called_once_with(
-            "local_file.parquet", volume_bulk_writer._remote_path
+            "local_file.parquet", f"{volume_bulk_writer._remote_path.rstrip('/')}/1"
         )
 
     def test_context_manager(self, simple_schema: CollectionSchema) -> None:


### PR DESCRIPTION
Normalize `VolumeBulkWriter` remote volume paths so service-side volume paths use stable POSIX semantics and uploads land under the same path family that `batch_files` records.

## What Problem This Solves

`VolumeBulkWriter.__init__()` previously built the remote volume directory with host filesystem semantics:

```python
remote_dir_path = Path(remote_path) / super().uuid
self._remote_path = str(remote_dir_path) + "/"
```

On Windows, using `Path` for a service-side remote path can produce mixed separators in `_remote_path`. That is the wrong abstraction boundary: `remote_path` is a Milvus/Zilliz volume object prefix, not a client-local filesystem path.

There was also a second mismatch in the upload path. `VolumeBulkWriter._upload()` computes a per-file remote object path and records it in `batch_files`, but `_upload_object()` previously ignored that computed `object_name` and uploaded to `self._remote_path` as a directory instead.

That can make the writer record a path such as:

```text
test/data/<writer_uuid>/1/part.parquet
```

while the volume upload helper writes the single file under:

```text
test/data/<writer_uuid>/part.parquet
```

The mismatch matters because `batch_files` and `get_volume_upload_result()["path"]` are the import-path contract for generated bulk files.

## Change

- Treat `remote_path` as a service-side POSIX object prefix.
- Reject backslashes in `remote_path` instead of silently accepting Windows-local-style paths.
- Reject `.` and `..` path segments before storing `_remote_path`, so recorded paths and canonicalized upload targets cannot diverge.
- Build `_remote_path` with `PurePosixPath` and preserve the existing trailing slash.
- Make `_upload_object(file_path, object_name)` pass the computed object path's parent directory to `VolumeFileManager.upload_file_to_volume(...)`.
- Keep local staging, row serialization, volume credential refresh, retry handling, multipart upload, and the public `VolumeFileManager.upload_file_to_volume(...)` directory-upload contract unchanged.

## Evidence

Focused tests cover the final behavior:

```text
remote_path input: test/data
_remote_path after init: test/data/<uuid>/
```

Invalid remote prefixes are rejected before `_remote_path` is stored:

```text
remote_path input: test\data
result: ValueError("remote_path must be a POSIX path and must not contain backslashes")

remote_path input: test/../data
result: ValueError("remote_path must not contain '.' or '..' segments")

remote_path input: test/./data
result: ValueError("remote_path must not contain '.' or '..' segments")
```

The upload path now uses the computed object path's parent directory:

```text
object_name: test/data/<uuid>/1/local_file.parquet
upload_file_to_volume receives target path: test/data/<uuid>/1
```

The updated tests also assert that `get_volume_upload_result()["path"]` and `_upload()` object names do not contain Windows backslashes.

## Possible call chain / impact

```text
User creates VolumeBulkWriter(remote_path=...)
  -> VolumeBulkWriter.__init__()
    -> validate remote_path as a POSIX volume prefix
    -> reject backslashes and dot segments
    -> store POSIX-style _remote_path
  -> append_row(...)
  -> commit()
  -> LocalBulkWriter._flush()
    -> persists files under local flush subdirectories
  -> VolumeBulkWriter._upload(file_list)
    -> computes remote_file_path from local relative path
    -> _upload_object(file_path, object_name=remote_file_path)
    -> VolumeFileManager.upload_file_to_volume(file_path, target parent path)
```

Affected surface: `VolumeBulkWriter` volume upload paths.

Sibling surfaces checked:

- `RemoteBulkWriter` has its own S3/Azure object-key handling and is not changed here.
- `VolumeFileManager.upload_file_to_volume(...)` remains a directory-upload helper for existing direct callers.
- Volume REST APIs, volume management, credential refresh, retry, and progress tracking are not changed by this PR.
- `LocalBulkWriter._exit()` now safely returns if validation fails before `_working_thread` is initialized, avoiding destructor warnings for partially initialized writer instances.

## Validation

- `uv run --python 3.11 --group dev black --check pymilvus/bulk_writer/volume_bulk_writer.py pymilvus/bulk_writer/local_bulk_writer.py tests/unit/test_bulk_writer_stage.py`
- `uv run --python 3.11 --group dev ruff check pymilvus/bulk_writer/volume_bulk_writer.py pymilvus/bulk_writer/local_bulk_writer.py tests/unit/test_bulk_writer_stage.py`
- `uv run --python 3.11 --group dev pytest tests/unit/test_bulk_writer_stage.py -k VolumeBulkWriter -q`
- `git diff --check -- pymilvus/bulk_writer/volume_bulk_writer.py pymilvus/bulk_writer/local_bulk_writer.py tests/unit/test_bulk_writer_stage.py`

Remote CI is also green for lint, proto checks, Python tests on Ubuntu/Windows, DCO, and Codecov patch/project coverage.