### PR TITLE
fix: unpack async schema result in optimize

### DIFF
--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -2176,7 +2176,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         self, collection_name: str, timeout: Optional[float] = None, **kwargs
     ) -> List[str]:
         conn = await self._get_connection()
-        schema_dict = await conn._get_schema(
+        schema_dict, _ = await conn._get_schema(
             collection_name,
             timeout=timeout,
             context=self._generate_call_context(**kwargs),

--- a/tests/unit/test_async_milvus_client_ops.py
+++ b/tests/unit/test_async_milvus_client_ops.py
@@ -502,7 +502,7 @@ class TestAsyncClientOptimize:
         handler.get_compaction_state.return_value = state
         handler.get_load_state.return_value = LoadState.NotLoad
         schema = {"fields": [{"name": "id", "type": DataType.INT64}]}
-        handler._get_schema.return_value = schema
+        handler._get_schema.return_value = (schema, 0)
         handler.list_indexes.return_value = []
         task = MagicMock()
         task.check_cancelled = MagicMock()
@@ -521,7 +521,7 @@ class TestAsyncClientOptimize:
         handler.get_compaction_state.return_value = state
         handler.get_load_state.return_value = LoadState.NotLoad
         schema = {"fields": [{"name": "id", "type": DataType.INT64}]}
-        handler._get_schema.return_value = schema
+        handler._get_schema.return_value = (schema, 0)
         handler.list_indexes.return_value = []
         result = await client.optimize("col", wait=True)
         assert isinstance(result, OptimizeResult)


### PR DESCRIPTION
## What changed

- Unpack the `(schema_dict, schema_timestamp)` tuple returned by `AsyncGrpcHandler._get_schema()` before discovering vector indexes in `AsyncMilvusClient.optimize()`.
- Update the async optimize unit tests to mock the real handler return contract.

## Why

`AsyncMilvusClient._list_vector_indexes()` treated the complete `_get_schema()` result as a dictionary. Because the async handler returns a tuple, every optimize call failed with `AttributeError: 'tuple' object has no attribute 'get'` before compaction could be submitted.

The synchronous client and other async call sites already unpack this result correctly.

## User impact

`AsyncMilvusClient.optimize()` can now discover vector indexes and complete the compaction, index rebuild, and load refresh workflow.

## Validation

- `pytest -q tests/unit/test_async_milvus_client_ops.py` — 80 passed
- `pytest -q tests/unit/test_optimize_task.py` — 40 passed
- Async handler schema contract tests — 2 passed
- Synchronous vector-index comparison tests — 2 passed
- Ruff check and format check passed
- Live validation against `master-20260714-1acbe20`: inserted and flushed three batches (1,500 rows total), then completed `AsyncMilvusClient.optimize(target_size="1GB")` with compaction ID `467664907943663510`; server state reached `Completed`.

Fixes #3680
