### PR TITLE
feat(milvus_client): require bound index_params in add_function_field

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1728,6 +1728,8 @@ class AsyncGrpcHandler:
         drop_field_id: Optional[int] = None,
         drop_function_name: Optional[str] = None,
         drop_function_output_fields: bool = False,
+        index_name: str = "",
+        index_extra_params: Optional[Dict] = None,
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
@@ -1739,6 +1741,8 @@ class AsyncGrpcHandler:
             drop_field_id=drop_field_id,
             drop_function_name=drop_function_name,
             drop_function_output_fields=drop_function_output_fields,
+            index_name=index_name,
+            index_extra_params=index_extra_params,
         )
         response = await self._async_stub.AlterCollectionSchema(
             request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -682,6 +682,8 @@ class GrpcHandler:
         drop_field_id: Optional[int] = None,
         drop_function_name: Optional[str] = None,
         drop_function_output_fields: bool = False,
+        index_name: str = "",
+        index_extra_params: Optional[Dict] = None,
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
@@ -693,6 +695,8 @@ class GrpcHandler:
             drop_field_id=drop_field_id,
             drop_function_name=drop_function_name,
             drop_function_output_fields=drop_function_output_fields,
+            index_name=index_name,
+            index_extra_params=index_extra_params,
         )
         response = self._stub.AlterCollectionSchema(
             request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -397,6 +397,8 @@ class Prepare:
         drop_field_id: Optional[int] = None,
         drop_function_name: Optional[str] = None,
         drop_function_output_fields: bool = False,
+        index_name: str = "",
+        index_extra_params: Optional[Dict] = None,
     ) -> milvus_types.AlterCollectionSchemaRequest:
         is_drop = any(
             identifier is not None
@@ -443,7 +445,14 @@ class Prepare:
 
                 field_info = milvus_types.AlterCollectionSchemaRequest.FieldInfo(
                     field_schema=field_schema_proto,
+                    index_name=index_name,
                 )
+                if index_extra_params:
+                    for tk, tv in index_extra_params.items():
+                        if tv is not None:
+                            field_info.extra_params.append(
+                                common_types.KeyValuePair(key=str(tk), value=utils.dumps(tv))
+                            )
                 field_infos.append(field_info)
 
             if func is not None:

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -40,7 +40,7 @@ from pymilvus.orm.types import DataType
 from .async_optimize_task import AsyncOptimizeTask
 from .base import BaseMilvusClient
 from .check import validate_param
-from .index import IndexParam, IndexParams
+from .index import IndexParam, IndexParams, extract_bound_index_param
 from .optimize_task import OptimizeResult, ProgressStage, parse_target_size
 
 
@@ -1130,6 +1130,8 @@ class AsyncMilvusClient(BaseMilvusClient):
         drop_field_id: Optional[int] = None,
         drop_function_name: Optional[str] = None,
         drop_function_output_fields: bool = False,
+        index_name: str = "",
+        index_extra_params: Optional[Dict] = None,
         **kwargs,
     ):
         """Alter collection schema supporting both Add and Drop operations.
@@ -1180,6 +1182,8 @@ class AsyncMilvusClient(BaseMilvusClient):
                 field_schema=field_schema,
                 func=func,
                 timeout=timeout,
+                index_name=index_name,
+                index_extra_params=index_extra_params,
                 context=self._generate_call_context(**kwargs),
                 **kwargs,
             )
@@ -1210,6 +1214,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         collection_name: str,
         field_schema: FieldSchema,
         func: Function,
+        index_params: IndexParams,
         timeout: Optional[float] = None,
         **kwargs,
     ):
@@ -1238,11 +1243,17 @@ class AsyncMilvusClient(BaseMilvusClient):
                 )
             )
 
+        bound_index_name, bound_index_extra_params = extract_bound_index_param(
+            field_schema.name, index_params
+        )
+
         await self._alter_collection_schema(
             collection_name=collection_name,
             field_schema=field_schema,
             func=func,
             timeout=timeout,
+            index_name=bound_index_name,
+            index_extra_params=bound_index_extra_params,
             **kwargs,
         )
 

--- a/pymilvus/milvus_client/index.py
+++ b/pymilvus/milvus_client/index.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Tuple
 
 from pymilvus.exceptions import ParamError
 
@@ -96,3 +96,40 @@ class IndexParams(list):
     def add_index(self, field_name: str, index_type: str = "", index_name: str = "", **kwargs):
         index_param = IndexParam(field_name, index_type, index_name, **kwargs)
         super().append(index_param)
+
+
+def extract_bound_index_param(
+    output_field_name: str, index_params: "IndexParams"
+) -> Tuple[str, Dict]:
+    """Validate the bound index of a function output field and extract it.
+
+    The bound index meta is mandatory for add_function_field: without it,
+    backfill compaction of the new vector output field would stall on a
+    missing index. Rejects invalid input before any RPC (the server enforces
+    the same rules) and returns ``(index_name, index_configs)``.
+    """
+    if not isinstance(index_params, IndexParams):
+        raise ParamError(
+            message=(
+                "wrong type of argument index_params, "
+                f"expected: IndexParams, got: {type(index_params).__name__}"
+            )
+        )
+    if len(index_params) != 1:
+        raise ParamError(
+            message="index_params must contain exactly one index for the function output field"
+        )
+    index_param = index_params[0]
+    if index_param.field_name not in ("", output_field_name):
+        raise ParamError(
+            message=(
+                f"index_params field_name {index_param.field_name!r} does not match "
+                f"the function output field {output_field_name!r}"
+            )
+        )
+    if not index_param.index_type:
+        raise ParamError(
+            message="an explicit index_type is required for the bound index of the function output field"
+        )
+    # Copy: get_index_configs() exposes IndexParam's internal dict.
+    return index_param.index_name, dict(index_param.get_index_configs())

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -46,7 +46,7 @@ from pymilvus.orm.types import DataType
 
 from .base import BaseMilvusClient
 from .check import validate_param
-from .index import IndexParam, IndexParams
+from .index import IndexParam, IndexParams, extract_bound_index_param
 from .optimize_task import OptimizeResult, OptimizeTask, ProgressStage, parse_target_size
 
 logger = logging.getLogger(__name__)
@@ -1405,6 +1405,8 @@ class MilvusClient(BaseMilvusClient):
         drop_field_id: Optional[int] = None,
         drop_function_name: Optional[str] = None,
         drop_function_output_fields: bool = False,
+        index_name: str = "",
+        index_extra_params: Optional[Dict] = None,
         **kwargs,
     ):
         """Alter collection schema supporting both Add and Drop operations.
