### PR TITLE
fix: mkts delta ignores everything above the sub-second component

### DIFF
--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -100,7 +100,7 @@ def mkts_from_hybridts(
         raise MilvusException(message="parameter milliseconds should be type of int or float")
 
     if isinstance(delta, datetime.timedelta):
-        milliseconds += delta.microseconds / 1000.0
+        milliseconds += delta / datetime.timedelta(milliseconds=1)
     elif delta is not None:
         raise MilvusException(message="parameter delta should be type of datetime.timedelta")
 
@@ -125,7 +125,7 @@ def mkts_from_unixtime(
         raise MilvusException(message="parameter milliseconds should be type of int or float")
 
     if isinstance(delta, datetime.timedelta):
-        milliseconds += delta.microseconds / 1000.0
+        milliseconds += delta / datetime.timedelta(milliseconds=1)
     elif delta is not None:
         raise MilvusException(message="parameter delta should be type of datetime.timedelta")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -87,6 +87,28 @@ class TestMktsFromHybridts:
         expected = (physical_ms + 300) << LOGICAL_BITS
         assert result == expected
 
+    def test_with_timedelta_whole_seconds(self):
+        physical_ms = 1000
+        hybridts = physical_ms << LOGICAL_BITS
+        result = utils.mkts_from_hybridts(hybridts, delta=timedelta(seconds=1))
+        expected = (physical_ms + 1000) << LOGICAL_BITS
+        assert result == expected
+
+    def test_with_timedelta_days(self):
+        physical_ms = 1000
+        hybridts = physical_ms << LOGICAL_BITS
+        result = utils.mkts_from_hybridts(hybridts, delta=timedelta(days=1))
+        expected = (physical_ms + 86400 * 1000) << LOGICAL_BITS
+        assert result == expected
+
+    def test_with_timedelta_seconds_and_microseconds(self):
+        physical_ms = 1000
+        hybridts = physical_ms << LOGICAL_BITS
+        delta = timedelta(seconds=1, microseconds=500000)  # 1500ms
+        result = utils.mkts_from_hybridts(hybridts, delta=delta)
+        expected = (physical_ms + 1500) << LOGICAL_BITS
+        assert result == expected
+
     def test_preserves_logical_part(self):
         physical_ms = 1000
         logical = 42
@@ -140,6 +162,17 @@ class TestMktsFromUnixtime:
         delta = timedelta(microseconds=200000)  # 200ms
         result = utils.mkts_from_unixtime(epoch, milliseconds=offset_ms, delta=delta)
         expected = 1300 << LOGICAL_BITS
+        assert result == expected
+
+    def test_with_timedelta_whole_seconds(self):
+        result = utils.mkts_from_unixtime(1.0, delta=timedelta(seconds=1))
+        expected = 2000 << LOGICAL_BITS
+        assert result == expected
+
+    def test_with_timedelta_seconds_and_microseconds(self):
+        delta = timedelta(seconds=1, microseconds=500000)  # 1500ms
+        result = utils.mkts_from_unixtime(1.0, delta=delta)
+        expected = 2500 << LOGICAL_BITS
         assert result == expected
 
     def test_zero_epoch(self):


### PR DESCRIPTION
## Summary

`mkts_from_hybridts` and `mkts_from_unixtime` read `delta.microseconds`, which is only the sub-second **component** of a `timedelta`, not its total duration. `timedelta(seconds=1).microseconds` is `0`, so any whole-second/minute/hour/day delta contributes nothing at all:

```python
base = 1000 << LOGICAL_BITS
mkts_from_hybridts(base, delta=timedelta(seconds=1)) - base   # -> 0    (expected 1000 << 18)
mkts_from_hybridts(base, delta=timedelta(days=1))    - base   # -> 0    (expected 86400000 << 18)
mkts_from_unixtime(0.0, delta=timedelta(seconds=1))           # -> 0
```

The clearest symptom is that a delta of **1500ms is indistinguishable from one of 500ms** — the whole second is silently dropped, so the caller gets a plausible-looking timestamp that is quietly wrong rather than an error.

The docstring in `orm/utility.py` describes `delta` as *"A duration expressing the difference between two date, time, or datetime instances to microsecond resolution"* — i.e. the entire duration (this is Python's own wording for `timedelta` as a whole), so sub-second-only was not the intent.

Both functions are public API, re-exported from `pymilvus/__init__.py` and wrapped by `pymilvus/orm/utility.py`.

## List of files changed and why

- `pymilvus/client/utils.py` — use `delta / timedelta(milliseconds=1)` in both functions, which accounts for every component exactly. (Preferred over `total_seconds() * 1000`, which routes through a float.)
- `tests/unit/test_utils.py` — regression tests for whole-second, day, and mixed seconds+microseconds deltas, on both functions.

## How Has This Been Tested?

- The 5 new tests fail on `master` and pass with this change.
- `PYTHONPATH=$PWD uv run --group dev pytest tests/unit/test_utils.py` — 74 passed.
- `PYTHONPATH=$PWD uv run --group dev pytest tests/unit` — 4440 passed, 3 skipped, no regressions. (`tests/unit/test_check.py::TestGetCommit::test_get_commit` fails in my environment both with and without this change — it needs git history and my checkout is shallow; verified against a clean tree via `git stash`.)
- `black --check` and `ruff check` clean on both files.

### Why the existing tests did not catch this

Every assertive test passes a microseconds-only delta (`tests/unit/test_utils.py`, `tests/unit/test_check.py`), which is exactly the case that works. `tests/unit/orm/test_utility.py:143` does use `timedelta(seconds=10)`, but only asserts `result_with_delta >= result_no_delta` — which holds trivially when the delta is dropped and the two are equal.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the regression tests. I ran the repro and the full unit suite locally and reviewed the diff before opening.