### PR TITLE
fix: allow partial update for struct array fields

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -818,6 +818,34 @@ class Prepare:
         return field_name
 
     @staticmethod
+    def _match_struct_sub_field_name(
+        field_name: str, struct_sub_field_info: Dict[str, Dict[str, Dict]]
+    ) -> Optional[str]:
+        """Return the parent struct when field_name uses known struct[sub-field] storage form."""
+        m = _STRUCT_FIELD_RE.match(field_name)
+        if m:
+            struct_name, sub_field_name = m.groups()
+            if sub_field_name in struct_sub_field_info.get(struct_name, {}):
+                return struct_name
+        return None
+
+    @staticmethod
+    def _raise_struct_sub_field_update_error(
+        field_name: str, struct_name: str, partial_update: bool
+    ) -> None:
+        if partial_update:
+            msg = (
+                f"Partial struct update is unsupported for struct sub-field `{field_name}`; "
+                f"update the whole struct field `{struct_name}` instead"
+            )
+        else:
+            msg = (
+                f"Struct sub-field `{field_name}` cannot be used as a top-level field; "
+                f"write the whole struct field `{struct_name}` instead"
+            )
+        raise DataNotMatchException(message=msg)
+
+    @staticmethod
     def _setup_struct_data_structures(struct_fields_info: Optional[List[Dict]]):
         """Setup common data structures for struct field processing.
 
@@ -1103,6 +1131,12 @@ class Prepare:
                         if k in function_output_field_names:
                             raise DataNotMatchException(
                                 message=ExceptionsMessage.InsertUnexpectedFunctionOutputField % k
+                            )
+
+                        struct_name = Prepare._match_struct_sub_field_name(k, struct_sub_field_info)
+                        if struct_name is not None:
+                            Prepare._raise_struct_sub_field_update_error(
+                                k, struct_name, partial_update
                             )
 
                         if not enable_dynamic:

--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -842,12 +842,25 @@ class Prepare:
             for struct_field_info in struct_fields_info:
                 struct_name = struct_field_info["name"]
                 normalized_struct = dict(struct_field_info)
+                normalized_struct["type"] = normalized_struct.get("type", DataType._ARRAY_OF_STRUCT)
                 normalized_fields = []
                 for field in struct_field_info["fields"]:
                     normalized_field = dict(field)
                     normalized_field["name"] = Prepare._strip_struct_sub_field_name(
                         struct_name, field["name"]
                     )
+                    field_type = normalized_field["type"]
+                    if field_type not in {DataType.ARRAY, DataType._ARRAY_OF_VECTOR}:
+                        normalized_field["element_type"] = field_type
+                        normalized_field["type"] = (
+                            DataType._ARRAY_OF_VECTOR
+                            if isVectorDataType(field_type)
+                            else DataType.ARRAY
+                        )
+                    params = dict(normalized_field.get("params", {}) or {})
+                    if "max_capacity" not in params and "max_capacity" in normalized_struct:
+                        params["max_capacity"] = normalized_struct["max_capacity"]
+                    normalized_field["params"] = params
                     normalized_fields.append(normalized_field)
                 normalized_struct["fields"] = normalized_fields
                 normalized_struct_fields_info.append(normalized_struct)
@@ -1047,10 +1060,6 @@ class Prepare:
         entities: List,
         partial_update: bool = False,
     ):
-        # For partial update, struct fields are not supported
-        if partial_update and struct_fields_info:
-            raise ParamError(message="Struct fields are not supported in partial update")
-
         input_fields_info = [
             field for field in fields_info if Prepare._is_input_field(field, is_upsert=True)
         ]
@@ -1066,21 +1075,15 @@ class Prepare:
         # key: field_data object id, value: list of bytes
         vector_bytes_cache: Dict[int, List[bytes]] = {}
 
-        # Use common struct data setup (only if not partial update)
-        if partial_update:
-            struct_fields_data = {}
-            struct_info_map = {}
-            struct_sub_fields_data = {}
-            struct_sub_field_info = {}
-            input_struct_field_info = []
-        else:
-            (
-                struct_fields_data,
-                struct_info_map,
-                struct_sub_fields_data,
-                struct_sub_field_info,
-                input_struct_field_info,
-            ) = Prepare._setup_struct_data_structures(struct_fields_info)
+        (
+            struct_fields_data,
+            struct_info_map,
+            struct_sub_fields_data,
+            struct_sub_field_info,
+            input_struct_field_info,
+        ) = Prepare._setup_struct_data_structures(struct_fields_info)
+        for struct in input_struct_field_info:
+            field_len[struct["name"]] = 0
 
         if enable_dynamic:
             d_field = schema_types.FieldData(
@@ -1131,6 +1134,7 @@ class Prepare:
                             raise DataNotMatchException(
                                 message=f"{ExceptionsMessage.FieldDataInconsistent % (k, 'struct array', type(v))} Detail: {e!s}"
                             ) from e
+                        field_len[k] += 1
                 for field in input_fields_info:
                     key = field["name"]
                     if key in entity:
@@ -1194,10 +1198,21 @@ class Prepare:
 
         request.fields_data.extend(fields_data.values())
 
-        if struct_fields_data:
+        if partial_update:
+            struct_field_names = [
+                struct["name"]
+                for struct in input_struct_field_info
+                if field_len[struct["name"]] > 0
+            ]
+        else:
+            struct_field_names = [struct["name"] for struct in input_struct_field_info]
+
+        if struct_field_names:
             # reconstruct the struct array fields data (same as in insert)
             for struct in input_struct_field_info:
                 struct_name = struct["name"]
+                if struct_name not in struct_field_names:
+                    continue
                 struct_field_data = struct_fields_data[struct_name]
                 for field_info in struct["fields"]:
                     # Use two-level map to get the correct sub-field data
@@ -1205,7 +1220,9 @@ class Prepare:
                     struct_field_data.struct_arrays.fields.append(
                         struct_sub_fields_data[struct_name][field_name]
                     )
-            request.fields_data.extend(struct_fields_data.values())
+            request.fields_data.extend(
+                struct_fields_data[struct_name] for struct_name in struct_field_names
+            )
 
         for field in input_fields_info:
             is_dynamic = False

--- a/tests/unit/prepare/test_data.py
+++ b/tests/unit/prepare/test_data.py
@@ -502,7 +502,31 @@ class TestRowUpsertParam:
         assert score_data.field_name == "score"
         assert list(score_data.scalars.array_data.data[0].float_data.data) == [1.0, 2.0]
 
-    def test_upsert_partial_update_rejects_struct_storage_sub_field_with_dynamic(self):
+    @pytest.mark.parametrize(
+        "partial_update,row,error_match",
+        [
+            pytest.param(
+                False,
+                {
+                    "pk": 1,
+                    "vector": [1.0, 2.0, 3.0, 4.0],
+                    "metadata": [{"score": 1.0}],
+                    "metadata[score]": [1.0],
+                },
+                "cannot be used as a top-level field",
+                id="full_upsert",
+            ),
+            pytest.param(
+                True,
+                {"pk": 1, "metadata[score]": [1.0, 2.0]},
+                "Partial struct update is unsupported",
+                id="partial_update",
+            ),
+        ],
+    )
+    def test_upsert_rejects_struct_storage_sub_field_with_dynamic(
+        self, partial_update, row, error_match
+    ):
         """Struct sub-field syntax must not fall back to the dynamic field."""
         struct_field = StructFieldSchema()
         struct_field.name = "metadata"
@@ -518,15 +542,15 @@ class TestRowUpsertParam:
         )
         schema.add_struct_field(struct_field)
 
-        with pytest.raises(DataNotMatchException, match="Partial struct update is unsupported"):
+        with pytest.raises(DataNotMatchException, match=error_match):
             Prepare.row_upsert_param(
                 "test_coll",
-                [{"pk": 1, "metadata[score]": [1.0, 2.0]}],
+                [row],
                 "",
                 fields_info=make_fields_info(schema),
                 struct_fields_info=make_struct_fields_info(schema),
                 enable_dynamic=True,
-                partial_update=True,
+                partial_update=partial_update,
             )
 
     @pytest.mark.parametrize(

--- a/tests/unit/prepare/test_data.py
+++ b/tests/unit/prepare/test_data.py
@@ -1,8 +1,11 @@
 """Tests for data operation Prepare methods (insert, upsert, delete)."""
 
+import json
+
 import numpy as np
 import pytest
 from pymilvus import CollectionSchema, DataType, FieldSchema
+from pymilvus.client.constants import DYNAMIC_FIELD_NAME
 from pymilvus.client.prepare import Prepare
 from pymilvus.exceptions import DataNotMatchException, ParamError
 from pymilvus.orm.schema import StructFieldSchema
@@ -498,6 +501,84 @@ class TestRowUpsertParam:
         score_data = metadata.struct_arrays.fields[0]
         assert score_data.field_name == "score"
         assert list(score_data.scalars.array_data.data[0].float_data.data) == [1.0, 2.0]
+
+    def test_upsert_partial_update_rejects_struct_storage_sub_field_with_dynamic(self):
+        """Struct sub-field syntax must not fall back to the dynamic field."""
+        struct_field = StructFieldSchema()
+        struct_field.name = "metadata"
+        struct_field.add_field("score", DataType.FLOAT)
+        struct_field.max_capacity = 10
+
+        schema = CollectionSchema(
+            [
+                FieldSchema("pk", DataType.INT64, is_primary=True),
+                FieldSchema("vector", DataType.FLOAT_VECTOR, dim=4),
+            ],
+            enable_dynamic_field=True,
+        )
+        schema.add_struct_field(struct_field)
+
+        with pytest.raises(DataNotMatchException, match="Partial struct update is unsupported"):
+            Prepare.row_upsert_param(
+                "test_coll",
+                [{"pk": 1, "metadata[score]": [1.0, 2.0]}],
+                "",
+                fields_info=make_fields_info(schema),
+                struct_fields_info=make_struct_fields_info(schema),
+                enable_dynamic=True,
+                partial_update=True,
+            )
+
+    @pytest.mark.parametrize(
+        "partial_update,row",
+        [
+            pytest.param(
+                False,
+                {
+                    "pk": 1,
+                    "vector": [1.0, 2.0, 3.0, 4.0],
+                    "metadata": [{"score": 1.0}],
+                    "score": "dynamic-value",
+                },
+                id="full_upsert",
+            ),
+            pytest.param(
+                True,
+                {"pk": 1, "score": "dynamic-value"},
+                id="partial_update",
+            ),
+        ],
+    )
+    def test_upsert_dynamic_field_can_share_struct_sub_field_short_name(self, partial_update, row):
+        """A top-level short name remains dynamic when dynamic fields are enabled."""
+        struct_field = StructFieldSchema()
+        struct_field.name = "metadata"
+        struct_field.add_field("score", DataType.FLOAT)
+        struct_field.max_capacity = 10
+
+        schema = CollectionSchema(
+            [
+                FieldSchema("pk", DataType.INT64, is_primary=True),
+                FieldSchema("vector", DataType.FLOAT_VECTOR, dim=4),
+            ],
+            enable_dynamic_field=True,
+        )
+        schema.add_struct_field(struct_field)
+
+        req = Prepare.row_upsert_param(
+            "test_coll",
+            [row],
+            "",
+            fields_info=make_fields_info(schema),
+            struct_fields_info=make_struct_fields_info(schema),
+            enable_dynamic=True,
+            partial_update=partial_update,
+        )
+
+        dynamic_data = next(
+            field for field in req.fields_data if field.field_name == DYNAMIC_FIELD_NAME
+        )
+        assert json.loads(dynamic_data.scalars.json_data.data[0]) == {"score": "dynamic-value"}
 
     def test_upsert_partial_update_struct_array_field_len_inconsistent(self):
         """Test partial update rejects rows with inconsistent struct array field presence."""

--- a/tests/unit/prepare/test_data.py
+++ b/tests/unit/prepare/test_data.py
@@ -436,8 +436,8 @@ class TestRowUpsertParam:
                 struct_fields_info=struct_fields_info,
             )
 
-    def test_upsert_partial_update_struct_not_supported(self):
-        """Test partial update with struct fields raises error."""
+    def test_upsert_partial_update_with_struct_schema_omits_struct_field(self):
+        """Test partial update works when schema has struct fields but payload omits them."""
         struct_field = StructFieldSchema()
         struct_field.name = "metadata"
         struct_field.add_field("score", DataType.FLOAT)
@@ -452,7 +452,70 @@ class TestRowUpsertParam:
         schema.add_struct_field(struct_field)
 
         rows = [{"pk": 1, "vector": [1.0, 2.0, 3.0, 4.0]}]
-        with pytest.raises(ParamError, match="Struct fields are not supported"):
+        req = Prepare.row_upsert_param(
+            "test_coll",
+            rows,
+            "",
+            fields_info=make_fields_info(schema),
+            struct_fields_info=make_struct_fields_info(schema),
+            partial_update=True,
+        )
+
+        assert req.partial_update is True
+        assert req.num_rows == 1
+        assert [field.field_name for field in req.fields_data] == ["pk", "vector"]
+
+    def test_upsert_partial_update_struct_array_field(self):
+        """Test partial update supports whole struct array fields."""
+        struct_field = StructFieldSchema()
+        struct_field.name = "metadata"
+        struct_field.add_field("score", DataType.FLOAT)
+        struct_field.max_capacity = 10
+
+        schema = CollectionSchema(
+            [
+                FieldSchema("pk", DataType.INT64, is_primary=True),
+                FieldSchema("vector", DataType.FLOAT_VECTOR, dim=4),
+            ]
+        )
+        schema.add_struct_field(struct_field)
+
+        rows = [{"pk": 1, "metadata": [{"score": 1.0}, {"score": 2.0}]}]
+        req = Prepare.row_upsert_param(
+            "test_coll",
+            rows,
+            "",
+            fields_info=make_fields_info(schema),
+            struct_fields_info=make_struct_fields_info(schema),
+            partial_update=True,
+        )
+
+        assert req.partial_update is True
+        assert req.num_rows == 1
+        assert [field.field_name for field in req.fields_data] == ["pk", "metadata"]
+        metadata = req.fields_data[1]
+        assert metadata.type == DataType._ARRAY_OF_STRUCT
+        score_data = metadata.struct_arrays.fields[0]
+        assert score_data.field_name == "score"
+        assert list(score_data.scalars.array_data.data[0].float_data.data) == [1.0, 2.0]
+
+    def test_upsert_partial_update_struct_array_field_len_inconsistent(self):
+        """Test partial update rejects rows with inconsistent struct array field presence."""
+        struct_field = StructFieldSchema()
+        struct_field.name = "metadata"
+        struct_field.add_field("score", DataType.FLOAT)
+        struct_field.max_capacity = 10
+
+        schema = CollectionSchema(
+            [
+                FieldSchema("pk", DataType.INT64, is_primary=True),
+                FieldSchema("vector", DataType.FLOAT_VECTOR, dim=4),
+            ]
+        )
+        schema.add_struct_field(struct_field)
+
+        rows = [{"pk": 1, "metadata": [{"score": 1.0}]}, {"pk": 2}]
+        with pytest.raises(DataNotMatchException, match="inconsistent"):
             Prepare.row_upsert_param(
                 "test_coll",
                 rows,


### PR DESCRIPTION
## What changed
- Remove the client-side block that rejected partial update when the schema contains struct fields.
- Normalize struct array schema metadata so partial update can pack whole struct array fields.
- Keep partial update payloads scoped to the fields actually provided by the user.
- Add unit coverage for omitting struct fields, updating a whole struct array field, and inconsistent struct array field presence.

## Verification
- /Users/jeremy.zhu/workspace/pymilvus.fix-struct-array-partial-update/.venv/bin/python -m pytest tests/unit/prepare/test_data.py -q
- ruff check pymilvus/client/prepare.py tests/unit/prepare/test_data.py
- ruff format --check pymilvus/client/prepare.py tests/unit/prepare/test_data.py
- git diff --check

Related Milvus PR: https://github.com/milvus-io/milvus/pull/51010