@@ -1455,6 +1457,8 @@ class MilvusClient(BaseMilvusClient):
                 field_schema=field_schema,
                 func=func,
                 timeout=timeout,
+                index_name=index_name,
+                index_extra_params=index_extra_params,
                 context=self._generate_call_context(**kwargs),
                 **kwargs,
             )
@@ -1485,14 +1489,19 @@ class MilvusClient(BaseMilvusClient):
         collection_name: str,
         field_schema: FieldSchema,
         func: Function,
+        index_params: IndexParams,
         timeout: Optional[float] = None,
         **kwargs,
     ):
         """Add a function-backed field (e.g. BM25 sparse vector) to an existing collection.
 
         This is a high-level convenience wrapper that commits the schema change
-        (new output field + function definition). Create indexes separately with
-        ``create_index`` after the schema change succeeds.
+        (new output field + function definition) together with the index meta bound
+        to the new output field. The server creates the index meta atomically with
+        the schema change, so backfill compaction is never blocked on a missing
+        vector index. ``index_params`` must contain exactly one entry with an
+        explicit ``index_type`` for the output field; the server rejects vector
+        output fields without bound index params.
 
         Args:
             collection_name(``str``): Name of the collection to modify.
@@ -1501,6 +1510,9 @@ class MilvusClient(BaseMilvusClient):
                 a ``BINARY_VECTOR`` field for MinHash).
             func(``Function``): Function definition that generates the output field
                 (e.g. a ``FunctionType.BM25`` or ``FunctionType.MINHASH`` function).
+            index_params(``IndexParams``): Index definition bound to the new output
+                field, exactly one entry with an explicit ``index_type``
+                (e.g. ``SPARSE_INVERTED_INDEX``/``BM25`` or ``MINHASH_LSH``/``MHJACCARD``).
             timeout(``float``, optional): Timeout in seconds for the schema-change RPC.
             **kwargs: Additional keyword arguments forwarded to the underlying calls.
 
@@ -1532,11 +1544,17 @@ class MilvusClient(BaseMilvusClient):
                 )
             )
 
+        bound_index_name, bound_index_extra_params = extract_bound_index_param(
+            field_schema.name, index_params
+        )
+
         self._alter_collection_schema(
             collection_name=collection_name,
             field_schema=field_schema,
             func=func,
             timeout=timeout,
+            index_name=bound_index_name,
+            index_extra_params=bound_index_extra_params,
             **kwargs,
         )
 

--- a/tests/unit/prepare/test_collection.py
+++ b/tests/unit/prepare/test_collection.py
@@ -506,6 +506,32 @@ class TestAlterCollectionSchemaRequest:
         with pytest.raises(ParamError, match="Must specify"):
             Prepare.alter_collection_schema_request(collection_name="coll")
 
+    def test_add_with_bound_index_params(self):
+        field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
+        func = Function(
+            name="bm25",
+            function_type=FunctionType.BM25,
+            input_field_names=["text"],
+            output_field_names=["sparse"],
+        )
+        req = Prepare.alter_collection_schema_request(
+            collection_name="coll",
+            field_schema=field,
+            func=func,
+            index_name="sparse_idx",
+            index_extra_params={
+                "index_type": "SPARSE_INVERTED_INDEX",
+                "metric_type": "BM25",
+                "params": {"bm25_k1": 1.2},
+            },
+        )
+        field_info = req.action.add_request.field_infos[0]
+        assert field_info.index_name == "sparse_idx"
+        extra = {kv.key: kv.value for kv in field_info.extra_params}
+        assert extra["index_type"] == "SPARSE_INVERTED_INDEX"
+        assert extra["metric_type"] == "BM25"
+        assert extra["params"] == '{"bm25_k1":1.2}'
+
     @pytest.mark.parametrize(
         "kwargs",
         [

--- a/tests/unit/test_async_milvus_client.py
+++ b/tests/unit/test_async_milvus_client.py
@@ -1534,10 +1534,14 @@ class TestAsyncAlterCollectionSchema:
     async def test_add_function_field_delegates(self, client_and_handler, field, func):
         client, mock_handler = client_and_handler
         mock_handler.alter_collection_schema = AsyncMock()
+        index_params = AsyncMilvusClient.prepare_index_params()
+        index_params.add_index(field_name=field.name, index_type="SPARSE_INVERTED_INDEX")
 
-        await client.add_function_field("col", field, func)
+        await client.add_function_field("col", field, func, index_params=index_params)
 
         mock_handler.alter_collection_schema.assert_called_once()
+        call_kwargs = mock_handler.alter_collection_schema.call_args.kwargs
+        assert call_kwargs["index_extra_params"]["index_type"] == "SPARSE_INVERTED_INDEX"
 
     @pytest.mark.asyncio
     async def test_add_function_field_rejects_unsupported_function_type(self, client_and_handler):
@@ -1546,10 +1550,12 @@ class TestAsyncAlterCollectionSchema:
         field = FieldSchema("sparse", DataType.SPARSE_FLOAT_VECTOR)
         func = Function("embed", FunctionType.TEXTEMBEDDING, ["text"], ["sparse"])
 
+        index_params = AsyncMilvusClient.prepare_index_params()
+        index_params.add_index(field_name="sparse", index_type="SPARSE_INVERTED_INDEX")
         with pytest.raises(
             ParamError, match=r"only supports FunctionType\.BM25.*FunctionType\.MINHASH"
         ):
-            await client.add_function_field("col", field, func)
+            await client.add_function_field("col", field, func, index_params=index_params)
         mock_handler.alter_collection_schema.assert_not_called()
 
     @pytest.mark.asyncio
@@ -1573,9 +1579,11 @@ class TestAsyncAlterCollectionSchema:
     ):
         client, mock_handler = client_and_handler
         mock_handler.alter_collection_schema = AsyncMock()
+        index_params = AsyncMilvusClient.prepare_index_params()
+        index_params.add_index(field_name="", index_type="SPARSE_INVERTED_INDEX")
 
         with pytest.raises(ParamError, match=expected):
-            await client.add_function_field("col", field, func)
+            await client.add_function_field("col", field, func, index_params=index_params)
         mock_handler.alter_collection_schema.assert_not_called()
 
 

--- a/tests/unit/test_index_params.py
+++ b/tests/unit/test_index_params.py
@@ -1,0 +1,59 @@
+import pytest
+from pymilvus.exceptions import ParamError
+from pymilvus.milvus_client.index import IndexParams, extract_bound_index_param
+
+
+class TestExtractBoundIndexParam:
+    """Tests for the shared bound-index validation used by add_function_field."""
+
+    def _valid_params(self, field_name: str = "sparse") -> IndexParams:
+        index_params = IndexParams()
+        index_params.add_index(
+            field_name=field_name,
+            index_type="SPARSE_INVERTED_INDEX",
+            index_name="sparse_idx",
+            metric_type="BM25",
+        )
+        return index_params
+
+    def test_happy_path(self):
+        index_name, configs = extract_bound_index_param("sparse", self._valid_params())
+        assert index_name == "sparse_idx"
+        assert configs["index_type"] == "SPARSE_INVERTED_INDEX"
+        assert configs["metric_type"] == "BM25"
+
+    def test_empty_field_name_matches_output_field(self):
+        index_name, configs = extract_bound_index_param("sparse", self._valid_params(field_name=""))
+        assert index_name == "sparse_idx"
+        assert configs["index_type"] == "SPARSE_INVERTED_INDEX"
+
+    def test_returns_copy_of_index_configs(self):
+        index_params = self._valid_params()
+        _, configs = extract_bound_index_param("sparse", index_params)
+        configs["metric_type"] = "IP"
+        _, configs_again = extract_bound_index_param("sparse", index_params)
+        assert configs_again["metric_type"] == "BM25"
+
+    def test_wrong_type_rejected(self):
+        with pytest.raises(ParamError, match="wrong type of argument index_params"):
+            extract_bound_index_param("sparse", {"index_type": "SPARSE_INVERTED_INDEX"})
+
+    def test_empty_index_params_rejected(self):
+        with pytest.raises(ParamError, match="exactly one index"):
+            extract_bound_index_param("sparse", IndexParams())
+
+    def test_multiple_entries_rejected(self):
+        index_params = self._valid_params()
+        index_params.add_index(field_name="sparse", index_type="SPARSE_WAND")
+        with pytest.raises(ParamError, match="exactly one index"):
+            extract_bound_index_param("sparse", index_params)
+
+    def test_field_name_mismatch_rejected(self):
+        with pytest.raises(ParamError, match="does not match"):
+            extract_bound_index_param("other_field", self._valid_params())
+
+    def test_missing_index_type_rejected(self):
+        index_params = IndexParams()
+        index_params.add_index(field_name="sparse", metric_type="BM25")
+        with pytest.raises(ParamError, match="explicit index_type is required"):
+            extract_bound_index_param("sparse", index_params)

--- a/tests/unit/test_milvus_client.py
+++ b/tests/unit/test_milvus_client.py
@@ -1759,10 +1759,14 @@ class TestMilvusClientCollectionMgmt:
     )
     def test_add_function_field_delegates(self, field, func):
         handler = _make_handler()
+        index_params = MilvusClient.prepare_index_params()
+        index_params.add_index(field_name=field.name, index_type="SPARSE_INVERTED_INDEX")
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()
-            client.add_function_field("col", field, func)
+            client.add_function_field("col", field, func, index_params=index_params)
             handler.alter_collection_schema.assert_called_once()
+            call_kwargs = handler.alter_collection_schema.call_args.kwargs
+            assert call_kwargs["index_extra_params"]["index_type"] == "SPARSE_INVERTED_INDEX"
 
     def test_add_function_field_rejects_unsupported_function_type(self):
         handler = _make_handler()
@@ -1775,10 +1779,12 @@ class TestMilvusClientCollectionMgmt:
                 input_field_names=["text"],
                 output_field_names=["sparse"],
             )
+            index_params = MilvusClient.prepare_index_params()
+            index_params.add_index(field_name="sparse", index_type="SPARSE_INVERTED_INDEX")
             with pytest.raises(
                 ParamError, match=r"only supports FunctionType\.BM25.*FunctionType\.MINHASH"
             ):
-                client.add_function_field("col", field, func)
+                client.add_function_field("col", field, func, index_params=index_params)
             handler.alter_collection_schema.assert_not_called()
 
     @pytest.mark.parametrize(
@@ -1808,10 +1814,12 @@ class TestMilvusClientCollectionMgmt:
     )
     def test_add_function_field_rejects_invalid_output(self, field, func, expected):
         handler = _make_handler()
+        index_params = MilvusClient.prepare_index_params()
+        index_params.add_index(field_name="", index_type="SPARSE_INVERTED_INDEX")
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()
             with pytest.raises(ParamError, match=expected):
-                client.add_function_field("col", field, func)
+                client.add_function_field("col", field, func, index_params=index_params)
             handler.alter_collection_schema.assert_not_called()
 
 


### PR DESCRIPTION
issue: milvus-io/milvus#51104

## Summary
- `MilvusClient.add_function_field` / `AsyncMilvusClient.add_function_field` now take a **mandatory** `index_params` (an `IndexParams` with exactly one entry and an explicit `index_type` for the function output field); missing/empty/AUTOINDEX-only params are rejected client-side.
- The bound index definition is serialized into the existing (previously unused) `AlterCollectionSchemaRequest.FieldInfo.index_name` / `extra_params` fields — **no milvus-proto change needed** — so the server can create the index meta atomically with the schema change and schema-bump/backfill compaction is never blocked by a missing vector index.
- Threaded through `_alter_collection_schema` → grpc handlers (sync + async) → `Prepare.alter_collection_schema_request`, using the same KV encoding as `create_index`.

## Merge order
This PR must merge **before** the server-side PR in milvus-io/milvus (linked from the issue); the server keeps rejecting index-less requests either way, so ordering only affects e2e suite runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)