### PR TITLE
fix(settings): only load MILVUS_ prefixed keys from dotenv to avoid env pollution

### DIFF
--- a/pymilvus/settings.py
+++ b/pymilvus/settings.py
@@ -1,9 +1,16 @@
 import logging.config
 import os
 
-from dotenv import load_dotenv
-
-load_dotenv()
+if os.getenv("PYTHON_DOTENV_DISABLED") != "1":
+    try:
+        from dotenv import dotenv_values, find_dotenv
+        dotenv_path = find_dotenv(usecwd=True)
+        if dotenv_path:
+            for k, v in dotenv_values(dotenv_path).items():
+                if k.startswith("MILVUS_") and v is not None and k not in os.environ:
+                    os.environ[k] = v
+    except ImportError:
+        pass
 
 
 class Config:

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,0 +1,102 @@
+import os
+import sys
+from importlib import reload
+
+def test_settings_dotenv_no_pollution(tmp_path):
+    old_uri = os.environ.get("MILVUS_URI")
+    old_secret = os.environ.get("MY_APP_SECRET")
+    old_disabled = os.environ.get("PYTHON_DOTENV_DISABLED")
+
+    if "MILVUS_URI" in os.environ:
+        del os.environ["MILVUS_URI"]
+    if "MY_APP_SECRET" in os.environ:
+        del os.environ["MY_APP_SECRET"]
+    if "PYTHON_DOTENV_DISABLED" in os.environ:
+        del os.environ["PYTHON_DOTENV_DISABLED"]
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with open(".env", "w") as f:
+            f.write("MILVUS_URI=http://localhost:19530\n")
+            f.write("MY_APP_SECRET=sensitive_value\n")
+
+        import pymilvus.settings
+        reload(pymilvus.settings)
+
+        assert os.environ.get("MILVUS_URI") == "http://localhost:19530"
+        assert os.environ.get("MY_APP_SECRET") is None
+
+    finally:
+        os.chdir(orig_cwd)
+        if old_uri is not None:
+            os.environ["MILVUS_URI"] = old_uri
+        elif "MILVUS_URI" in os.environ:
+            del os.environ["MILVUS_URI"]
+        if old_secret is not None:
+            os.environ["MY_APP_SECRET"] = old_secret
+        elif "MY_APP_SECRET" in os.environ:
+            del os.environ["MY_APP_SECRET"]
+        if old_disabled is not None:
+            os.environ["PYTHON_DOTENV_DISABLED"] = old_disabled
+        elif "PYTHON_DOTENV_DISABLED" in os.environ:
+            del os.environ["PYTHON_DOTENV_DISABLED"]
+
+
+def test_settings_dotenv_disabled(tmp_path):
+    old_uri = os.environ.get("MILVUS_URI")
+    old_disabled = os.environ.get("PYTHON_DOTENV_DISABLED")
+
+    if "MILVUS_URI" in os.environ:
+        del os.environ["MILVUS_URI"]
+    os.environ["PYTHON_DOTENV_DISABLED"] = "1"
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with open(".env", "w") as f:
+            f.write("MILVUS_URI=http://localhost:19530\n")
+
+        import pymilvus.settings
+        reload(pymilvus.settings)
+
+        # Should NOT load because dotenv is disabled
+        assert os.environ.get("MILVUS_URI") is None
+
+    finally:
+        os.chdir(orig_cwd)
+        if old_uri is not None:
+            os.environ["MILVUS_URI"] = old_uri
+        elif "MILVUS_URI" in os.environ:
+            del os.environ["MILVUS_URI"]
+        if old_disabled is not None:
+            os.environ["PYTHON_DOTENV_DISABLED"] = old_disabled
+        elif "PYTHON_DOTENV_DISABLED" in os.environ:
+            del os.environ["PYTHON_DOTENV_DISABLED"]
+
+
+def test_settings_dotenv_valueless_keys_skipped(tmp_path):
+    old_uri = os.environ.get("MILVUS_URI")
+
+    if "MILVUS_URI" in os.environ:
+        del os.environ["MILVUS_URI"]
+
+    orig_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        with open(".env", "w") as f:
+            # Valueless key in .env syntax
+            f.write("MILVUS_URI\n")
+
+        # This should not raise TypeError during load
+        import pymilvus.settings
+        reload(pymilvus.settings)
+
+        assert os.environ.get("MILVUS_URI") is None
+
+    finally:
+        os.chdir(orig_cwd)
+        if old_uri is not None:
+            os.environ["MILVUS_URI"] = old_uri
+        elif "MILVUS_URI" in os.environ:
+            del os.environ["MILVUS_URI"]


### PR DESCRIPTION
Resolves #3666.

### Description
Currently, `pymilvus` calls `load_dotenv()` unconditionally in global namespace when importing `pymilvus/settings.py`. This causes side effects by loading all key-value pairs from `.env` (such as app secrets or credentials for other systems) into the process-wide `os.environ` environment variables, polluting the host application space.

To solve this, this change replaces the unconditional global `load_dotenv()` with a structured check using `dotenv_values(find_dotenv(usecwd=True))` that filters and only injects keys prefixed with `MILVUS_` (e.g. `MILVUS_URI`, `MILVUS_CONN_ALIAS`) into `os.environ` if they are not already set.

### Changes
- Updated `pymilvus/settings.py` to use `find_dotenv(usecwd=True)` + `dotenv_values()` and only inject keys beginning with `MILVUS_`.
- Added a new unit test suite in `tests/unit/test_settings.py` checking that `MILVUS_` keys are loaded, while non-Milvus keys (like `MY_APP_SECRET`) remain untouched in the host environment.