### PR TITLE
[Backport 3.0] fix: align add field and drop function RPC routes (#3704)

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -1592,11 +1592,24 @@ class AsyncGrpcHandler:
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
-        request = Prepare.add_collection_field_request(collection_name, field_schema)
-        status = await self._async_stub.AddCollectionField(
-            request, timeout=timeout, metadata=_api_level_md(context)
+        request = Prepare.alter_collection_schema_request(
+            collection_name=collection_name,
+            field_schema=field_schema,
         )
-        check_status(status)
+        try:
+            response = await self._async_stub.AlterCollectionSchema(
+                request, timeout=timeout, metadata=_api_level_md(context)
+            )
+            check_status(response.alter_status)
+        except grpc.RpcError as e:
+            if e.code() != grpc.StatusCode.UNIMPLEMENTED:
+                raise
+            legacy_request = Prepare.add_collection_field_request(collection_name, field_schema)
+            status = await self._async_stub.AddCollectionField(
+                legacy_request, timeout=timeout, metadata=_api_level_md(context)
+            )
+            check_status(status)
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     async def add_collection_struct_field(
@@ -1670,14 +1683,13 @@ class AsyncGrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        await self._alter_collection_schema_drop(
-            collection_name,
-            function_name=function_name,
-            timeout=timeout,
-            context=context,
-            **kwargs,
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.drop_collection_function_request(collection_name, function_name)
+
+        status = await self._async_stub.DropCollectionFunction(
+            request, timeout=timeout, metadata=_api_level_md(context)
         )
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
+        check_status(status)
 
     @retry_on_rpc_failure()
     async def add_collection_function(

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -547,11 +547,24 @@ class GrpcHandler:
         **kwargs,
     ):
         check_pass_param(collection_name=collection_name, timeout=timeout)
-        request = Prepare.add_collection_field_request(collection_name, field_schema)
-        status = self._stub.AddCollectionField(
-            request, timeout=timeout, metadata=_api_level_md(context)
+        request = Prepare.alter_collection_schema_request(
+            collection_name=collection_name,
+            field_schema=field_schema,
         )
-        check_status(status)
+        try:
+            response = self._stub.AlterCollectionSchema(
+                request, timeout=timeout, metadata=_api_level_md(context)
+            )
+            check_status(response.alter_status)
+        except grpc.RpcError as e:
+            if e.code() != grpc.StatusCode.UNIMPLEMENTED:
+                raise
+            legacy_request = Prepare.add_collection_field_request(collection_name, field_schema)
+            status = self._stub.AddCollectionField(
+                legacy_request, timeout=timeout, metadata=_api_level_md(context)
+            )
+            check_status(status)
+        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
 
     @retry_on_rpc_failure()
     def add_collection_struct_field(
@@ -624,14 +637,13 @@ class GrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        self._alter_collection_schema_drop(
-            collection_name,
-            function_name=function_name,
-            timeout=timeout,
-            context=context,
-            **kwargs,
+        check_pass_param(collection_name=collection_name, timeout=timeout)
+        request = Prepare.drop_collection_function_request(collection_name, function_name)
+
+        status = self._stub.DropCollectionFunction(
+            request, timeout=timeout, metadata=_api_level_md(context)
         )
-        self._invalidate_schema(collection_name, db_name=(context.get_db_name() if context else ""))
+        check_status(status)
 
     @retry_on_rpc_failure()
     def add_collection_function(

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1011,10 +1011,18 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    @deprecated(
+        "AsyncMilvusClient.add_collection_function",
+        replacement="AsyncMilvusClient.add_function_field",
+        reason="is unsupported by Milvus 3.0 and later",
+    )
     async def add_collection_function(
         self, collection_name: str, function: Function, timeout: Optional[float] = None, **kwargs
     ):
-        """Add a new function to the collection.
+        """Deprecated: Use add_function_field instead.
+
+        Milvus 3.0 and later do not support adding a function separately. The replacement
+        adds the function together with its output field and index.
 
         Args:
             collection_name(``string``): The name of collection.
@@ -1068,10 +1076,18 @@ class AsyncMilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    @deprecated(
+        "AsyncMilvusClient.drop_collection_function",
+        replacement="AsyncMilvusClient.drop_function_field",
+        reason="is unsupported by Milvus 3.0 and later",
+    )
     async def drop_collection_function(
         self, collection_name: str, function_name: str, timeout: Optional[float] = None, **kwargs
     ):
-        """Drop a function from the collection.
+        """Deprecated: Use drop_function_field instead.
+
+        Milvus 3.0 and later do not support dropping a function separately. The replacement
+        also removes the function's output field and its index.
 
         Args:
             collection_name(``string``): The name of collection.
@@ -1084,10 +1100,12 @@ class AsyncMilvusClient(BaseMilvusClient):
         Raises:
             MilvusException: If anything goes wrong
         """
-        await self._alter_collection_schema(
-            collection_name=collection_name,
-            drop_function_name=function_name,
+        conn = await self._get_connection()
+        await conn.drop_collection_function(
+            collection_name,
+            function_name,
             timeout=timeout,
+            context=self._generate_call_context(**kwargs),
             **kwargs,
         )
 

--- a/pymilvus/milvus_client/milvus_client.py
+++ b/pymilvus/milvus_client/milvus_client.py
@@ -1288,10 +1288,18 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    @deprecated(
+        "MilvusClient.add_collection_function",
+        replacement="MilvusClient.add_function_field",
+        reason="is unsupported by Milvus 3.0 and later",
+    )
     def add_collection_function(
         self, collection_name: str, function: Function, timeout: Optional[float] = None, **kwargs
     ):
-        """Add a new function to the collection.
+        """Deprecated: Use add_function_field instead.
+
+        Milvus 3.0 and later do not support adding a function separately. The replacement
+        adds the function together with its output field and index.
 
         Args:
             collection_name(``string``): The name of collection.
@@ -1345,10 +1353,18 @@ class MilvusClient(BaseMilvusClient):
             **kwargs,
         )
 
+    @deprecated(
+        "MilvusClient.drop_collection_function",
+        replacement="MilvusClient.drop_function_field",
+        reason="is unsupported by Milvus 3.0 and later",
+    )
     def drop_collection_function(
         self, collection_name: str, function_name: str, timeout: Optional[float] = None, **kwargs
     ):
-        """Drop a function from the collection.
+        """Deprecated: Use drop_function_field instead.
+
+        Milvus 3.0 and later do not support dropping a function separately. The replacement
+        also removes the function's output field and its index.
 
         Args:
             collection_name(``string``): The name of collection.
@@ -1361,10 +1377,12 @@ class MilvusClient(BaseMilvusClient):
         Raises:
             MilvusException: If anything goes wrong
         """
-        self._alter_collection_schema(
-            collection_name=collection_name,
-            drop_function_name=function_name,
+        conn = self._get_connection()
+        conn.drop_collection_function(
+            collection_name,
+            function_name,
             timeout=timeout,
+            context=self._generate_call_context(**kwargs),
             **kwargs,
         )
 

--- a/tests/unit/async_grpc_handler/test_async_collection.py
+++ b/tests/unit/async_grpc_handler/test_async_collection.py
@@ -6,6 +6,7 @@ Coverage: Collection create/drop/load/release, schema caching, collection proper
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import grpc
 import pytest
 from pymilvus.client.async_grpc_handler import AsyncGrpcHandler
 from pymilvus.client.cache import GlobalCache
@@ -629,18 +630,66 @@ class TestAsyncGrpcHandlerCollectionProperties:
         handler.ensure_channel_ready = AsyncMock()
 
         mock_stub = AsyncMock()
-        mock_status = MagicMock()
-        mock_status.code = 0
-        mock_stub.AddCollectionField = AsyncMock(return_value=mock_status)
+        mock_response = MagicMock()
+        mock_response.alter_status = MagicMock(code=0, error_code=0, reason="")
+        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        mock_stub.AddCollectionField = AsyncMock()
         handler._async_stub = mock_stub
 
         mock_field_schema = MagicMock()
         with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
-            mock_prepare.add_collection_field_request.return_value = MagicMock()
+            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            GlobalCache._reset_for_testing()
+            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
             await handler.add_collection_field("test_coll", mock_field_schema)
-            mock_stub.AddCollectionField.assert_called_once()
+            mock_prepare.alter_collection_schema_request.assert_called_once_with(
+                collection_name="test_coll",
+                field_schema=mock_field_schema,
+            )
+            mock_stub.AlterCollectionSchema.assert_called_once()
+            mock_stub.AddCollectionField.assert_not_called()
+            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
+            GlobalCache._reset_for_testing()
+
+    @pytest.mark.asyncio
+    async def test_add_collection_field_falls_back_for_older_server(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+        handler.ensure_channel_ready = AsyncMock()
+
+        mock_stub = AsyncMock()
+        unimplemented = grpc.RpcError()
+        unimplemented.code = MagicMock(return_value=grpc.StatusCode.UNIMPLEMENTED)
+        mock_stub.AlterCollectionSchema = AsyncMock(side_effect=unimplemented)
+        legacy_status = MagicMock(code=0, error_code=0, reason="")
+        mock_stub.AddCollectionField = AsyncMock(return_value=legacy_status)
+        handler._async_stub = mock_stub
+
+        mock_field_schema = MagicMock()
+        alter_request = MagicMock()
+        legacy_request = MagicMock()
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_pass_param"
+        ), patch("pymilvus.client.async_grpc_handler.check_status") as mock_check_status:
+            mock_prepare.alter_collection_schema_request.return_value = alter_request
+            mock_prepare.add_collection_field_request.return_value = legacy_request
+            GlobalCache._reset_for_testing()
+            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"fields": []})
+            await handler.add_collection_field("test_coll", mock_field_schema)
+
+            mock_stub.AlterCollectionSchema.assert_awaited_once()
+            mock_prepare.add_collection_field_request.assert_called_once_with(
+                "test_coll", mock_field_schema
+            )
+            mock_stub.AddCollectionField.assert_awaited_once()
+            assert mock_stub.AddCollectionField.call_args.args[0] is legacy_request
+            mock_check_status.assert_called_once_with(legacy_status)
+            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
+            GlobalCache._reset_for_testing()
 
     @pytest.mark.asyncio
     async def test_add_collection_struct_field(self) -> None:
@@ -681,30 +730,22 @@ class TestAsyncGrpcHandlerCollectionProperties:
         handler.ensure_channel_ready = AsyncMock()
 
         mock_stub = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.alter_status = MagicMock(code=0, error_code=0, reason="")
-        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
-        mock_stub.DropCollectionFunction = AsyncMock()
+        mock_status = MagicMock()
+        mock_status.code = 0
+        mock_stub.DropCollectionFunction = AsyncMock(return_value=mock_status)
+        mock_stub.AlterCollectionSchema = AsyncMock()
         handler._async_stub = mock_stub
 
         with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
             "pymilvus.client.async_grpc_handler.check_pass_param"
         ), patch("pymilvus.client.async_grpc_handler.check_status"):
-            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
-            GlobalCache._reset_for_testing()
-            GlobalCache.schema.set(handler.server_address, "", "test_coll", {"functions": []})
+            mock_prepare.drop_collection_function_request.return_value = MagicMock()
             await handler.drop_collection_function("test_coll", "func1")
-            mock_prepare.alter_collection_schema_request.assert_called_once_with(
-                collection_name="test_coll",
-                drop_field_name="",
-                drop_field_id=0,
-                drop_function_name="func1",
-                drop_function_output_fields=False,
+            mock_prepare.drop_collection_function_request.assert_called_once_with(
+                "test_coll", "func1"
             )
-            mock_stub.AlterCollectionSchema.assert_called_once()
-            mock_stub.DropCollectionFunction.assert_not_called()
-            assert GlobalCache.schema.get(handler.server_address, "", "test_coll") is None
-            GlobalCache._reset_for_testing()
+            mock_stub.DropCollectionFunction.assert_called_once()
+            mock_stub.AlterCollectionSchema.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_drop_collection_field(self) -> None:

--- a/tests/unit/grpc_handler/test_collection.py
+++ b/tests/unit/grpc_handler/test_collection.py
@@ -3,12 +3,13 @@
 import inspect
 from unittest.mock import MagicMock, patch
 
+import grpc
 import pytest
 from pymilvus import FieldSchema, Function, FunctionType, StructFieldSchema
 from pymilvus.client.cache import GlobalCache
 from pymilvus.client.types import DataType
 from pymilvus.exceptions import DescribeCollectionException
-from pymilvus.grpc_gen import common_pb2
+from pymilvus.grpc_gen import common_pb2, schema_pb2
 
 from .conftest import (
     COLLECTION_VALIDATION_CASES,
@@ -206,11 +207,41 @@ class TestGrpcHandlerCollectionProperties:
         handler._stub.AlterCollectionField.assert_called_once()
 
     def test_add_collection_field(self, handler):
+        response = MagicMock()
+        response.alter_status = make_status()
+        handler._stub.AlterCollectionSchema.return_value = response
+        field = FieldSchema(name="new_field", dtype=DataType.VARCHAR, max_length=256)
 
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
+        handler.add_collection_field("coll", field)
+        handler._stub.AlterCollectionSchema.assert_called_once()
+        request = handler._stub.AlterCollectionSchema.call_args.args[0]
+        assert request.action.add_request.field_infos[0].field_schema.name == "new_field"
+        handler._stub.AddCollectionField.assert_not_called()
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()
+
+    def test_add_collection_field_falls_back_for_older_server(self, handler):
+        unimplemented = grpc.RpcError()
+        unimplemented.code = MagicMock(return_value=grpc.StatusCode.UNIMPLEMENTED)
+        handler._stub.AlterCollectionSchema.side_effect = unimplemented
         handler._stub.AddCollectionField.return_value = make_status()
         field = FieldSchema(name="new_field", dtype=DataType.VARCHAR, max_length=256)
+
+        GlobalCache._reset_for_testing()
+        GlobalCache.schema.set(handler.server_address, "", "coll", {"fields": []})
         handler.add_collection_field("coll", field)
+
+        handler._stub.AlterCollectionSchema.assert_called_once()
         handler._stub.AddCollectionField.assert_called_once()
+        request = handler._stub.AddCollectionField.call_args.args[0]
+        field_schema = schema_pb2.FieldSchema()
+        field_schema.ParseFromString(request.schema)
+        assert request.collection_name == "coll"
+        assert field_schema.name == "new_field"
+        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
+        GlobalCache._reset_for_testing()
 
     def test_add_collection_struct_field(self, handler):
         handler._stub.AddCollectionStructField.return_value = make_status()
@@ -227,19 +258,10 @@ class TestGrpcHandlerCollectionProperties:
         GlobalCache._reset_for_testing()
 
     def test_drop_collection_function(self, handler):
-        response = MagicMock()
-        response.alter_status = make_status()
-        handler._stub.AlterCollectionSchema.return_value = response
-        GlobalCache._reset_for_testing()
-        GlobalCache.schema.set(handler.server_address, "", "coll", {"functions": []})
+        handler._stub.DropCollectionFunction.return_value = make_status()
         handler.drop_collection_function("coll", "func")
-        handler._stub.AlterCollectionSchema.assert_called_once()
-        request = handler._stub.AlterCollectionSchema.call_args.args[0]
-        assert request.action.drop_request.function_name == "func"
-        assert not request.action.drop_request.drop_function_output_fields
-        handler._stub.DropCollectionFunction.assert_not_called()
-        assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
-        GlobalCache._reset_for_testing()
+        handler._stub.DropCollectionFunction.assert_called_once()
+        handler._stub.AlterCollectionSchema.assert_not_called()
 
     def test_drop_collection_field(self, handler):
         response = MagicMock()

--- a/tests/unit/test_async_milvus_client.py
+++ b/tests/unit/test_async_milvus_client.py
@@ -14,6 +14,7 @@ from pymilvus import (
     FunctionChain,
     FunctionChainStage,
     FunctionType,
+    PyMilvusDeprecationWarning,
     SearchAggregation,
     TopHits,
 )
@@ -1475,14 +1476,27 @@ class TestAsyncAlterCollectionSchema:
         mock_handler.alter_collection_schema = AsyncMock()
         mock_handler.drop_collection_function = AsyncMock()
 
-        await client.drop_collection_function("col", "fn")
+        with pytest.warns(
+            PyMilvusDeprecationWarning,
+            match=r"AsyncMilvusClient\.drop_collection_function.*Milvus 3\.0.*AsyncMilvusClient\.drop_function_field",
+        ):
+            await client.drop_collection_function("col", "fn")
 
-        mock_handler.alter_collection_schema.assert_called_once()
-        assert mock_handler.alter_collection_schema.call_args.kwargs["drop_function_name"] == "fn"
-        assert not mock_handler.alter_collection_schema.call_args.kwargs[
-            "drop_function_output_fields"
-        ]
-        mock_handler.drop_collection_function.assert_not_called()
+        mock_handler.drop_collection_function.assert_called_once()
+        mock_handler.alter_collection_schema.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_collection_function_delegates(self, client_and_handler):
+        client, mock_handler = client_and_handler
+        mock_handler.add_collection_function = AsyncMock()
+
+        with pytest.warns(
+            PyMilvusDeprecationWarning,
+            match=r"AsyncMilvusClient\.add_collection_function.*Milvus 3\.0.*AsyncMilvusClient\.add_function_field",
+        ):
+            await client.add_collection_function("col", MagicMock())
+
+        mock_handler.add_collection_function.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_drop_function_field_delegates(self, client_and_handler):

--- a/tests/unit/test_async_milvus_client_ops.py
+++ b/tests/unit/test_async_milvus_client_ops.py
@@ -127,7 +127,7 @@ _SIMPLE_ASYNC_DELEGATION_CASES = [
         {},
         "alter_collection_field",
     ),
-    ("drop_collection_function", ("col", "fn"), {}, "alter_collection_schema"),
+    ("drop_collection_function", ("col", "fn"), {}, "drop_collection_function"),
     ("drop_function_field", ("col", "fn"), {}, "alter_collection_schema"),
     ("add_collection_function", ("col", MagicMock()), {}, "add_collection_function"),
     ("alter_collection_function", ("col", "fn", MagicMock()), {}, "alter_collection_function"),

--- a/tests/unit/test_milvus_client.py
+++ b/tests/unit/test_milvus_client.py
@@ -12,6 +12,7 @@ from pymilvus import (
     FunctionChain,
     FunctionChainStage,
     FunctionType,
+    PyMilvusDeprecationWarning,
     SearchAggregation,
     StructFieldSchema,
     TopHits,
@@ -1638,7 +1639,11 @@ class TestMilvusClientCollectionMgmt:
         handler = _make_handler()
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()
-            client.add_collection_function("col", MagicMock())
+            with pytest.warns(
+                PyMilvusDeprecationWarning,
+                match=r"MilvusClient\.add_collection_function.*Milvus 3\.0.*MilvusClient\.add_function_field",
+            ):
+                client.add_collection_function("col", MagicMock())
             handler.add_collection_function.assert_called_once()
 
     def test_alter_collection_function_delegates(self):
@@ -1652,13 +1657,13 @@ class TestMilvusClientCollectionMgmt:
         handler = _make_handler()
         with patch("pymilvus.client.grpc_handler.GrpcHandler", return_value=handler):
             client = MilvusClient()
-            client.drop_collection_function("col", "fn")
-            handler.alter_collection_schema.assert_called_once()
-            assert handler.alter_collection_schema.call_args.kwargs["drop_function_name"] == "fn"
-            assert not handler.alter_collection_schema.call_args.kwargs[
-                "drop_function_output_fields"
-            ]
-            handler.drop_collection_function.assert_not_called()
+            with pytest.warns(
+                PyMilvusDeprecationWarning,
+                match=r"MilvusClient\.drop_collection_function.*Milvus 3\.0.*MilvusClient\.drop_function_field",
+            ):
+                client.drop_collection_function("col", "fn")
+            handler.drop_collection_function.assert_called_once()
+            handler.alter_collection_schema.assert_not_called()
 
     def test_drop_function_field_delegates(self):
         handler = _make_handler()


### PR DESCRIPTION
Cherry-pick from master
pr: #3704

issue: #3128

## What changed

- Route synchronous and asynchronous `add_collection_field` through a field-only `AlterCollectionSchema` AddRequest.
- Fall back to the legacy `AddCollectionField` RPC only when an older server returns gRPC `UNIMPLEMENTED`.
- Invalidate the schema cache after either add-field path succeeds.
- Restore synchronous and asynchronous `drop_collection_function` to the original `DropCollectionFunction` RPC.
- Keep the destructive `drop_function_field` operation on `AlterCollectionSchema`.
- Deprecate `add_collection_function` and `drop_collection_function` in favor of `add_function_field` and `drop_function_field`, because Milvus 3.0 no longer supports separate function attachment and detachment.

## Why

This keeps the 3.0 SDK aligned with the master schema-mutation routing while preserving compatibility with older Milvus servers that support `AddCollectionField` but do not expose `AlterCollectionSchema`.

The fallback is restricted to gRPC `UNIMPLEMENTED`; permission failures, validation failures, and server status errors are not retried through the legacy RPC.

Restoring `drop_collection_function` preserves its established wire and privilege contract. It does not claim to enable function detachment; the supported destructive operation remains `drop_function_field`, which deletes the function together with its output field and index.

Related Milvus issue: https://github.com/milvus-io/milvus/issues/48983

## Test Plan

- [x] Four related sync/async unit-test files: 506 passed
- [x] Ruff checks for changed files
- [x] `git diff --check`
- [x] Stable patch-id matches master commit `c5dcb2438f59cbadc8c4aff5dc549b67066c96bb`
- [x] The master compatibility path was validated against a local Milvus 2.6 server for both sync and async clients: Alter returned `UNIMPLEMENTED`, the legacy RPC succeeded, the new field appeared in the schema, and inserts using it succeeded