### PR TITLE
fix: allow null auto_id primary column in DataFrame insert

### DIFF
--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -1328,7 +1328,7 @@ def check_insert_schema(schema: CollectionSchema, data: Union[List[List], pd.Dat
             msg = f"Expect no data for auto_id primary field: {schema.primary_field.name}"
             raise DataNotMatchException(message=msg)
         columns = list(data.columns)
-        columns.remove(schema.primary_field)
+        columns.remove(schema.primary_field.name)
         data = data[columns]
 
     tmp_fields = list(

--- a/tests/unit/orm/test_schema.py
+++ b/tests/unit/orm/test_schema.py
@@ -1756,6 +1756,18 @@ class TestCheckInsertSchema:
         with pytest.raises(DataNotMatchException, match="auto_id"):
             check_insert_schema(schema, insert_data)
 
+    def test_check_insert_schema_auto_id_with_null_pk_column(self):
+        """Test auto_id DataFrame inserts tolerate an all-null pk column."""
+        schema = CollectionSchema(
+            [
+                FieldSchema("id", DataType.INT64, is_primary=True, auto_id=True),
+                FieldSchema("vec", DataType.FLOAT_VECTOR, dim=2),
+            ]
+        )
+        insert_data = pd.DataFrame({"id": [None, None], "vec": [[1.0, 2.0], [3.0, 4.0]]})
+
+        check_insert_schema(schema, insert_data)
+
 
 class TestCheckUpsertSchema:
     """Tests for check_upsert_schema function."""


### PR DESCRIPTION
﻿This PR fixes a DataFrame insert validation crash when an auto_id primary key column is present but contains only null values.

## What Problem This Solves

`check_insert_schema()` already treats an all-null auto_id primary key column as "no primary key values were provided" and tries to remove that column before validating the remaining DataFrame fields.

The current code builds a list of DataFrame column labels, but then attempts to remove the `FieldSchema` object itself:

```python
columns = list(data.columns)
columns.remove(schema.primary_field)
```

Since `data.columns` contains column names, not `FieldSchema` objects, this raises:

```text
ValueError: list.remove(x): x not in list
```

A minimal trigger is an auto_id schema with a DataFrame that keeps the primary key column but leaves it entirely null:

```python
pd.DataFrame({
    "id": [None, None],
    "vec": [[1.0, 2.0], [3.0, 4.0]],
})
```

## Change

Remove the primary key column by its field name instead of by the `FieldSchema` object:

```python
columns.remove(schema.primary_field.name)
```

This keeps the existing behavior unchanged for non-null auto_id primary key values: if users explicitly provide primary key data, `check_insert_schema()` still raises `DataNotMatchException`.

## Evidence

Before this fix, `check_insert_schema()` crashes before it can validate the remaining DataFrame fields:

```text
ValueError: list.remove(x): x not in list
```

After this fix:

- DataFrame inserts with an all-null auto_id primary key column pass schema validation.
- DataFrame inserts with non-null auto_id primary key values are still rejected with `DataNotMatchException`.

## Possible call chain / impact

```text
Collection.insert(pd.DataFrame)
  -> check_insert_schema(...)
    -> auto_id primary field exists in DataFrame
    -> all primary key values are null
    -> remove auto_id primary column before validating remaining fields
```

This PR only changes the column removal path for all-null auto_id primary key columns in DataFrame insert validation. It does not change list-based inserts, row-based inserts, upsert validation, or the existing rejection of non-null auto_id primary key values.

## Testing

- `uv run --python 3.11 --group dev pytest tests/unit/orm/test_schema.py::TestCheckInsertSchema -q`
- `uv run --python 3.11 --group dev pytest tests/unit/orm/test_prepare.py -k auto_id -q`
- `uv run --python 3.11 --group dev black --check pymilvus/orm/schema.py tests/unit/orm/test_schema.py`
- `uv run --python 3.11 --group dev ruff check pymilvus/orm/schema.py tests/unit/orm/test_schema.py`
- `git diff --check -- pymilvus/orm/schema.py tests/unit/orm/test_schema.py`
