### PR TITLE
fix: reject primary field as partition key

### DIFF
--- a/pymilvus/orm/schema.py
+++ b/pymilvus/orm/schema.py
@@ -60,7 +60,7 @@ def validate_partition_key(
     # not allow partition_key field is primary key field
     if partition_key_field is not None:
         if partition_key_field.name == primary_field_name:
-            PartitionKeyException(message=ExceptionsMessage.PartitionKeyNotPrimary)
+            raise PartitionKeyException(message=ExceptionsMessage.PartitionKeyNotPrimary)
 
         if partition_key_field.dtype not in [DataType.INT64, DataType.VARCHAR]:
             raise PartitionKeyException(message=ExceptionsMessage.PartitionKeyType)
@@ -262,6 +262,13 @@ class CollectionSchema:
                     )
                     raise ClusteringKeyException(message=msg)
                 self._clustering_key_field = field
+
+            if self._primary_field is not None and self._partition_key_field is not None:
+                validate_partition_key(
+                    self._partition_key_field.name,
+                    self._partition_key_field,
+                    self._primary_field.name,
+                )
         except Exception:
             self._primary_field = primary_field
             self._partition_key_field = partition_key_field

--- a/tests/unit/orm/test_schema.py
+++ b/tests/unit/orm/test_schema.py
@@ -598,6 +598,22 @@ class TestCollectionSchemaKeyFields:
         assert schema.partition_key_field.name == "category"
         assert schema.partition_key_field.is_partition_key is True
 
+    def test_partition_key_same_as_primary_from_fields_raises(self):
+        """Test direct schema construction rejects primary field as partition key."""
+        with pytest.raises(PartitionKeyException, match="should not be primary"):
+            CollectionSchema(
+                [FieldSchema("pk", DataType.INT64, is_primary=True, is_partition_key=True)]
+            )
+
+    def test_partition_key_same_as_primary_from_kwargs_raises(self):
+        """Test kwarg schema construction rejects primary field as partition key."""
+        fields = [
+            FieldSchema("pk", DataType.INT64),
+            FieldSchema("vec", DataType.FLOAT_VECTOR, dim=128),
+        ]
+        with pytest.raises(PartitionKeyException, match="should not be primary"):
+            CollectionSchema(fields, primary_field="pk", partition_key_field="pk")
+
     def test_clustering_key_field_from_kwarg(self):
         """Test setting clustering key field from kwarg."""
         fields = [
@@ -721,6 +737,17 @@ class TestCollectionSchemaAddField:
         assert [field.to_dict() for field in schema.fields] == fields_before
         assert schema.primary_field is None
         assert schema.partition_key_field.name == "category"
+
+    def test_add_field_rejects_primary_field_as_partition_key(self):
+        """Test add_field rejects a field that is both primary and partition key."""
+        schema = CollectionSchema([], check_fields=False)
+
+        with pytest.raises(PartitionKeyException, match="should not be primary"):
+            schema.add_field("pk", DataType.INT64, is_primary=True, is_partition_key=True)
+
+        assert schema.fields == []
+        assert schema.primary_field is None
+        assert schema.partition_key_field is None
 
     def test_add_struct_field_missing_struct_schema(self):
         """Test adding struct field without struct_schema raises error."""
@@ -2033,12 +2060,10 @@ class TestValidatePartitionKeyLine63:
     """Cover line 63: partition_key_field.name == primary_field_name path."""
 
     def test_partition_key_same_as_primary(self):
-        """When partition key field is the same as primary, line 63 constructs the exception
-        but does NOT raise it (it's a bug in the source -- missing 'raise').
-        We just verify the code path runs without error."""
+        """Partition key field cannot be the same field as the primary key."""
         pk = FieldSchema("pk", DataType.INT64, is_primary=True, is_partition_key=True)
-        # Exercises the branch where partition key name matches the primary field name
-        validate_partition_key("pk", pk, "pk")
+        with pytest.raises(PartitionKeyException, match="should not be primary"):
+            validate_partition_key("pk", pk, "pk")
 
     def test_partition_key_wrong_type(self):
         """Partition key field with unsupported dtype raises."""


### PR DESCRIPTION
Fix schema validation so the same field cannot be accepted as both primary key and partition key.

## What Problem This Solves

`validate_partition_key()` already had an explicit branch for `partition_key_field.name == primary_field_name`, but it only constructed `PartitionKeyException` without raising it. As a result, invalid schemas could be accepted even though the nearby comment and exception message both state that a partition key field should not be the primary field.

Before this change, these invalid shapes could pass client-side schema construction:

```python
CollectionSchema([
    FieldSchema("pk", DataType.INT64, is_primary=True, is_partition_key=True)
])

CollectionSchema(
    [FieldSchema("pk", DataType.INT64), FieldSchema("vec", DataType.FLOAT_VECTOR, dim=4)],
    primary_field="pk",
    partition_key_field="pk",
)
```

## Change

- Raise the existing `PartitionKeyException` in `validate_partition_key()` when the partition key field is also the primary field.
- Reuse the same validation during `CollectionSchema.add_field()` key metadata updates, so incremental schema construction rejects the same invalid shape and rolls metadata back.
- Add regression coverage for direct field flags, `primary_field` / `partition_key_field` kwargs, incremental `add_field()`, and the helper branch itself.

## Evidence

After the patch, the focused reproduction rejects all affected entry points:

```text
validate_partition_key: PartitionKeyException: Partition key field should not be primary field
CollectionSchema direct: PartitionKeyException: Partition key field should not be primary field
CollectionSchema kwargs: PartitionKeyException: Partition key field should not be primary field
add_field: PartitionKeyException: Partition key field should not be primary field
```

## Possible call chain / impact

```text
CollectionSchema(...)
  -> _check_fields()
  -> validate_partition_key(...)
  -> raise PartitionKeyException

CollectionSchema(..., check_fields=False).add_field(...)
  -> _update_key_field_metadata(...)
  -> validate_partition_key(...)
  -> raise PartitionKeyException and roll back key metadata
```

This is a narrow client-side validation tightening. It only affects schemas that try to use the same field as both primary key and partition key, which the existing validation comment and `PartitionKeyNotPrimary` message already mark as invalid.

## Validation

- `UV_CACHE_DIR='D:\ZXY\Github\.uv-cache' uv run pytest tests/unit/orm/test_schema.py::TestValidatePartitionKeyLine63::test_partition_key_same_as_primary tests/unit/orm/test_schema.py::TestCollectionSchemaKeyFields::test_partition_key_same_as_primary_from_fields_raises tests/unit/orm/test_schema.py::TestCollectionSchemaKeyFields::test_partition_key_same_as_primary_from_kwargs_raises tests/unit/orm/test_schema.py::TestCollectionSchemaAddField::test_add_field_rejects_primary_field_as_partition_key -q` - 4 passed
- `UV_CACHE_DIR='D:\ZXY\Github\.uv-cache' uv run pytest tests/unit/orm/test_schema.py -q` - 257 passed
- `UV_CACHE_DIR='D:\ZXY\Github\.uv-cache' uv run ruff check pymilvus/orm/schema.py tests/unit/orm/test_schema.py` - passed
- `git diff --check` - passed
