### PR TITLE
fix: allow all specified function chain stages in search

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -1638,8 +1638,10 @@ class Prepare:
             )
 
         for chain in chains:
-            if chain.stage != FunctionChainStage.L2_RERANK:
-                raise ParamError(message="Only L2_RERANK function chains are supported for search")
+            if chain.stage == FunctionChainStage.UNSPECIFIED:
+                raise ParamError(
+                    message="UNSPECIFIED function chain stage is not supported for search"
+                )
         return [chain.to_proto() for chain in chains]
 
     @staticmethod

--- a/tests/unit/test_function_chain.py
+++ b/tests/unit/test_function_chain.py
@@ -254,10 +254,26 @@ class TestFunctionChain:
         with pytest.raises(ParamError):
             call()
 
-    def test_bad_stage_for_search(self):
-        chain = FunctionChain(FunctionChainStage.L1_RERANK)
-        with pytest.raises(ParamError, match="L2_RERANK"):
+    def test_prepare_search_rejects_unspecified_stage(self):
+        chain = FunctionChain(FunctionChainStage.UNSPECIFIED)
+        with pytest.raises(ParamError, match="UNSPECIFIED"):
             _prepare_search(function_chains=[chain])
+
+    @pytest.mark.parametrize(
+        "stage",
+        [
+            FunctionChainStage.INGESTION,
+            FunctionChainStage.PRE_PROCESS,
+            FunctionChainStage.L0_RERANK,
+            FunctionChainStage.L1_RERANK,
+            FunctionChainStage.L2_RERANK,
+            FunctionChainStage.POST_PROCESS,
+        ],
+    )
+    def test_prepare_search_allows_all_specified_function_chain_stages(self, stage):
+        chain = FunctionChain(stage)
+        request = _prepare_search(function_chains=[chain])
+        assert request.function_chains[0].stage == stage
 
 
 class TestSearchIntegration:


### PR DESCRIPTION
Relax search-side function chain validation to reject only UNSPECIFIED while forwarding all explicit stages to the server. Update unit tests to cover the new validation behavior.

issue: https://github.com/milvus-io/milvus/issues/51011