### PR TITLE
fix: handle unimplemented errors from async methods

### DIFF
--- a/pymilvus/decorators.py
+++ b/pymilvus/decorators.py
@@ -571,6 +571,22 @@ def tracing_request():
 
 def ignore_unimplemented(default_return_value: Any):
     def wrapper(func: Callable):
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_handler(*args, **kwargs):
+                try:
+                    return await func(*args, **kwargs)
+                except grpc.RpcError as e:
+                    if e.code() == grpc.StatusCode.UNIMPLEMENTED:
+                        LOGGER.debug(f"{func.__name__} unimplemented, ignore it")
+                        return default_return_value
+                    raise e from e
+                except Exception as e:
+                    raise e from e
+
+            return async_handler
+
         @functools.wraps(func)
         def handler(*args, **kwargs):
             try:

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -586,6 +586,14 @@ class TestIgnoreUnimplementedDecorator:
         result = unimplemented_func()
         assert result == "default"
 
+    def test_ignore_unimplemented_returns_default_for_async_function(self):
+        @ignore_unimplemented(default_return_value="default")
+        async def unimplemented_func():
+            raise MockUnimplementedError
+
+        assert asyncio.iscoroutinefunction(unimplemented_func)
+        assert asyncio.run(unimplemented_func()) == "default"
+
     def test_ignore_unimplemented_raises_other_grpc_errors(self):
         @ignore_unimplemented(default_return_value="default")
         def unavailable_func():


### PR DESCRIPTION
Closes #3711

`ignore_unimplemented` now preserves async callables and catches `UNIMPLEMENTED` errors raised while awaiting them. This lets the async Milvus Lite timestamp fallback return its configured default instead of leaking the gRPC error.

Added a regression test covering coroutine detection and the async fallback. The focused decorator tests and Ruff checks pass.
