### PR TITLE
fix: unbound `dim`/`num` variables in partition example

### DIFF
--- a/examples/orm_deprecated/partition.py
+++ b/examples/orm_deprecated/partition.py
@@ -75,7 +75,7 @@ def gen_data(nb):
     entities = [
         [i for i in range(nb)],
         [float(i) for i in range(nb)],
-        [[random.random() for _ in range(dim)] for _ in range(num)],
+        [[random.random() for _ in range(default_dim)] for _ in range(nb)],
     ]
     return entities
 


### PR DESCRIPTION
Hello. Noticed a small error in `examples/orm_deprecated/partition.py`. 

`gen_data` is using `dim` and `num` variables, though they're never defined.

https://github.com/milvus-io/pymilvus/blob/08f7e10bbf88aad2957d7d5b27cb6eee68033bc0/examples/orm_deprecated/partition.py#L74-L80

The issue occurred after commit b9a10c9c41708d4b4d3735d4d1f76713872e31ba

<img width="920" height="409" alt="image" src="https://github.com/user-attachments/assets/7c2c2b90-2778-42f5-9e1b-d322db8ca4c5" />

To fix this I've used `default_dim` instead of `dim` (as it was originally used in `gen_data`, see screenshot above) and `nb` instead of `num`.

https://github.com/milvus-io/pymilvus/blob/395957bb1b1e87520f8ccfa1929f9270fe2e19c3/examples/orm_deprecated/partition.py#L74-L80