### PR TITLE
fix: fallback add field for external collections

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -69,6 +69,7 @@ from .utils import (
     check_status,
     get_server_type,
     immutable_message_to_dict,
+    is_external_collection_schema_alter_unsupported,
     is_successful,
     len_of,
     replicate_checkpoint_to_dict,
@@ -1596,14 +1597,21 @@ class AsyncGrpcHandler:
             collection_name=collection_name,
             field_schema=field_schema,
         )
+        fallback_to_legacy = False
         try:
             response = await self._async_stub.AlterCollectionSchema(
                 request, timeout=timeout, metadata=_api_level_md(context)
             )
-            check_status(response.alter_status)
+            if is_external_collection_schema_alter_unsupported(response.alter_status):
+                fallback_to_legacy = True
+            else:
+                check_status(response.alter_status)
         except grpc.RpcError as e:
             if e.code() != grpc.StatusCode.UNIMPLEMENTED:
                 raise
+            fallback_to_legacy = True
+
+        if fallback_to_legacy:
             legacy_request = Prepare.add_collection_field_request(collection_name, field_schema)
             status = await self._async_stub.AddCollectionField(
                 legacy_request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -91,6 +91,7 @@ from .utils import (
     check_status,
     get_server_type,
     immutable_message_to_dict,
+    is_external_collection_schema_alter_unsupported,
     is_successful,
     len_of,
     replicate_checkpoint_to_dict,
@@ -551,14 +552,21 @@ class GrpcHandler:
             collection_name=collection_name,
             field_schema=field_schema,
         )
+        fallback_to_legacy = False
         try:
             response = self._stub.AlterCollectionSchema(
                 request, timeout=timeout, metadata=_api_level_md(context)
             )
-            check_status(response.alter_status)
+            if is_external_collection_schema_alter_unsupported(response.alter_status):
+                fallback_to_legacy = True
+            else:
+                check_status(response.alter_status)
         except grpc.RpcError as e:
             if e.code() != grpc.StatusCode.UNIMPLEMENTED:
                 raise
+            fallback_to_legacy = True
+
+        if fallback_to_legacy:
             legacy_request = Prepare.add_collection_field_request(collection_name, field_schema)
             status = self._stub.AddCollectionField(
                 legacy_request, timeout=timeout, metadata=_api_level_md(context)

--- a/pymilvus/client/utils.py
+++ b/pymilvus/client/utils.py
@@ -77,6 +77,14 @@ def check_status(status: common_pb2.Status):
         raise MilvusException.from_status(status)
 
 
+def is_external_collection_schema_alter_unsupported(status: common_pb2.Status) -> bool:
+    is_parameter_invalid = status.code == 1100 or status.error_code == common_pb2.IllegalArgument
+    return is_parameter_invalid and (
+        "alter collection schema operation is not supported for external collection"
+        in status.reason
+    )
+
+
 def is_successful(status: common_pb2.Status):
     return status.code == 0 and status.error_code == 0
 

--- a/tests/unit/async_grpc_handler/test_async_collection.py
+++ b/tests/unit/async_grpc_handler/test_async_collection.py
@@ -692,6 +692,47 @@ class TestAsyncGrpcHandlerCollectionProperties:
             GlobalCache._reset_for_testing()
 
     @pytest.mark.asyncio
+    async def test_add_collection_field_falls_back_for_external_collection(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        handler._is_channel_ready = True
+        handler.ensure_channel_ready = AsyncMock()
+
+        mock_stub = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.alter_status = common_pb2.Status(
+            code=1100,
+            error_code=common_pb2.IllegalArgument,
+            reason=(
+                "alter collection schema operation is not supported for external collection "
+                "test_coll: invalid parameter"
+            ),
+        )
+        mock_stub.AlterCollectionSchema = AsyncMock(return_value=mock_response)
+        legacy_status = MagicMock(code=0, error_code=0, reason="")
+        mock_stub.AddCollectionField = AsyncMock(return_value=legacy_status)
+        handler._async_stub = mock_stub
+
+        mock_field_schema = MagicMock()
+        legacy_request = MagicMock()
+        with patch("pymilvus.client.async_grpc_handler.Prepare") as mock_prepare, patch(
+            "pymilvus.client.async_grpc_handler.check_pass_param"
+        ), patch("pymilvus.client.async_grpc_handler.check_status") as mock_check_status:
+            mock_prepare.alter_collection_schema_request.return_value = MagicMock()
+            mock_prepare.add_collection_field_request.return_value = legacy_request
+
+            await handler.add_collection_field("test_coll", mock_field_schema)
+
+            mock_stub.AlterCollectionSchema.assert_awaited_once()
+            mock_prepare.add_collection_field_request.assert_called_once_with(
+                "test_coll", mock_field_schema
+            )
+            mock_stub.AddCollectionField.assert_awaited_once()
+            assert mock_stub.AddCollectionField.call_args.args[0] is legacy_request
+            mock_check_status.assert_called_once_with(legacy_status)
+
+    @pytest.mark.asyncio
     async def test_add_collection_struct_field(self) -> None:
         """Test add_collection_struct_field async API"""
         mock_channel = MagicMock()

--- a/tests/unit/grpc_handler/test_collection.py
+++ b/tests/unit/grpc_handler/test_collection.py
@@ -8,7 +8,7 @@ import pytest
 from pymilvus import FieldSchema, Function, FunctionType, StructFieldSchema
 from pymilvus.client.cache import GlobalCache
 from pymilvus.client.types import DataType
-from pymilvus.exceptions import DescribeCollectionException
+from pymilvus.exceptions import DescribeCollectionException, MilvusException
 from pymilvus.grpc_gen import common_pb2, schema_pb2
 
 from .conftest import (
@@ -242,6 +242,50 @@ class TestGrpcHandlerCollectionProperties:
         assert field_schema.name == "new_field"
         assert GlobalCache.schema.get(handler.server_address, "", "coll") is None
         GlobalCache._reset_for_testing()
+
+    def test_add_collection_field_falls_back_for_external_collection(self, handler):
+        response = MagicMock()
+        response.alter_status = common_pb2.Status(
+            code=1100,
+            error_code=common_pb2.IllegalArgument,
+            reason=(
+                "alter collection schema operation is not supported for external collection coll: "
+                "invalid parameter"
+            ),
+        )
+        handler._stub.AlterCollectionSchema.return_value = response
+        handler._stub.AddCollectionField.return_value = make_status()
+        field = FieldSchema(
+            name="new_field",
+            dtype=DataType.VARCHAR,
+            max_length=256,
+            external_field="source_field",
+        )
+
+        handler.add_collection_field("coll", field)
+
+        handler._stub.AlterCollectionSchema.assert_called_once()
+        handler._stub.AddCollectionField.assert_called_once()
+        request = handler._stub.AddCollectionField.call_args.args[0]
+        field_schema = schema_pb2.FieldSchema()
+        field_schema.ParseFromString(request.schema)
+        assert field_schema.name == "new_field"
+        assert field_schema.external_field == "source_field"
+
+    def test_add_collection_field_does_not_fallback_for_other_business_errors(self, handler):
+        response = MagicMock()
+        response.alter_status = common_pb2.Status(
+            code=1100,
+            error_code=common_pb2.IllegalArgument,
+            reason="invalid add field request",
+        )
+        handler._stub.AlterCollectionSchema.return_value = response
+        field = FieldSchema(name="new_field", dtype=DataType.VARCHAR, max_length=256)
+
+        with pytest.raises(MilvusException, match="invalid add field request"):
+            handler.add_collection_field("coll", field)
+
+        handler._stub.AddCollectionField.assert_not_called()
 
     def test_add_collection_struct_field(self, handler):
         handler._stub.AddCollectionStructField.return_value = make_status()


### PR DESCRIPTION
## What changed

- Detect the explicit parameter-invalid status returned when `AlterCollectionSchema` is used on an external collection.
- Fall back to the legacy `AddCollectionField` RPC for that compatibility case in synchronous and asynchronous handlers.
- Preserve all unrelated business and permission errors without fallback.
- Cover the real wire status and verify that `external_field` metadata survives the legacy request.

## Why

After https://github.com/milvus-io/pymilvus/pull/3704, `add_collection_field` first uses the unified `AlterCollectionSchema` RPC. Milvus currently rejects that RPC for external collections with code `1100`, legacy `IllegalArgument`, and the reason `alter collection schema operation is not supported for external collection ...`.

The legacy `AddCollectionField` RPC supports external collections and validates their `external_field` mappings. Without this compatibility fallback, a valid public `add_collection_field` call fails before reaching the supported path.

issue: #3726

Related schema-routing PR: https://github.com/milvus-io/pymilvus/pull/3704

## Test plan

- [x] Sync and async collection handler unit tests: `74 passed`
- [x] Ruff checks for all changed files
- [x] Black format verification for all changed files
- [x] `git diff --check`
- [x] Local Milvus external-table L0 E2E: add scalar field, refresh, load, query, and filter (`1 passed`)
- [x] Local RPC spy verified `AlterCollectionSchema(code=1100, error_code=IllegalArgument)` followed by `AddCollectionField(success)`
- [x] Described schema retained `nullable=True` and `external_field="score"`
