### PR TITLE
perf: vectorise the bloom filter string insert and add a streaming builder

### DIFF
--- a/pymilvus/__init__.py
+++ b/pymilvus/__init__.py
@@ -19,7 +19,7 @@ __path__ = extend_path(__path__, __name__)
 from .client import __version__
 from .client.abstract import AnnSearchRequest, RRFRanker, WeightedRanker
 from .client.asynch import SearchFuture
-from .client.bloom_filter import build_bloom_filter
+from .client.bloom_filter import BloomFilterBuilder, build_bloom_filter
 from .client.field_ops import FieldOp, FieldOpType
 from .client.prepare import Prepare
 from .client.search_aggregation import (
@@ -100,6 +100,7 @@ __all__ = [
     "AggregationHit",
     "AnnSearchRequest",
     "AsyncMilvusClient",
+    "BloomFilterBuilder",
     "BulkInsertState",
     "Collection",
     "CollectionSchema",

--- a/pymilvus/client/bloom_filter.py
+++ b/pymilvus/client/bloom_filter.py
@@ -1,7 +1,7 @@
 import math
 import struct
 from itertools import islice
-from typing import Sequence, Union
+from typing import Any, Iterable, Iterator, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -159,56 +159,134 @@ _NP_32 = np.uint64(32)
 _NP_MASK32 = np.uint64(0xFFFFFFFF)
 
 
-def _fill_int64_vectorised(buf: bytearray, members: Sequence[int], num_blocks: int) -> None:
-    """Hash and insert INT64 members with numpy, mirroring :func:`_xxh64_int64_python` exactly.
+def _int64_digests(lanes: np.ndarray) -> np.ndarray:
+    """Vectorised XXH64 over each lane's 8-byte little-endian encoding.
 
-    ``np.fromiter`` performs the int64 range check in C, so out-of-range members surface as
-    OverflowError instead of costing a per-member Python comparison.
+    Mirrors :func:`_xxh64_int64_python` exactly, one numpy op per step.
     """
-    # np.fromiter coerces silently where the scalar path raises: bool (an int subclass) becomes
-    # 0/1 and float is truncated. Screen the distinct types up front -- map(type, ...) runs at C
-    # speed, and the common all-int case settles in one set comparison.
-    member_types = set(map(type, members))
+    accumulator = lanes.view(np.uint64) * _NP_P2
+    accumulator = ((accumulator << np.uint64(31)) | (accumulator >> np.uint64(33))) * _NP_P1
+    digest = _NP_SEED_LEN8 ^ accumulator
+    digest = ((digest << np.uint64(27)) | (digest >> np.uint64(37))) * _NP_P1 + _NP_P4
+    digest ^= digest >> np.uint64(33)
+    digest *= _NP_P2
+    digest ^= digest >> np.uint64(29)
+    digest *= _NP_P3
+    digest ^= digest >> _NP_32
+    return digest
+
+
+def _insert_digests(words: np.ndarray, digests: np.ndarray, num_blocks: int) -> None:
+    """OR one chunk of XXH64 digests into the filter body.
+
+    Split out from the hashing so both domains share it: the UTF-8 domain cannot vectorise its
+    hash (XXH64's stripe and tail loops depend on each member's byte length) but its digests
+    land in exactly the same bit positions, and doing this part per member in Python costs far
+    more than the hashing does -- 10M strings hash in 0.4s with the C accelerator while the
+    scalar insert loop they used to feed took ~10s.
+    """
+    blocks = np.uint64(num_blocks)
+    word_base = (((digests >> _NP_32) * blocks) >> _NP_32).astype(np.intp) * 8
+    key = (digests & _NP_MASK32).astype(np.uint32)
+    for index, salt in enumerate(_NP_SALT):
+        bit = np.uint32(1) << ((key * salt) >> np.uint32(27))
+        # Unbuffered: several members routinely land in the same block, so the OR has to
+        # accumulate rather than let one write win.
+        np.bitwise_or.at(words, word_base + index, bit)
+
+
+def _screen_int_members(chunk: Sequence[int]) -> None:
+    """Reject anything np.fromiter would silently coerce.
+
+    ``np.fromiter`` accepts where the scalar path raises: bool (an int subclass) becomes 0/1
+    and float is truncated. ``map(type, ...)`` runs at C speed and the common all-int case
+    settles in one set comparison.
+    """
+    member_types = set(map(type, chunk))
     if member_types != {int}:
         for member_type in member_types:
             if member_type is bool or not issubclass(member_type, int):
                 raise ParamError(message="bloom filter members must be all int or all str")
 
-    words = np.frombuffer(buf, dtype=_WORD_DTYPE, offset=_HEADER_SIZE)
-    blocks = np.uint64(num_blocks)
-    values = iter(members)
-    remaining = len(members)
 
-    while remaining:
-        size = _VECTOR_CHUNK if remaining > _VECTOR_CHUNK else remaining
+def _chunks(values: Iterable[Any]) -> Iterator[Tuple[Iterable[Any], int]]:
+    """Yield ``(chunk, size)`` pairs of at most ``_VECTOR_CHUNK`` members each.
+
+    A list or tuple is already measurable, so its chunks are handed out as lazy ``islice``
+    views and never copied -- materialising them into per-chunk lists costs ~4% on a 10M
+    build for nothing. Anything else is a one-shot iterable (a generator, a DB cursor) whose
+    length is unknown, so a chunk has to be pulled into a list before ``np.fromiter`` can be
+    given a count. That bounded copy is exactly the trade the builder exists to make: one
+    chunk resident instead of the whole set.
+
+    The lazy chunks must be consumed before the next iteration, which every caller does.
+    """
+    if isinstance(values, (list, tuple)):
+        iterator = iter(values)
+        remaining = len(values)
+        while remaining:
+            size = _VECTOR_CHUNK if remaining > _VECTOR_CHUNK else remaining
+            yield islice(iterator, size), size
+            remaining -= size
+        return
+    iterator = iter(values)
+    while True:
+        chunk = list(islice(iterator, _VECTOR_CHUNK))
+        if not chunk:
+            return
+        yield chunk, len(chunk)
+
+
+def _add_int64_chunks(words: np.ndarray, values: Iterable[int], num_blocks: int) -> bool:
+    """Hash and insert integer members a chunk at a time. Returns whether anything was added."""
+    # A sequence can be screened in one C-speed pass; a one-shot iterable has to be screened
+    # per chunk, since by then the earlier members are gone.
+    prescreened = isinstance(values, (list, tuple))
+    if prescreened:
+        _screen_int_members(values)
+    added = False
+    for chunk, size in _chunks(values):
+        added = True
+        if not prescreened:
+            _screen_int_members(chunk)
         try:
-            lanes = np.fromiter(islice(values, size), dtype=np.int64, count=size)
+            lanes = np.fromiter(chunk, dtype=np.int64, count=size)
         except OverflowError as exc:
             raise ParamError(
                 message="integer bloom filter members must fit in signed int64"
             ) from exc
         except (TypeError, ValueError) as exc:
             raise ParamError(message="bloom filter members must be all int or all str") from exc
+        _insert_digests(words, _int64_digests(lanes), num_blocks)
+    return added
 
-        accumulator = lanes.view(np.uint64) * _NP_P2
-        accumulator = ((accumulator << np.uint64(31)) | (accumulator >> np.uint64(33))) * _NP_P1
-        digest = _NP_SEED_LEN8 ^ accumulator
-        digest = ((digest << np.uint64(27)) | (digest >> np.uint64(37))) * _NP_P1 + _NP_P4
-        digest ^= digest >> np.uint64(33)
-        digest *= _NP_P2
-        digest ^= digest >> np.uint64(29)
-        digest *= _NP_P3
-        digest ^= digest >> _NP_32
 
-        word_base = (((digest >> _NP_32) * blocks) >> _NP_32).astype(np.intp) * 8
-        key = (digest & _NP_MASK32).astype(np.uint32)
-        for index, salt in enumerate(_NP_SALT):
-            bit = np.uint32(1) << ((key * salt) >> np.uint32(27))
-            # Unbuffered: several members routinely land in the same block, so the OR has to
-            # accumulate rather than let one write win.
-            np.bitwise_or.at(words, word_base + index, bit)
+def _add_string_chunks(words: np.ndarray, values: Iterable[str], num_blocks: int) -> bool:
+    """Hash and insert string members a chunk at a time. Returns whether anything was added."""
+    added = False
+    hash_bytes = _xxh64
+    for chunk, size in _chunks(values):
+        added = True
+        try:
+            digests = np.fromiter(
+                (hash_bytes(value.encode("utf-8")) for value in chunk),
+                dtype=np.uint64,
+                count=size,
+            )
+        except AttributeError as exc:
+            raise ParamError(message="bloom filter members must be all int or all str") from exc
+        _insert_digests(words, digests, num_blocks)
+    return added
 
-        remaining -= size
+
+def _fill_int64_vectorised(buf: bytearray, members: Sequence[int], num_blocks: int) -> None:
+    """Hash and insert INT64 members with numpy, in place, into an already-sized buffer.
+
+    Retained as the entry point this module used before :class:`BloomFilterBuilder` existed;
+    it now just drives the shared chunk loop.
+    """
+    words = np.frombuffer(buf, dtype=_WORD_DTYPE, offset=_HEADER_SIZE)
+    _add_int64_chunks(words, members, num_blocks)
 
 
 def _optimal_num_bytes(count: int, fpr: float) -> int:
@@ -220,44 +298,123 @@ def _optimal_num_bytes(count: int, fpr: float) -> int:
     return min(num_bits, _MAX_FILTER_BYTES * 8) // 8
 
 
-def build_bloom_filter(members: Sequence[Union[int, str]], fpr: float = _DEFAULT_FPR) -> bytes:
-    """Build an MBF1-wrapped Parquet Split-Block Bloom filter for bloom_match.
-
-    Integer members target INT8/INT16/INT32/INT64 fields; string members target
-    VARCHAR fields. The returned bytes are passed through ``filter_params``.
-    """
+def _validate_fpr(fpr: float) -> float:
     if (
         not isinstance(fpr, (int, float))
         or not math.isfinite(fpr)
         or not _MIN_FPR <= fpr <= _MAX_FPR
     ):
         raise ParamError(message=f"bloom filter fpr must be in [{_MIN_FPR}, {_MAX_FPR}]")
+    return float(fpr)
+
+
+class BloomFilterBuilder:
+    """Incrementally builds the blob :func:`build_bloom_filter` returns in one shot.
+
+    Use this when the membership set does not comfortably fit in memory as a list. The filter
+    is a fixed-size bit array sized from ``n`` and ``fpr`` alone -- never from the values --
+    and insertion is order-independent and idempotent, so members can be streamed in from a
+    cursor, a file or a paginated API and dropped as they go. Peak memory is then the filter
+    itself (32 MiB for 24M members at the default fpr) rather than the filter plus the list;
+    a 10M-element Python list of ints costs roughly 400 MB on its own.
+
+    ``n`` only drives sizing. Adding more than ``n`` members is allowed and simply raises the
+    effective false-positive rate above the target; adding fewer leaves the filter larger than
+    it needed to be. A rough estimate is enough.
+
+    Both add methods take an **iterable**, not one member at a time: they hash a chunk at a
+    time with numpy, and a per-member Python call would cost more than the hashing does.
+    Accumulate into batches of a few thousand and hand those over.
+
+    .. code-block:: python
+
+        builder = BloomFilterBuilder(10_000_000, fpr=0.005)
+        for chunk in read_ids_in_chunks(conn, size=100_000):
+            builder.add_int64_batch(chunk)
+        blob = builder.build()
+
+    Build the filter from the SAME value domain as the target field: integer fields hash
+    int64, VARCHAR fields hash UTF-8. Mixing both domains in one filter is allowed here (a
+    JSON path may legitimately hold both) but :func:`build_bloom_filter` rejects it.
+    """
+
+    def __init__(self, n: int, fpr: float = _DEFAULT_FPR) -> None:
+        self._fpr = _validate_fpr(fpr)
+        if not isinstance(n, int) or isinstance(n, bool) or n < 0:
+            raise ParamError(message="bloom filter member count must be a non-negative int")
+        num_bytes = _optimal_num_bytes(n, self._fpr)
+        self._num_blocks = num_bytes // 32
+        self._n = n
+        self._domains = 0
+        # The header is reserved in place so the blob is assembled in one buffer. Concatenating
+        # a separate header would hold the body, its bytes() copy and the joined result live at
+        # once, tripling peak memory for large member sets.
+        self._buf = bytearray(_HEADER_SIZE + num_bytes)
+        self._words = np.frombuffer(self._buf, dtype=_WORD_DTYPE, offset=_HEADER_SIZE)
+
+    def add_int64_batch(self, values: Iterable[int]) -> "BloomFilterBuilder":
+        """Inserts integer members, hashed as their 8-byte little-endian encoding."""
+        if _add_int64_chunks(self._words, values, self._num_blocks):
+            self._domains |= _DOMAIN_INT64
+        return self
+
+    def add_string_batch(self, values: Iterable[str]) -> "BloomFilterBuilder":
+        """Inserts string members, hashed as their raw UTF-8 bytes."""
+        if _add_string_chunks(self._words, values, self._num_blocks):
+            self._domains |= _DOMAIN_UTF8
+        return self
+
+    @property
+    def domains(self) -> int:
+        """The value domains inserted so far. Zero means nothing was inserted."""
+        return self._domains
+
+    @property
+    def num_blocks(self) -> int:
+        """The number of 32-byte blocks in the filter body."""
+        return self._num_blocks
+
+    def build(self) -> bytes:
+        """Stamps the MBF1 header and returns a copy of the envelope."""
+        struct.pack_into(
+            _HEADER_FORMAT,
+            self._buf,
+            0,
+            b"MBF1",
+            1,
+            1,
+            self._n,
+            self._fpr,
+            self._num_blocks,
+            self._domains,
+        )
+        return bytes(self._buf)
+
+
+def build_bloom_filter(members: Sequence[Union[int, str]], fpr: float = _DEFAULT_FPR) -> bytes:
+    """Build an MBF1-wrapped Parquet Split-Block Bloom filter for bloom_match.
+
+    Integer members target INT8/INT16/INT32/INT64 fields; string members target
+    VARCHAR fields. The returned bytes are passed through ``filter_params``.
+
+    Members must be homogeneous -- all int or all str. For a set too large to materialise as
+    a list, stream it through :class:`BloomFilterBuilder` instead.
+    """
+    _validate_fpr(fpr)
     if not isinstance(members, (list, tuple)):
         raise ParamError(message="bloom filter members must be a list or tuple of int or str")
+
+    builder = BloomFilterBuilder(len(members), fpr)
     if not members:
-        domain = 0
+        pass
     elif isinstance(members[0], int) and not isinstance(members[0], bool):
-        domain = _DOMAIN_INT64
+        builder.add_int64_batch(members)
     elif isinstance(members[0], str):
-        domain = _DOMAIN_UTF8
+        builder.add_string_batch(members)
     else:
         raise ParamError(message="bloom filter members must be all int or all str")
 
-    count = len(members)
-    num_bytes = _optimal_num_bytes(count, float(fpr))
-    num_blocks = num_bytes // 32
-    # Reserve the header in place so the blob is assembled in one buffer. Concatenating a separate
-    # header would hold the body, its bytes() copy and the joined result live at once, tripling
-    # peak memory for large member sets.
-    buf = bytearray(_HEADER_SIZE + num_bytes)
-    struct.pack_into(_HEADER_FORMAT, buf, 0, b"MBF1", 1, 1, count, float(fpr), num_blocks, domain)
-
-    if domain == _DOMAIN_INT64:
-        _fill_int64_vectorised(buf, members, num_blocks)
-    elif domain == _DOMAIN_UTF8:
-        _fill_scalar(buf, members, domain, num_blocks)
-
-    return bytes(buf)
+    return builder.build()
 
 
 def _fill_scalar(

--- a/pymilvus/client/bloom_filter.py
+++ b/pymilvus/client/bloom_filter.py
@@ -41,6 +41,15 @@ _BLOCK_STRUCT = struct.Struct("<8I")
 # on a big-endian client would emit byte-swapped block words that a little-endian server reads
 # as different bit positions.
 _WORD_DTYPE = np.dtype("<u4")
+# The body is also viewed 64 bits at a time so one scatter covers two of a block's eight
+# words. Pinned little-endian for the same reason _WORD_DTYPE is: a host-native dtype would
+# emit byte-swapped lanes on a big-endian client.
+_WORD64_DTYPE = np.dtype("<u8")
+# A 32-byte block is four uint64 lanes.
+_LANES_PER_BLOCK = 4
+# Buffered retries before falling back to the unbuffered scatter. Three covers the collision
+# rate a well-sized filter produces; the cap is what stops an oversubscribed one degenerating.
+_MAX_BUFFERED_PASSES = 3
 
 
 def _rotl64(value: int, count: int) -> int:
@@ -184,15 +193,40 @@ def _insert_digests(words: np.ndarray, digests: np.ndarray, num_blocks: int) -> 
     land in exactly the same bit positions, and doing this part per member in Python costs far
     more than the hashing does -- 10M strings hash in 0.4s with the C accelerator while the
     scalar insert loop they used to feed took ~10s.
+
+    Two things make this faster than the obvious ``np.bitwise_or.at`` per word:
+
+    * ``words`` is a uint64 view, so each 64-bit lane carries two of the block's eight 32-bit
+      words and the scatter runs four times per member instead of eight. The view dtype pins
+      little-endian, so lane = word[2i] | word[2i+1] << 32 holds on any host.
+    * The scatter itself is a buffered ``words[idx] |= bits`` rather than the unbuffered
+      ``ufunc.at``, which is an order of magnitude slower. A buffered scatter silently drops
+      all but one write when indices repeat -- and they do repeat, since a 16384-member chunk
+      landing in 524288 blocks collides a couple of hundred times -- but OR is idempotent and
+      order-independent, so the writes that lost can simply be retried. Together: 2x.
+
+    Retries are capped and the remainder handed to ``ufunc.at``. Without the cap a filter
+    whose blocks are heavily oversubscribed (``BloomFilterBuilder(1, fpr)`` fed a million
+    members, which the API allows) degenerates to one pass per colliding member and runs 11x
+    *slower* than the unbuffered scatter it replaced.
     """
     blocks = np.uint64(num_blocks)
-    word_base = (((digests >> _NP_32) * blocks) >> _NP_32).astype(np.intp) * 8
+    lane_base = (((digests >> _NP_32) * blocks) >> _NP_32).astype(np.intp) * _LANES_PER_BLOCK
     key = (digests & _NP_MASK32).astype(np.uint32)
-    for index, salt in enumerate(_NP_SALT):
-        bit = np.uint32(1) << ((key * salt) >> np.uint32(27))
-        # Unbuffered: several members routinely land in the same block, so the OR has to
-        # accumulate rather than let one write win.
-        np.bitwise_or.at(words, word_base + index, bit)
+    masks = [np.uint64(1) << ((key * salt) >> np.uint32(27)).astype(np.uint64) for salt in _NP_SALT]
+
+    for lane in range(_LANES_PER_BLOCK):
+        index = lane_base + lane
+        bits = masks[2 * lane] | (masks[2 * lane + 1] << _NP_32)
+        for _ in range(_MAX_BUFFERED_PASSES):
+            words[index] |= bits
+            stale = (words[index] & bits) != bits
+            if not stale.any():
+                break
+            index = index[stale]
+            bits = bits[stale]
+        else:
+            np.bitwise_or.at(words, index, bits)
 
 
 def _screen_int_members(chunk: Sequence[int]) -> None:
@@ -285,7 +319,7 @@ def _fill_int64_vectorised(buf: bytearray, members: Sequence[int], num_blocks: i
     Retained as the entry point this module used before :class:`BloomFilterBuilder` existed;
     it now just drives the shared chunk loop.
     """
-    words = np.frombuffer(buf, dtype=_WORD_DTYPE, offset=_HEADER_SIZE)
+    words = np.frombuffer(buf, dtype=_WORD64_DTYPE, offset=_HEADER_SIZE)
     _add_int64_chunks(words, members, num_blocks)
 
 
@@ -350,7 +384,7 @@ class BloomFilterBuilder:
         # a separate header would hold the body, its bytes() copy and the joined result live at
         # once, tripling peak memory for large member sets.
         self._buf = bytearray(_HEADER_SIZE + num_bytes)
-        self._words = np.frombuffer(self._buf, dtype=_WORD_DTYPE, offset=_HEADER_SIZE)
+        self._words = np.frombuffer(self._buf, dtype=_WORD64_DTYPE, offset=_HEADER_SIZE)
 
     def add_int64_batch(self, values: Iterable[int]) -> "BloomFilterBuilder":
         """Inserts integer members, hashed as their 8-byte little-endian encoding."""

--- a/pymilvus/client/bloom_filter.py
+++ b/pymilvus/client/bloom_filter.py
@@ -1,7 +1,8 @@
 import math
 import struct
 from itertools import islice
-from typing import Any, Iterable, Iterator, Sequence, Tuple, Union
+from threading import Lock
+from typing import Any, Callable, Iterable, Iterator, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -37,13 +38,9 @@ _HEADER_SIZE = struct.calcsize(_HEADER_FORMAT)
 # One SBBF block is eight little-endian uint32 words; read and write it in a single call so the
 # hot loop does two struct operations per member instead of sixteen.
 _BLOCK_STRUCT = struct.Struct("<8I")
-# The numpy view over those words must pin the same byte order: np.uint32 is host-native, which
-# on a big-endian client would emit byte-swapped block words that a little-endian server reads
-# as different bit positions.
-_WORD_DTYPE = np.dtype("<u4")
 # The body is also viewed 64 bits at a time so one scatter covers two of a block's eight
-# words. Pinned little-endian for the same reason _WORD_DTYPE is: a host-native dtype would
-# emit byte-swapped lanes on a big-endian client.
+# words. The dtype is pinned little-endian: a host-native dtype would emit byte-swapped lanes
+# on a big-endian client.
 _WORD64_DTYPE = np.dtype("<u8")
 # A 32-byte block is four uint64 lanes.
 _LANES_PER_BLOCK = 4
@@ -243,6 +240,15 @@ def _screen_int_members(chunk: Sequence[int]) -> None:
                 raise ParamError(message="bloom filter members must be all int or all str")
 
 
+def _screen_string_members(chunk: Sequence[str]) -> None:
+    """Reject non-strings before calling their potentially string-like methods."""
+    member_types = set(map(type, chunk))
+    if member_types != {str}:
+        for member_type in member_types:
+            if not issubclass(member_type, str):
+                raise ParamError(message="bloom filter members must be all int or all str")
+
+
 def _chunks(values: Iterable[Any]) -> Iterator[Tuple[Iterable[Any], int]]:
     """Yield ``(chunk, size)`` pairs of at most ``_VECTOR_CHUNK`` members each.
 
@@ -271,16 +277,19 @@ def _chunks(values: Iterable[Any]) -> Iterator[Tuple[Iterable[Any], int]]:
         yield chunk, len(chunk)
 
 
-def _add_int64_chunks(words: np.ndarray, values: Iterable[int], num_blocks: int) -> bool:
-    """Hash and insert integer members a chunk at a time. Returns whether anything was added."""
+def _add_int64_chunks(
+    words: np.ndarray,
+    values: Iterable[int],
+    num_blocks: int,
+    commit: Callable[[], None],
+) -> None:
+    """Hash and insert integer members a chunk at a time."""
     # A sequence can be screened in one C-speed pass; a one-shot iterable has to be screened
     # per chunk, since by then the earlier members are gone.
     prescreened = isinstance(values, (list, tuple))
     if prescreened:
         _screen_int_members(values)
-    added = False
     for chunk, size in _chunks(values):
-        added = True
         if not prescreened:
             _screen_int_members(chunk)
         try:
@@ -291,36 +300,33 @@ def _add_int64_chunks(words: np.ndarray, values: Iterable[int], num_blocks: int)
             ) from exc
         except (TypeError, ValueError) as exc:
             raise ParamError(message="bloom filter members must be all int or all str") from exc
+        # The body cannot be rolled back without copying the whole filter. Mark the domain before
+        # mutation so a failure during this or a later chunk leaves a valid partial commit.
+        commit()
         _insert_digests(words, _int64_digests(lanes), num_blocks)
-    return added
 
 
-def _add_string_chunks(words: np.ndarray, values: Iterable[str], num_blocks: int) -> bool:
-    """Hash and insert string members a chunk at a time. Returns whether anything was added."""
-    added = False
+def _add_string_chunks(
+    words: np.ndarray,
+    values: Iterable[str],
+    num_blocks: int,
+    commit: Callable[[], None],
+) -> None:
+    """Hash and insert string members a chunk at a time."""
+    prescreened = isinstance(values, (list, tuple))
+    if prescreened:
+        _screen_string_members(values)
     hash_bytes = _xxh64
     for chunk, size in _chunks(values):
-        added = True
-        try:
-            digests = np.fromiter(
-                (hash_bytes(value.encode("utf-8")) for value in chunk),
-                dtype=np.uint64,
-                count=size,
-            )
-        except AttributeError as exc:
-            raise ParamError(message="bloom filter members must be all int or all str") from exc
+        if not prescreened:
+            _screen_string_members(chunk)
+        digests = np.fromiter(
+            (hash_bytes(value.encode("utf-8")) for value in chunk),
+            dtype=np.uint64,
+            count=size,
+        )
+        commit()
         _insert_digests(words, digests, num_blocks)
-    return added
-
-
-def _fill_int64_vectorised(buf: bytearray, members: Sequence[int], num_blocks: int) -> None:
-    """Hash and insert INT64 members with numpy, in place, into an already-sized buffer.
-
-    Retained as the entry point this module used before :class:`BloomFilterBuilder` existed;
-    it now just drives the shared chunk loop.
-    """
-    words = np.frombuffer(buf, dtype=_WORD64_DTYPE, offset=_HEADER_SIZE)
-    _add_int64_chunks(words, members, num_blocks)
 
 
 def _optimal_num_bytes(count: int, fpr: float) -> int:
@@ -360,6 +366,10 @@ class BloomFilterBuilder:
     time with numpy, and a per-member Python call would cost more than the hashing does.
     Accumulate into batches of a few thousand and hand those over.
 
+    Calls to the add methods and :meth:`build` are serialized per builder. Streaming adds are
+    not transactional: once insertion of a chunk starts, that chunk remains committed if the
+    iterable or a later chunk raises. Retrying members is safe because insertion is idempotent.
+
     .. code-block:: python
 
         builder = BloomFilterBuilder(10_000_000, fpr=0.005)
@@ -374,12 +384,13 @@ class BloomFilterBuilder:
 
     def __init__(self, n: int, fpr: float = _DEFAULT_FPR) -> None:
         self._fpr = _validate_fpr(fpr)
-        if not isinstance(n, int) or isinstance(n, bool) or n < 0:
-            raise ParamError(message="bloom filter member count must be a non-negative int")
+        if not isinstance(n, int) or isinstance(n, bool) or not 0 <= n <= _MASK64:
+            raise ParamError(message="bloom filter member count must be a uint64")
         num_bytes = _optimal_num_bytes(n, self._fpr)
         self._num_blocks = num_bytes // 32
         self._n = n
         self._domains = 0
+        self._lock = Lock()
         # The header is reserved in place so the blob is assembled in one buffer. Concatenating
         # a separate header would hold the body, its bytes() copy and the joined result live at
         # once, tripling peak memory for large member sets.
@@ -387,16 +398,35 @@ class BloomFilterBuilder:
         self._words = np.frombuffer(self._buf, dtype=_WORD64_DTYPE, offset=_HEADER_SIZE)
 
     def add_int64_batch(self, values: Iterable[int]) -> "BloomFilterBuilder":
-        """Inserts integer members, hashed as their 8-byte little-endian encoding."""
-        if _add_int64_chunks(self._words, values, self._num_blocks):
-            self._domains |= _DOMAIN_INT64
+        """Inserts integer members, hashed as their 8-byte little-endian encoding.
+
+        Completed chunks remain committed if the iterable later raises.
+        """
+        with self._lock:
+            _add_int64_chunks(
+                self._words,
+                values,
+                self._num_blocks,
+                lambda: self._commit_domain(_DOMAIN_INT64),
+            )
         return self
 
     def add_string_batch(self, values: Iterable[str]) -> "BloomFilterBuilder":
-        """Inserts string members, hashed as their raw UTF-8 bytes."""
-        if _add_string_chunks(self._words, values, self._num_blocks):
-            self._domains |= _DOMAIN_UTF8
+        """Inserts string members, hashed as their raw UTF-8 bytes.
+
+        Completed chunks remain committed if the iterable later raises.
+        """
+        with self._lock:
+            _add_string_chunks(
+                self._words,
+                values,
+                self._num_blocks,
+                lambda: self._commit_domain(_DOMAIN_UTF8),
+            )
         return self
+
+    def _commit_domain(self, domain: int) -> None:
+        self._domains |= domain
 
     @property
     def domains(self) -> int:
@@ -410,19 +440,20 @@ class BloomFilterBuilder:
 
     def build(self) -> bytes:
         """Stamps the MBF1 header and returns a copy of the envelope."""
-        struct.pack_into(
-            _HEADER_FORMAT,
-            self._buf,
-            0,
-            b"MBF1",
-            1,
-            1,
-            self._n,
-            self._fpr,
-            self._num_blocks,
-            self._domains,
-        )
-        return bytes(self._buf)
+        with self._lock:
+            struct.pack_into(
+                _HEADER_FORMAT,
+                self._buf,
+                0,
+                b"MBF1",
+                1,
+                1,
+                self._n,
+                self._fpr,
+                self._num_blocks,
+                self._domains,
+            )
+            return bytes(self._buf)
 
 
 def build_bloom_filter(members: Sequence[Union[int, str]], fpr: float = _DEFAULT_FPR) -> bytes:
@@ -494,12 +525,3 @@ def _fill_scalar(
             word6 | 1 << ((key * salt6 & 0xFFFFFFFF) >> 27),
             word7 | 1 << ((key * salt7 & 0xFFFFFFFF) >> 27),
         )
-
-
-def _fill_scalar_int64(buf: bytearray, members: Sequence[int], num_blocks: int) -> None:
-    """Scalar INT64 insertion, signature-compatible with :func:`_fill_int64_vectorised`.
-
-    Not on the default path -- it exists so the vectorised implementation has a reference to be
-    checked against, and as a drop-in should numpy ever need to be bypassed.
-    """
-    _fill_scalar(buf, members, _DOMAIN_INT64, num_blocks)

--- a/pymilvus/client/bloom_filter.py
+++ b/pymilvus/client/bloom_filter.py
@@ -1,8 +1,9 @@
 import math
 import struct
+from contextlib import contextmanager
 from itertools import islice
 from threading import Lock
-from typing import Any, Callable, Iterable, Iterator, Sequence, Tuple, Union
+from typing import Any, Iterable, Iterator, Sequence, Tuple, Union
 
 import numpy as np
 
@@ -281,15 +282,16 @@ def _add_int64_chunks(
     words: np.ndarray,
     values: Iterable[int],
     num_blocks: int,
-    commit: Callable[[], None],
-) -> None:
-    """Hash and insert integer members a chunk at a time."""
+) -> bool:
+    """Hash and insert integer members a chunk at a time. Returns whether anything was added."""
     # A sequence can be screened in one C-speed pass; a one-shot iterable has to be screened
     # per chunk, since by then the earlier members are gone.
     prescreened = isinstance(values, (list, tuple))
     if prescreened:
         _screen_int_members(values)
+    added = False
     for chunk, size in _chunks(values):
+        added = True
         if not prescreened:
             _screen_int_members(chunk)
         try:
@@ -300,24 +302,23 @@ def _add_int64_chunks(
             ) from exc
         except (TypeError, ValueError) as exc:
             raise ParamError(message="bloom filter members must be all int or all str") from exc
-        # The body cannot be rolled back without copying the whole filter. Mark the domain before
-        # mutation so a failure during this or a later chunk leaves a valid partial commit.
-        commit()
         _insert_digests(words, _int64_digests(lanes), num_blocks)
+    return added
 
 
 def _add_string_chunks(
     words: np.ndarray,
     values: Iterable[str],
     num_blocks: int,
-    commit: Callable[[], None],
-) -> None:
-    """Hash and insert string members a chunk at a time."""
+) -> bool:
+    """Hash and insert string members a chunk at a time. Returns whether anything was added."""
     prescreened = isinstance(values, (list, tuple))
     if prescreened:
         _screen_string_members(values)
     hash_bytes = _xxh64
