### PR TITLE
fix: remove load_dotenv() call from settings.py

### DIFF
--- a/pymilvus/settings.py
+++ b/pymilvus/settings.py
@@ -1,10 +1,6 @@
 import logging.config
 import os
 
-from dotenv import load_dotenv
-
-load_dotenv()
-
 
 class Config:
     # legacy env MILVUS_DEFAULT_CONNECTION, not recommended

--- a/tests/unit/test_settings_dotenv.py
+++ b/tests/unit/test_settings_dotenv.py
@@ -1,0 +1,43 @@
+"""Test that importing pymilvus does not call load_dotenv() (#3666).
+
+Libraries should not call load_dotenv() at import time because it injects
+all .env keys into os.environ for the entire process, breaking test isolation.
+"""
+
+import importlib
+import os
+from pathlib import Path
+
+import pymilvus.settings as settings_module
+
+
+def test_settings_does_not_call_load_dotenv():
+    """Verify that pymilvus.settings no longer imports or calls load_dotenv."""
+    source_file = Path(settings_module.__file__)
+    source = source_file.read_text()
+    assert "load_dotenv" not in source, (
+        "pymilvus.settings should not call load_dotenv() — "
+        "libraries must not load .env files at import time (see #3666)"
+    )
+    assert "from dotenv" not in source, (
+        "pymilvus.settings should not import from dotenv (see #3666)"
+    )
+
+
+def test_importing_pymilvus_does_not_load_env_file(tmp_path, monkeypatch):
+    """Verify that importing pymilvus with a .env file present does not
+    pollute os.environ."""
+    env_file = tmp_path / ".env"
+    test_key = "PYMILVUS_TEST_DOTENV_SHOULD_NOT_LOAD"
+    test_value = "this_should_not_be_in_os_environ"
+    env_file.write_text(f"{test_key}={test_value}\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(test_key, raising=False)
+
+    importlib.reload(settings_module)
+
+    assert test_key not in os.environ, (
+        f"Importing pymilvus should not load .env files into os.environ — "
+        f"{test_key} was set by load_dotenv() (see #3666)"
+    )


### PR DESCRIPTION
## Summary

`pymilvus/settings.py` unconditionally called `load_dotenv()` at import time, injecting all `.env` keys into `os.environ` for the entire process. This breaks test isolation for any project that uses pymilvus alongside a `.env` file containing non-Milvus variables.

`load_dotenv()` is meant to be called by the **application entry point**, not by libraries — python-dotenv's own docs acknowledge this and added `PYTHON_DOTENV_DISABLED=1` specifically for cases where "you can't modify third-party package calls".

## Changes

- Removed `from dotenv import load_dotenv` and `load_dotenv()` from `pymilvus/settings.py`
- Added unit tests verifying that importing pymilvus does not load `.env` files into `os.environ`

## Behavior change

Users who relied on pymilvus auto-loading their `.env` file should add `load_dotenv()` to their own application entry point before importing pymilvus:

```python
from dotenv import load_dotenv
load_dotenv()  # application-level, not library-level

from pymilvus import MilvusClient
```

`python-dotenv` remains a dependency for backward compatibility — it's just no longer called automatically.

## Testing

```
pytest tests/unit/test_settings_dotenv.py -v
```

Both tests pass:
1. `test_settings_does_not_call_load_dotenv` — verifies source code no longer imports or calls `load_dotenv`
2. `test_importing_pymilvus_does_not_load_env_file` — verifies importing pymilvus with a `.env` file present does not pollute `os.environ`

Closes #3666