### PR TITLE
Reject an empty binary vector list instead of raising IndexError

### DIFF
--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -148,7 +148,7 @@ def mkts_from_datetime(
 def check_invalid_binary_vector(entities: List) -> bool:
     for entity in entities:
         if entity["type"] == DataType.BINARY_VECTOR:
-            if not isinstance(entity["values"], list) and len(entity["values"]) == 0:
+            if not isinstance(entity["values"], list) or len(entity["values"]) == 0:
                 return False
 
             dim = len(entity["values"][0]) * 8

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -255,6 +255,10 @@ class TestCheckInvalidBinaryVector:
         entities = [{"type": DataType.BINARY_VECTOR, "values": [[0, 1], [2, 3]]}]
         assert utils.check_invalid_binary_vector(entities) is False
 
+    def test_empty_values(self):
+        entities = [{"type": DataType.BINARY_VECTOR, "values": []}]
+        assert utils.check_invalid_binary_vector(entities) is False
+
 
 class TestSparseParseSingleRow:
     def test_basic_parsing(self):


### PR DESCRIPTION
## Problem

`check_invalid_binary_vector` raises `IndexError` on an empty binary-vector list instead of returning `False`:

```python
>>> check_invalid_binary_vector([{"type": DataType.BINARY_VECTOR, "values": []}])
IndexError: list index out of range
```

The guard uses `and`:

```python
if not isinstance(entity["values"], list) and len(entity["values"]) == 0:
    return False

dim = len(entity["values"][0]) * 8
```

For `values = []` the two sides are `False` and `True`, so the guard doesn't fire and the next line indexes `[0]` on an empty list:

```
not isinstance(values, list) = False
len(values) == 0             = True
False and True               = False   -> guard skipped
```

Neither side is redundant with `or`, which is what makes `and` look like a typo rather than a choice: a non-list has no meaningful `values[0]` either, and today that case reaches `len(entity["values"][0])` too.

## Impact

This function's whole job is to return `False` so the caller can raise a clean error. `grpc_handler.py:1074` (and `:1208`, plus the async handler) does:

```python
if not check_invalid_binary_vector(entities):
    raise ParamError(message="Invalid binary vector data exists")
```

So instead of `ParamError("Invalid binary vector data exists")`, the user gets a raw `IndexError` out of the validation helper. Reachable from `Collection.insert(data=[[], []])` via `orm/collection.py:570`.

## Fix

`and` -> `or`. One character.

## Testing

Added `test_empty_values` to `TestCheckInvalidBinaryVector`, alongside the existing `test_inconsistent_dimensions` / `test_non_bytes_values` False-cases. The class covers five cases today — including an empty *entities* list — but never an entity whose `values` list is empty, which is why this survived.

Verified it fails first (`IndexError`) and passes after. Full `tests/unit/` — 4441 passed. `tests/unit/test_check.py::TestGetCommit::test_get_commit` fails identically before and after my change (I checked against a clean tree rather than assuming), so it's pre-existing and unrelated.

---

This change was AI-assisted (Claude). I reproduced the `IndexError` myself, evaluated the guard's two subconditions directly to confirm the short-circuit, read the `grpc_handler` call sites to check what the caller expects, and ran the tests and the baseline comparison above myself.