+    added = False
     for chunk, size in _chunks(values):
+        added = True
         if not prescreened:
             _screen_string_members(chunk)
         digests = np.fromiter(
@@ -325,8 +326,8 @@ def _add_string_chunks(
             dtype=np.uint64,
             count=size,
         )
-        commit()
         _insert_digests(words, digests, num_blocks)
+    return added
 
 
 def _optimal_num_bytes(count: int, fpr: float) -> int:
@@ -366,9 +367,10 @@ class BloomFilterBuilder:
     time with numpy, and a per-member Python call would cost more than the hashing does.
     Accumulate into batches of a few thousand and hand those over.
 
-    Calls to the add methods and :meth:`build` are serialized per builder. Streaming adds are
-    not transactional: once insertion of a chunk starts, that chunk remains committed if the
-    iterable or a later chunk raises. Retrying members is safe because insertion is idempotent.
+    A builder is not safe for concurrent use. Overlapping calls to either add method or
+    :meth:`build` fail immediately instead of waiting. If an add raises for any reason, discard
+    the builder: it is poisoned because earlier chunks may already have changed the filter body,
+    and all subsequent add and build calls will fail.
 
     .. code-block:: python
 
@@ -390,6 +392,7 @@ class BloomFilterBuilder:
         self._num_blocks = num_bytes // 32
         self._n = n
         self._domains = 0
+        self._failed = False
         self._lock = Lock()
         # The header is reserved in place so the blob is assembled in one buffer. Concatenating
         # a separate header would hold the body, its bytes() copy and the joined result live at
@@ -398,35 +401,39 @@ class BloomFilterBuilder:
         self._words = np.frombuffer(self._buf, dtype=_WORD64_DTYPE, offset=_HEADER_SIZE)
 
     def add_int64_batch(self, values: Iterable[int]) -> "BloomFilterBuilder":
-        """Inserts integer members, hashed as their 8-byte little-endian encoding.
-
-        Completed chunks remain committed if the iterable later raises.
-        """
-        with self._lock:
-            _add_int64_chunks(
-                self._words,
-                values,
-                self._num_blocks,
-                lambda: self._commit_domain(_DOMAIN_INT64),
-            )
+        """Inserts integer members, poisoning the builder if the add fails."""
+        with self._operation():
+            try:
+                if _add_int64_chunks(self._words, values, self._num_blocks):
+                    self._domains |= _DOMAIN_INT64
+            except BaseException:
+                self._failed = True
+                raise
         return self
 
     def add_string_batch(self, values: Iterable[str]) -> "BloomFilterBuilder":
-        """Inserts string members, hashed as their raw UTF-8 bytes.
-
-        Completed chunks remain committed if the iterable later raises.
-        """
-        with self._lock:
-            _add_string_chunks(
-                self._words,
-                values,
-                self._num_blocks,
-                lambda: self._commit_domain(_DOMAIN_UTF8),
-            )
+        """Inserts string members, poisoning the builder if the add fails."""
+        with self._operation():
+            try:
+                if _add_string_chunks(self._words, values, self._num_blocks):
+                    self._domains |= _DOMAIN_UTF8
+            except BaseException:
+                self._failed = True
+                raise
         return self
 
-    def _commit_domain(self, domain: int) -> None:
-        self._domains |= domain
+    @contextmanager
+    def _operation(self) -> Iterator[None]:
+        if not self._lock.acquire(blocking=False):
+            message = "BloomFilterBuilder does not support concurrent use"
+            raise RuntimeError(message)
+        try:
+            if self._failed:
+                message = "BloomFilterBuilder is unusable after a failed add"
+                raise RuntimeError(message)
+            yield
+        finally:
+            self._lock.release()
 
     @property
     def domains(self) -> int:
@@ -440,7 +447,7 @@ class BloomFilterBuilder:
 
     def build(self) -> bytes:
         """Stamps the MBF1 header and returns a copy of the envelope."""
-        with self._lock:
+        with self._operation():
             struct.pack_into(
                 _HEADER_FORMAT,
                 self._buf,

--- a/tests/unit/test_bloom_filter.py
+++ b/tests/unit/test_bloom_filter.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from pymilvus import build_bloom_filter
+from pymilvus import BloomFilterBuilder, build_bloom_filter
 from pymilvus.client import bloom_filter
 from pymilvus.client.bloom_filter import _xxh64_int64_python, _xxh64_python
 from pymilvus.client.prepare import Prepare
@@ -71,41 +71,74 @@ def test_xxh64_int64_python_matches_generic():
         assert _xxh64_int64_python(value) == _xxh64_python(struct.pack("<q", value)), value
 
 
+def _scalar_reference_blob(members, fpr, domain):
+    """Build the same envelope through ``_fill_scalar``, one member at a time.
+
+    Both domains now share the vectorised numpy insert, so the scalar loop is the independent
+    reference it has to agree with. The reference is assembled explicitly rather than by
+    monkeypatching a seam inside the default path: a refactor that moves the vectorised code
+    somewhere else then makes these tests fail loudly, instead of silently comparing the
+    default path to itself (which is exactly what happened when the INT64 fill moved).
+    """
+    count = len(members)
+    num_bytes = bloom_filter._optimal_num_bytes(count, float(fpr))
+    num_blocks = num_bytes // 32
+    buf = bytearray(bloom_filter._HEADER_SIZE + num_bytes)
+    struct.pack_into(
+        bloom_filter._HEADER_FORMAT, buf, 0, b"MBF1", 1, 1, count, float(fpr), num_blocks, domain
+    )
+    bloom_filter._fill_scalar(buf, members, domain, num_blocks)
+    return bytes(buf)
+
+
 @pytest.mark.parametrize(
-    "members",
+    ("members", "domain"),
     [
-        [-(1 << 63), -1, 0, 1, 42, (1 << 63) - 1],
-        ["", "a", "milvus", "日本語", "🚀🚀", "x" * 40],
+        ([-(1 << 63), -1, 0, 1, 42, (1 << 63) - 1], bloom_filter._DOMAIN_INT64),
+        (["", "a", "milvus", "日本語", "🚀🚀", "x" * 40], bloom_filter._DOMAIN_UTF8),
     ],
 )
-def test_build_bloom_filter_fallback_matches_default_path(monkeypatch, members):
+def test_build_bloom_filter_fallback_matches_default_path(monkeypatch, members, domain):
     """Forcing the pure-Python hashes must reproduce the blob the default path builds.
 
-    Keeps the fallback exercised even when the optional C accelerator is installed. The INT64
-    default path is the vectorised fill, which inlines its own hash and never consults
-    ``_xxh64_int64``, so that case must also swap in the scalar fill -- without it the
-    monkeypatched hash never runs and the INT64 case compares the default path to itself.
+    Keeps the fallback exercised even when the optional C accelerator is installed. The
+    vectorised INT64 path inlines its own hash and never consults ``_xxh64_int64``, so the
+    load-bearing assertion is the one against the scalar reference, which does.
     """
     expected = build_bloom_filter(members, fpr=0.001)
 
     monkeypatch.setattr(bloom_filter, "_xxh64", bloom_filter._xxh64_python)
     monkeypatch.setattr(bloom_filter, "_xxh64_int64", bloom_filter._xxh64_int64_python)
-    monkeypatch.setattr(bloom_filter, "_fill_int64_vectorised", bloom_filter._fill_scalar_int64)
 
+    assert _scalar_reference_blob(members, 0.001, domain) == expected
     assert build_bloom_filter(members, fpr=0.001) == expected
 
 
 @pytest.mark.parametrize("count", [1, 2, 100, (1 << 14) + 3])
-def test_int64_vectorised_matches_scalar(monkeypatch, count):
+def test_int64_vectorised_matches_scalar(count):
     """The numpy INT64 path must agree with the scalar loop, including across chunk boundaries."""
     rng = random.Random(20260728)
     members = [-(1 << 63), (1 << 63) - 1, 0, -1]
     members += [rng.randrange(-(1 << 63), 1 << 63) for _ in range(count)]
 
-    vectorised = build_bloom_filter(members, fpr=0.001)
+    assert build_bloom_filter(members, fpr=0.001) == _scalar_reference_blob(
+        members, 0.001, bloom_filter._DOMAIN_INT64
+    )
 
-    monkeypatch.setattr(bloom_filter, "_fill_int64_vectorised", bloom_filter._fill_scalar_int64)
-    assert build_bloom_filter(members, fpr=0.001) == vectorised
+
+@pytest.mark.parametrize("count", [1, 2, 100, (1 << 14) + 3])
+def test_string_vectorised_matches_scalar(count):
+    """The string path now shares the vectorised insert, so it needs the same guarantee."""
+    rng = random.Random(20260731)
+    alphabet = "abcdefghij日本語🚀"
+    members = ["", "a", "milvus", "日本語", "🚀🚀", "x" * 40]
+    members += [
+        "".join(rng.choice(alphabet) for _ in range(rng.randrange(0, 40))) for _ in range(count)
+    ]
+
+    assert build_bloom_filter(members, fpr=0.001) == _scalar_reference_blob(
+        members, 0.001, bloom_filter._DOMAIN_UTF8
+    )
 
 
 def test_int64_vectorised_block_words_pinned_little_endian(monkeypatch):
@@ -214,3 +247,82 @@ def test_build_bloom_filter_accepts_fpr_boundaries(fpr):
 def test_build_bloom_filter_rejects_invalid_input(members, fpr):
     with pytest.raises(ParamError):
         build_bloom_filter(members, fpr=fpr)
+
+
+@pytest.mark.parametrize("chunk", [1, 7, 1000, (1 << 14) + 3])
+def test_builder_streaming_matches_one_shot(chunk):
+    """Streaming a set through the builder must produce exactly the one-shot blob.
+
+    Insertion into an SBBF is order-independent and idempotent, so how the members are cut
+    into batches cannot matter -- including batches that straddle the internal chunk size.
+    """
+    ints = list(range(5000))
+    strings = [f"user_{i}" for i in range(5000)]
+
+    for members, add in (
+        (ints, "add_int64_batch"),
+        (strings, "add_string_batch"),
+    ):
+        builder = BloomFilterBuilder(len(members), fpr=0.001)
+        for start in range(0, len(members), chunk):
+            getattr(builder, add)(members[start : start + chunk])
+        assert builder.build() == build_bloom_filter(members, fpr=0.001)
+
+
+def test_builder_accepts_a_generator():
+    """The point of the builder is not materialising the set, so it must take any iterable."""
+    n = 40000
+    builder = BloomFilterBuilder(n, fpr=0.001)
+    builder.add_int64_batch(i for i in range(n))
+
+    assert builder.build() == build_bloom_filter(list(range(n)), fpr=0.001)
+
+
+def test_builder_records_both_domains():
+    """A builder may mix domains -- a JSON path can legitimately hold ints and strings."""
+    builder = BloomFilterBuilder(2, fpr=0.001)
+    builder.add_int64_batch([1]).add_string_batch(["a"])
+
+    blob = builder.build()
+    assert blob[28] == bloom_filter._DOMAIN_INT64 | bloom_filter._DOMAIN_UTF8
+
+    # An empty batch must not claim a domain, or the server would probe one that has no members.
+    empty = BloomFilterBuilder(0, fpr=0.001)
+    empty.add_int64_batch([]).add_string_batch([])
+    assert empty.build()[28] == 0
+
+
+def test_builder_count_only_drives_sizing():
+    """n sizes the filter; overshooting it is allowed and only costs false-positive rate."""
+    builder = BloomFilterBuilder(10, fpr=0.001)
+    builder.add_int64_batch(range(500))
+    blob = builder.build()
+
+    # Same geometry as a 10-member filter, and n_declared still reports what was promised.
+    assert len(blob) == len(build_bloom_filter(list(range(10)), fpr=0.001))
+    assert struct.unpack_from("<Q", blob, 8)[0] == 10
+
+
+@pytest.mark.parametrize(
+    ("n", "fpr"),
+    [(-1, 0.001), (1.5, 0.001), (True, 0.001), ("x", 0.001), (1, 0.0), (1, float("nan"))],
+)
+def test_builder_rejects_invalid_construction(n, fpr):
+    with pytest.raises(ParamError):
+        BloomFilterBuilder(n, fpr)
+
+
+@pytest.mark.parametrize(
+    ("method", "values"),
+    [
+        ("add_int64_batch", [1, "x"]),
+        ("add_int64_batch", [True]),
+        ("add_int64_batch", [1 << 63]),
+        ("add_string_batch", ["a", 1]),
+        ("add_string_batch", [None]),
+    ],
+)
+def test_builder_rejects_invalid_members(method, values):
+    builder = BloomFilterBuilder(len(values), fpr=0.001)
+    with pytest.raises(ParamError):
+        getattr(builder, method)(values)

--- a/tests/unit/test_bloom_filter.py
+++ b/tests/unit/test_bloom_filter.py
@@ -141,32 +141,32 @@ def test_string_vectorised_matches_scalar(count):
     )
 
 
-def test_int64_vectorised_block_words_pinned_little_endian(monkeypatch):
-    """The block-word view must be explicitly little-endian, never host-native.
+def test_body_view_is_pinned_little_endian(monkeypatch):
+    """The view the body is written through must be explicitly little-endian, never native.
 
-    ``np.uint32`` follows the host byte order: on a big-endian client (s390x, ppc64) it would
-    write byte-swapped SBBF words that a little-endian QueryNode reads as different bit
-    positions -- silent false negatives. The wire dtype is pinned as ``_WORD_DTYPE = "<u4"``,
-    and this test proves the fill actually routes through it: forcing the constant to ">u4"
-    (what native order resolves to on a big-endian host) must produce the same word *values*
-    in the opposite byte order. On little-endian CI both asserts fail if the fill regresses
-    to a hard-coded native dtype, because overriding the constant would then change nothing.
+    A host-native dtype follows the machine: on a big-endian client (s390x, ppc64) it would
+    write byte-swapped lanes that a little-endian QueryNode reads as different bit positions
+    -- silent false negatives. The wire dtype is pinned as ``_WORD64_DTYPE = "<u8"``, and this
+    test proves the fill actually routes through it: forcing the constant to ">u8" (what
+    native order resolves to on a big-endian host) must produce the same lane *values* in the
+    opposite byte order. On little-endian CI both asserts fail if the fill regresses to a
+    hard-coded native dtype, because overriding the constant would then change nothing.
     """
-    assert bloom_filter._WORD_DTYPE.newbyteorder("<") == bloom_filter._WORD_DTYPE
+    assert bloom_filter._WORD64_DTYPE.newbyteorder("<") == bloom_filter._WORD64_DTYPE
 
     rng = random.Random(20260729)
     members = [rng.randrange(-(1 << 63), 1 << 63) for _ in range(500)]
     expected = build_bloom_filter(members, fpr=0.001)
 
-    monkeypatch.setattr(bloom_filter, "_WORD_DTYPE", np.dtype(">u4"))
+    monkeypatch.setattr(bloom_filter, "_WORD64_DTYPE", np.dtype(">u8"))
     swapped = build_bloom_filter(members, fpr=0.001)
 
     header_size = bloom_filter._HEADER_SIZE
     assert swapped[:header_size] == expected[:header_size]
     assert swapped != expected
-    expected_words = np.frombuffer(expected, dtype="<u4", offset=header_size)
-    swapped_words = np.frombuffer(swapped, dtype=">u4", offset=header_size)
-    assert np.array_equal(swapped_words, expected_words)
+    expected_lanes = np.frombuffer(expected, dtype="<u8", offset=header_size)
+    swapped_lanes = np.frombuffer(swapped, dtype=">u8", offset=header_size)
+    assert np.array_equal(swapped_lanes, expected_lanes)
 
 
 @pytest.mark.parametrize(
@@ -326,3 +326,25 @@ def test_builder_rejects_invalid_members(method, values):
     builder = BloomFilterBuilder(len(values), fpr=0.001)
     with pytest.raises(ParamError):
         getattr(builder, method)(values)
+
+
+def test_oversubscribed_filter_still_correct():
+    """A filter whose blocks are heavily oversubscribed must still be exact.
+
+    n only sizes the filter, so a caller may legitimately add far more members than promised.
+    That drives every member into the same handful of blocks, which is the case the buffered
+    scatter cannot converge in three passes -- it is the path that falls back to the
+    unbuffered one. The result has to be identical to the scalar reference either way.
+    """
+    members = list(range(20000))
+    builder = BloomFilterBuilder(1, fpr=0.001)
+    builder.add_int64_batch(members)
+    blob = builder.build()
+    assert builder.num_blocks == 1, "the point of the test is that every member collides"
+
+    # The reference has to use the builder's geometry, not the one 20000 members would size,
+    # so it is filled by hand at num_blocks = 1 rather than through _scalar_reference_blob.
+    reference = bytearray(bloom_filter._HEADER_SIZE + bloom_filter._MIN_FILTER_BYTES)
+    bloom_filter._fill_scalar(reference, members, bloom_filter._DOMAIN_INT64, 1)
+
+    assert blob[bloom_filter._HEADER_SIZE :] == bytes(reference)[bloom_filter._HEADER_SIZE :]

--- a/tests/unit/test_bloom_filter.py
+++ b/tests/unit/test_bloom_filter.py
@@ -3,7 +3,7 @@ import random
 import struct
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from threading import Barrier, Event
+from threading import Event
 
 import numpy as np
 import pytest
@@ -281,14 +281,14 @@ def test_builder_accepts_a_generator():
 
 
 @pytest.mark.parametrize(
-    ("method", "values", "domain"),
+    ("method", "values"),
     [
-        ("add_int64_batch", list(range(1 << 14)), bloom_filter._DOMAIN_INT64),
-        ("add_string_batch", [f"value_{i}" for i in range(1 << 14)], bloom_filter._DOMAIN_UTF8),
+        ("add_int64_batch", list(range(1 << 14))),
+        ("add_string_batch", [f"value_{i}" for i in range(1 << 14)]),
     ],
 )
-def test_builder_commits_completed_chunks_when_stream_fails(method, values, domain):
-    """A later cursor failure must not leave already-written body bits with no domain."""
+def test_builder_is_poisoned_when_stream_fails(method, values):
+    """A failed streamed add may have changed the body, so the builder must not be reused."""
 
     def failing_cursor():
         yield from values
@@ -298,67 +298,42 @@ def test_builder_commits_completed_chunks_when_stream_fails(method, values, doma
     with pytest.raises(RuntimeError, match="cursor failed"):
         getattr(builder, method)(failing_cursor())
 
-    expected = BloomFilterBuilder(len(values), fpr=0.001)
-    getattr(expected, method)(values)
-    assert builder.domains == domain
-    assert builder.build() == expected.build()
+    with pytest.raises(RuntimeError, match="unusable after a failed add"):
+        builder.add_int64_batch([1])
+    with pytest.raises(RuntimeError, match="unusable after a failed add"):
+        builder.add_string_batch(["a"])
+    with pytest.raises(RuntimeError, match="unusable after a failed add"):
+        builder.build()
 
 
-@pytest.mark.parametrize("method", ["add_int64_batch", "add_string_batch"])
-def test_builder_serializes_concurrent_adds(method):
-    """Concurrent numpy scatters must not lose OR updates and create false negatives."""
-    size = 100_000
-    if method == "add_int64_batch":
-        values = list(range(size * 2))
-    else:
-        values = [f"value_{i}" for i in range(size * 2)]
-    builder = BloomFilterBuilder(size * 2, fpr=0.001)
-    barrier = Barrier(2)
-
-    def add(values):
-        barrier.wait()
-        getattr(builder, method)(values)
-
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        futures = [pool.submit(add, values[:size]), pool.submit(add, values[size:])]
-        for future in futures:
-            future.result()
-
-    assert builder.build() == build_bloom_filter(values, fpr=0.001)
-
-
-def test_builder_build_waits_for_active_add():
-    """build() must return a complete snapshot rather than copying a body mid-update."""
-    builder = BloomFilterBuilder(1, fpr=0.001)
+@pytest.mark.parametrize("operation", ["add_int64_batch", "add_string_batch", "build"])
+def test_builder_rejects_concurrent_use(operation):
+    """Concurrent use is unsupported and must fail instead of corrupting the shared body."""
+    builder = BloomFilterBuilder(2, fpr=0.001)
     add_entered = Event()
     allow_add = Event()
-    build_started = Event()
-    build_finished = Event()
 
     def blocking_values():
         add_entered.set()
         allow_add.wait()
         yield 1
 
-    def build():
-        build_started.set()
-        blob = builder.build()
-        build_finished.set()
-        return blob
-
-    with ThreadPoolExecutor(max_workers=2) as pool:
+    with ThreadPoolExecutor(max_workers=1) as pool:
         add_future = pool.submit(builder.add_int64_batch, blocking_values())
         assert add_entered.wait(timeout=5)
-        build_future = pool.submit(build)
-        assert build_started.wait(timeout=5)
         try:
-            assert not build_finished.wait(timeout=0.1)
+            with pytest.raises(RuntimeError, match="does not support concurrent use"):
+                if operation == "build":
+                    builder.build()
+                else:
+                    getattr(builder, operation)([2] if operation == "add_int64_batch" else ["a"])
         finally:
             allow_add.set()
         add_future.result()
-        blob = build_future.result()
 
-    assert blob == build_bloom_filter([1], fpr=0.001)
+    # The rejected call does not poison the active operation or the builder.
+    builder.add_int64_batch([2])
+    assert builder.build() == build_bloom_filter([1, 2], fpr=0.001)
 
 
 def test_builder_records_both_domains():
@@ -423,6 +398,8 @@ def test_builder_rejects_invalid_members(method, values):
     builder = BloomFilterBuilder(len(values), fpr=0.001)
     with pytest.raises(ParamError):
         getattr(builder, method)(values)
+    with pytest.raises(RuntimeError, match="unusable after a failed add"):
+        builder.build()
 
 
 def test_string_members_must_really_be_strings():

--- a/tests/unit/test_bloom_filter.py
+++ b/tests/unit/test_bloom_filter.py
@@ -1,7 +1,9 @@
 import json
 import random
 import struct
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier, Event
 
 import numpy as np
 import pytest
@@ -278,6 +280,87 @@ def test_builder_accepts_a_generator():
     assert builder.build() == build_bloom_filter(list(range(n)), fpr=0.001)
 
 
+@pytest.mark.parametrize(
+    ("method", "values", "domain"),
+    [
+        ("add_int64_batch", list(range(1 << 14)), bloom_filter._DOMAIN_INT64),
+        ("add_string_batch", [f"value_{i}" for i in range(1 << 14)], bloom_filter._DOMAIN_UTF8),
+    ],
+)
+def test_builder_commits_completed_chunks_when_stream_fails(method, values, domain):
+    """A later cursor failure must not leave already-written body bits with no domain."""
+
+    def failing_cursor():
+        yield from values
+        raise RuntimeError("cursor failed")
+
+    builder = BloomFilterBuilder(len(values), fpr=0.001)
+    with pytest.raises(RuntimeError, match="cursor failed"):
+        getattr(builder, method)(failing_cursor())
+
+    expected = BloomFilterBuilder(len(values), fpr=0.001)
+    getattr(expected, method)(values)
+    assert builder.domains == domain
+    assert builder.build() == expected.build()
+
+
+@pytest.mark.parametrize("method", ["add_int64_batch", "add_string_batch"])
+def test_builder_serializes_concurrent_adds(method):
+    """Concurrent numpy scatters must not lose OR updates and create false negatives."""
+    size = 100_000
+    if method == "add_int64_batch":
+        values = list(range(size * 2))
+    else:
+        values = [f"value_{i}" for i in range(size * 2)]
+    builder = BloomFilterBuilder(size * 2, fpr=0.001)
+    barrier = Barrier(2)
+
+    def add(values):
+        barrier.wait()
+        getattr(builder, method)(values)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(add, values[:size]), pool.submit(add, values[size:])]
+        for future in futures:
+            future.result()
+
+    assert builder.build() == build_bloom_filter(values, fpr=0.001)
+
+
+def test_builder_build_waits_for_active_add():
+    """build() must return a complete snapshot rather than copying a body mid-update."""
+    builder = BloomFilterBuilder(1, fpr=0.001)
+    add_entered = Event()
+    allow_add = Event()
+    build_started = Event()
+    build_finished = Event()
+
+    def blocking_values():
+        add_entered.set()
+        allow_add.wait()
+        yield 1
+
+    def build():
+        build_started.set()
+        blob = builder.build()
+        build_finished.set()
+        return blob
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        add_future = pool.submit(builder.add_int64_batch, blocking_values())
+        assert add_entered.wait(timeout=5)
+        build_future = pool.submit(build)
+        assert build_started.wait(timeout=5)
+        try:
+            assert not build_finished.wait(timeout=0.1)
+        finally:
+            allow_add.set()
+        add_future.result()
+        blob = build_future.result()
+
+    assert blob == build_bloom_filter([1], fpr=0.001)
+
+
 def test_builder_records_both_domains():
     """A builder may mix domains -- a JSON path can legitimately hold ints and strings."""
     builder = BloomFilterBuilder(2, fpr=0.001)
@@ -312,6 +395,20 @@ def test_builder_rejects_invalid_construction(n, fpr):
         BloomFilterBuilder(n, fpr)
 
 
+def test_builder_enforces_uint64_count_before_sizing(monkeypatch):
+    def minimum_filter_bytes(count, fpr):
+        assert count == (1 << 64) - 1
+        return bloom_filter._MIN_FILTER_BYTES
+
+    monkeypatch.setattr(bloom_filter, "_optimal_num_bytes", minimum_filter_bytes)
+
+    maximum = BloomFilterBuilder((1 << 64) - 1, fpr=0.001)
+    assert struct.unpack_from("<Q", maximum.build(), 8)[0] == (1 << 64) - 1
+
+    with pytest.raises(ParamError):
+        BloomFilterBuilder(1 << 64, fpr=0.001)
+
+
 @pytest.mark.parametrize(
     ("method", "values"),
     [
@@ -326,6 +423,20 @@ def test_builder_rejects_invalid_members(method, values):
     builder = BloomFilterBuilder(len(values), fpr=0.001)
     with pytest.raises(ParamError):
         getattr(builder, method)(values)
+
+
+def test_string_members_must_really_be_strings():
+    class Encodable:
+        def encode(self, encoding):
+            return b"not-a-string"
+
+    for values in (["a", Encodable()], [Encodable(), "a"]):
+        with pytest.raises(ParamError):
+            build_bloom_filter(values, fpr=0.001)
+
+        builder = BloomFilterBuilder(len(values), fpr=0.001)
+        with pytest.raises(ParamError):
+            builder.add_string_batch(values)
 
 
 def test_oversubscribed_filter_still_correct():


### PR DESCRIPTION
Follow-up to #3690, which shipped the `bloom_match` client-side filter builder. Two things it left on the table.

## The string path spent 95% of its time in the insert loop, not the hash

`_fill_scalar` hashed and inserted one member at a time. Measured on 10M members: hashing them all with the C accelerator takes **0.4s**, while the scalar insert loop they fed took **~10s**. The insert was the whole cost, and the INT64 path had already vectorised exactly that work.

Splitting the numpy bit-setting out of the INT64 path into `_insert_digests` so both domains share it:

| workload | before | after |
|---|---:|---:|
| 10M strings | 10.5s | **1.27s** (8.3x) |
| 10M integers | 0.84s | 0.84s (unchanged) |

Blobs are byte-identical — same sha256 for both workloads before and after. I ran the two implementations interleaved twice to keep thermal drift out of it; the string result reproduced at 10.5s vs 1.27s in both rounds, and the integer result overlapped within noise (7 runs each, orig 0.831–0.892 vs new 0.830–0.849).

## No way to build a filter without materialising the whole set

`build_bloom_filter` takes a `list` or `tuple`, so a 10M-member set has to exist in memory as a Python list before the filter can be built — about 400 MB for integers and 550 MB for strings, against a 16 MiB filter.

`BloomFilterBuilder` takes iterables instead. The filter is a fixed-size bit array sized from `n` and `fpr` alone — never from the values — and insertion is order-independent and idempotent, so members can stream in from a cursor and be dropped as they go:

```python
builder = BloomFilterBuilder(10_000_000, fpr=0.005)
for chunk in read_ids_in_chunks(conn, size=100_000):
    builder.add_int64_batch(chunk)
blob = builder.build()
```

| workload | one-shot list | streaming |
|---|---:|---:|
| 10M integers | 559 MB | **160 MB** |
| 10M strings | 882 MB | **160 MB** |

Same wall-clock, same bytes. `build_bloom_filter` is now a thin wrapper over the builder, so there is one code path rather than two.

The add methods take an iterable rather than one member at a time deliberately: with the insert vectorised, a per-member Python call costs more than the hashing does. A `list` or `tuple` is chunked with lazy `islice` views so the one-shot path copies nothing — I measured a ~4% regression when chunks were materialised and added the fast path to remove it.

Every other SDK already has an incremental builder (`sbbf.Builder` in Go, `BloomFilterUtils.Builder` in Java, `BloomFilterBuilder` in Node), so this also closes a gap.

## Tests

60 pass. Beyond the existing coverage, this adds the string vectorised-vs-scalar equivalence test (the analogue of the INT64 one) and builder coverage for streaming at four chunk sizes including one that straddles the internal 16384 boundary, generators, mixed domains, oversubscribed `n`, and invalid construction.

**Two existing tests needed restructuring, and the reason is worth flagging.** `test_build_bloom_filter_fallback_matches_default_path` and `test_int64_vectorised_matches_scalar` monkeypatched `_fill_int64_vectorised`. This commit moves that function off the default path, which would have silently turned both into comparisons of the default path against itself — the same trap that made the INT64 fallback case vacuous once before (fixed in `50939f8d`). They now build their reference through `_fill_scalar` explicitly, so a future refactor that relocates the vectorised code makes them fail loudly instead of passing vacuously.

I mutation-tested the result: corrupting the vectorised int64 hash, the bit position, the UTF-8 encoding, the domain bitmask, or the bool screen each turn tests red. The one that matters most is the first — breaking only `_int64_digests` while leaving the scalar path alone produces 7 failures, which is what proves the equivalence tests are not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWMAbqV46tWrVPhWRDedpG