### PR TITLE
enhance: add query_iterator to AsyncMilvusClient

### DIFF
--- a/pymilvus/client/iterator/__init__.py
+++ b/pymilvus/client/iterator/__init__.py
@@ -1,3 +1,4 @@
+from .async_query_iterator import AsyncQueryIterator
 from .query_iterator import (
     NO_CACHE_ID,
     IteratorCache,
@@ -19,6 +20,7 @@ from .search_iterator import (
 
 __all__ = [
     "NO_CACHE_ID",
+    "AsyncQueryIterator",
     "IteratorCache",
     "QueryIterator",
     "QueryIteratorCursor",

--- a/pymilvus/client/iterator/async_query_iterator.py
+++ b/pymilvus/client/iterator/async_query_iterator.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Mapping, Protocol
+
+from pymilvus.client.constants import MAX_BATCH_SIZE
+
+from .query_iterator import _QueryIteratorBase
+
+if TYPE_CHECKING:
+    from pymilvus.client.call_context import CallContext
+
+log = logging.getLogger(__name__)
+
+
+class AsyncQueryIteratorHandler(Protocol):
+    async def describe_collection(
+        self, collection_name: str, **kwargs: Any
+    ) -> Mapping[str, Any]: ...
+
+    async def query(self, collection_name: str, **kwargs: Any) -> Any: ...
+
+
+class AsyncQueryIterator(_QueryIteratorBase):
+    """Non-blocking counterpart of :class:`QueryIterator`.
+
+    ``__init__`` cannot await, so setup RPCs (describe collection, mvccTs probe and the
+    optional offset seek) run in :meth:`create`. Build instances through that classmethod,
+    or through :meth:`AsyncMilvusClient.query_iterator`, never by calling the constructor
+    directly.
+
+    A single iterator must not be advanced concurrently: calling ``await it.next()``
+    from two tasks at once corrupts the primary-key cursor, because the state mutation
+    straddles the await. (The sync iterator has the same hazard across threads.)
+
+    When a checkpoint file is configured (the ``iterator_cp_file`` option), every batch
+    write goes through :meth:`_finalize_batch`, which writes and flushes one cursor line
+    to that file synchronously, on the event-loop thread; the same is true of the file
+    open/read done by :meth:`create` and the close/unlink done by :meth:`close`. A slow
+    or network-mounted checkpoint path therefore blocks the loop and stalls unrelated
+    coroutines. Leave checkpointing off, or point it at local disk, on latency-sensitive
+    loops.
+
+    Examples:
+        >>> it = await client.query_iterator(collection_name="c", filter="pk > 0")
+        >>> try:
+        ...     async for batch in it:
+        ...         handle(batch)
+        ... finally:
+        ...     await it.close()
+    """
+
+    @classmethod
+    async def create(
+        cls,
+        handler: AsyncQueryIteratorHandler,
+        context: CallContext | None,
+        collection_name: str,
+        batch_size: int | None = 1000,
+        limit: int | None = -1,
+        expr: str | None = None,
+        output_fields: list[str] | None = None,
+        partition_names: list[str] | None = None,
+        schema: Mapping[str, Any] | None = None,
+        timeout: float | None = None,
+        rpc_options: Mapping[str, Any] | None = None,
+    ) -> AsyncQueryIterator:
+        iterator = cls(
+            handler=handler,
+            context=context,
+            collection_name=collection_name,
+            batch_size=batch_size,
+            limit=limit,
+            expr=expr,
+            output_fields=output_fields,
+            partition_names=partition_names,
+            schema=schema,
+            timeout=timeout,
+            rpc_options=rpc_options,
+        )
+        await iterator._setup()
+        return iterator
+
+    async def _setup(self) -> None:
+        self._apply_collection_id(
+            await self._handler.describe_collection(
+                self._collection_name, **self._describe_kwargs()
+            )
+        )
+        if self._prepare_ts_cp():
+            self._consume_ts_response(await self._handler.query(**self._ts_query_kwargs()))
+            self._save_mvcc_ts_if_needed()
+        await self._seek_to_offset()
+
+    async def _seek_to_offset(self) -> None:
+        offset = self._seek_offset_start()
+        if offset <= 0:
+            return
+        start_time = time.time()
+        while offset > 0:
+            batch_size = min(MAX_BATCH_SIZE, offset)
+            query_kwargs = self._seek_query_kwargs(batch_size)
+            seeked_count = self._consume_seek_batch(await self._handler.query(**query_kwargs))
+            log.debug(
+                f"seeked offset, seek_expr:{query_kwargs['expr']} "
+                f"batch_size:{batch_size} seeked_count:{seeked_count}"
+            )
+            if seeked_count == 0:
+                log.info("seek offset has drained all matched results for query iterator, break")
+                break
+            offset -= seeked_count
+        self._finish_seek(offset, start_time)
+
+    async def next(self) -> list:
+        ret = self._take_from_cache()
+        if ret is None:
+            ret = self._consume_next_response(
+                await self._handler.query(**self._next_query_kwargs())
+            )
+        return self._finalize_batch(ret)
+
+    async def close(self) -> None:
+        self._close_common()
+
+    def __aiter__(self) -> AsyncQueryIterator:
+        return self
+
+    async def __anext__(self) -> list:
+        batch = await self.next()
+        if not batch:
+            raise StopAsyncIteration
+        return batch

--- a/pymilvus/client/iterator/query_iterator.py
+++ b/pymilvus/client/iterator/query_iterator.py
@@ -82,10 +82,18 @@ def io_operation(io_func: Callable[[Any], None], message: str):
         raise MilvusException(message=message) from ose
 
 
-class QueryIterator:
+class _QueryIteratorBase:
+    """Transport-agnostic state machine shared by QueryIterator and AsyncQueryIterator.
+
+    Holds every piece of pure logic: cursor bookkeeping, expression assembly, batch and
+    limit accounting, the result cache and the checkpoint file. Subclasses own the RPCs:
+    they call a ``_*_kwargs`` builder, block on or await the handler, then feed the
+    response back through the matching ``_consume_*`` method.
+    """
+
     def __init__(
         self,
-        handler: QueryIteratorHandler,
+        handler: Any,
         context: CallContext | None,
         collection_name: str,
         batch_size: int | None = 1000,
@@ -96,20 +104,19 @@ class QueryIterator:
         schema: Mapping[str, Any] | None = None,
         timeout: float | None = None,
         rpc_options: Mapping[str, Any] | None = None,
-    ) -> QueryIterator:
+    ) -> None:
         self._handler = handler
         self._context = context
         self._rpc_options = dict(rpc_options or {})
         self._query_options = self._rpc_options.copy()
         self._collection_name = collection_name
-        self.__set_up_collection_id()
+        self._collection_id = None
         self._output_fields = output_fields
         self._partition_names = partition_names
         self._schema = schema
         self._timeout = timeout
         self._session_ts = 0
         self._query_options[ITERATOR_FIELD] = "True"
-        self._query_options[COLLECTION_ID] = self._collection_id
         self.__check_set_batch_size(batch_size)
         self._limit = limit
         self.__check_set_reduce_stop_for_best()
@@ -121,67 +128,169 @@ class QueryIterator:
         self._is_element_filter_iterator = self.__is_element_filter_expr(self._expr)
         self._cache_id_in_use = NO_CACHE_ID
         self._cp_file_handler = None
-        self.__set_up_ts_cp()
-        self.__seek_to_offset()
 
-    def __set_up_collection_id(self):
-        res = self._handler.describe_collection(
-            self._collection_name,
-            context=self._context,
-            **self._rpc_options,
-        )
+    def _describe_kwargs(self) -> dict[str, Any]:
+        return {"context": self._context, **self._rpc_options}
+
+    def _apply_collection_id(self, res: Mapping[str, Any]) -> None:
         self._collection_id = res[COLLECTION_ID]
+        self._query_options[COLLECTION_ID] = self._collection_id
 
-    def __seek_to_offset(self):
+    def _ts_query_kwargs(self) -> dict[str, Any]:
+        init_ts_kwargs = self._query_options.copy()
+        init_ts_kwargs[OFFSET] = 0
+        # just to set up mvccTs for iterator, no need correct limit
+        init_ts_kwargs[MILVUS_LIMIT] = 1
+        return {
+            "collection_name": self._collection_name,
+            "expr": self._expr,
+            "output_fields": [],
+            "partition_names": [],
+            "timeout": self._timeout,
+            "context": self._context,
+            **init_ts_kwargs,
+        }
+
+    def _consume_ts_response(self, res: Any) -> None:
+        if res is None:
+            raise MilvusException(
+                message="failed to connect to milvus for setting up "
+                "mvccTs, check milvus servers' status"
+            )
+        if res.extra is not None:
+            self._session_ts = res.extra.get(ITERATOR_SESSION_TS_FIELD, 0)
+        if self._session_ts <= 0:
+            log.warning("failed to get mvccTs from milvus server, use client-side ts instead")
+            self._session_ts = fall_back_to_latest_session_ts()
+        self._query_options[GUARANTEE_TIMESTAMP] = self._session_ts
+
+    def _prepare_ts_cp(self) -> bool:
+        """Set up checkpoint state.
+
+        Returns True when the caller still has to issue the mvccTs query, False when the
+        session ts and the pk cursor were restored from an existing checkpoint file.
+        """
+        self._buffer_cursor_lines_number = 0
+        self._cp_file_path_str = self._query_options.get(ITERATOR_SESSION_CP_FILE, None)
+        self._cp_file_path = None
+        if self._cp_file_path_str is None:
+            self._need_save_cp = False
+            return True
+        self._need_save_cp = True
+        self._cp_file_path = Path(self._cp_file_path_str)
+        if not self.__init_cp_file_handler():
+            # input cp file is empty, set up mvccTs by query request
+            return True
+        try:
+            # input cp file is not emtpy, init mvccTs by reading cp file
+            lines = self._cp_file_handler.readlines()
+            line_count = len(lines)
+            if line_count < 2:
+                raise ParamError(
+                    message=f"input cp file:{self._cp_file_path_str} should contain "
+                    f"at least two lines, but only:{line_count} lines"
+                )
+            self._session_ts = int(lines[0])
+            self._query_options[GUARANTEE_TIMESTAMP] = self._session_ts
+            if line_count > 1:
+                self._buffer_cursor_lines_number = line_count - 1
+                self.__restore_cursor_line(lines[self._buffer_cursor_lines_number])
+        except OSError as ose:
+            raise MilvusException(
+                message=f"Failed to read cp info from file:{self._cp_file_path_str}"
+            ) from ose
+        except ValueError as e:
+            raise ParamError(message=f"cannot parse input cp session_ts:{lines[0]}") from e
+        return False
+
+    def _save_mvcc_ts_if_needed(self) -> None:
+        if self._need_save_cp:
+            io_operation(self.__save_mvcc_ts, "Failed to save mvcc ts")
+
+    def _seek_offset_start(self) -> int:
         # read pk cursor from cp file, no need to seek offset
         if self._next_id is not None:
-            return
-        offset = self._query_options.get(OFFSET, 0)
-        if offset > 0:
-            seek_params = self._query_options.copy()
-            seek_params[OFFSET] = 0
-            seek_params[ITERATOR_FIELD] = "False"
-            seek_params[REDUCE_STOP_FOR_BEST] = "False"
-            start_time = time.time()
+            return 0
+        return self._query_options.get(OFFSET, 0)
 
-            def seek_offset_by_batch(batch: int, expr: str) -> int:
-                seek_params[MILVUS_LIMIT] = batch
-                query_params = seek_params.copy()
-                query_params.pop(QUERY_ITER_LAST_PK, None)
-                query_params.pop(QUERY_ITER_LAST_ELEMENT_OFFSET, None)
-                if self._has_element_cursor():
-                    query_params[QUERY_ITER_LAST_PK] = self._next_id
-                    query_params[QUERY_ITER_LAST_ELEMENT_OFFSET] = self._next_element_offset
-                res = self._handler.query(
-                    collection_name=self._collection_name,
-                    expr=expr,
-                    output_fields=[],
-                    partition_names=self._partition_names,
-                    timeout=self._timeout,
-                    context=self._context,
-                    **query_params,
-                )
-                self.__update_cursor(res)
-                return len(res)
+    def _seek_query_kwargs(self, batch: int) -> dict[str, Any]:
+        seek_params = self._query_options.copy()
+        seek_params[OFFSET] = 0
+        seek_params[ITERATOR_FIELD] = "False"
+        seek_params[REDUCE_STOP_FOR_BEST] = "False"
+        seek_params[MILVUS_LIMIT] = batch
+        seek_params.pop(QUERY_ITER_LAST_PK, None)
+        seek_params.pop(QUERY_ITER_LAST_ELEMENT_OFFSET, None)
+        if self._has_element_cursor():
+            seek_params[QUERY_ITER_LAST_PK] = self._next_id
+            seek_params[QUERY_ITER_LAST_ELEMENT_OFFSET] = self._next_element_offset
+        return {
+            "collection_name": self._collection_name,
+            "expr": self._setup_next_expr(),
+            "output_fields": [],
+            "partition_names": self._partition_names,
+            "timeout": self._timeout,
+            "context": self._context,
+            **seek_params,
+        }
 
-            while offset > 0:
-                batch_size = min(MAX_BATCH_SIZE, offset)
-                next_expr = self.__setup_next_expr()
-                seeked_count = seek_offset_by_batch(batch_size, next_expr)
-                log.debug(
-                    f"seeked offset, seek_expr:{next_expr} batch_size:{batch_size} seeked_count:{seeked_count}"
-                )
-                if seeked_count == 0:
-                    log.info(
-                        "seek offset has drained all matched results for query iterator, break"
-                    )
-                    break
-                offset -= seeked_count
-            self._query_options[OFFSET] = 0
-            seek_offset_duration = time.time() - start_time
-            log.info(
-                f"Finish seek offset for query iterator, offset:{offset}, current_pk_cursor:{self._next_id}, "
-                f"duration:{seek_offset_duration}"
+    def _consume_seek_batch(self, res: Any) -> int:
+        self.__update_cursor(res)
+        return len(res)
+
+    def _finish_seek(self, offset: int, start_time: float) -> None:
+        self._query_options[OFFSET] = 0
+        log.info(
+            f"Finish seek offset for query iterator, offset:{offset}, "
+            f"current_pk_cursor:{self._next_id}, duration:{time.time() - start_time}"
+        )
+
+    def _take_from_cache(self) -> list | None:
+        cached_res = iterator_cache.fetch_cache(self._cache_id_in_use)
+        if self.__is_res_sufficient(cached_res):
+            batch = self._query_options[BATCH_SIZE]
+            ret = cached_res[0:batch]
+            iterator_cache.cache(cached_res[batch:], self._cache_id_in_use)
+            return ret
+        iterator_cache.release_cache(self._cache_id_in_use)
+        return None
+
+    def _next_query_kwargs(self) -> dict[str, Any]:
+        current_expr = self._setup_next_expr()
+        log.debug(f"query_iterator_next_expr:{current_expr}")
+        return {
+            "collection_name": self._collection_name,
+            "expr": current_expr,
+            "output_fields": self._output_fields,
+            "partition_names": self._partition_names,
+            "timeout": self._timeout,
+            "context": self._context,
+            **self.__setup_query_params(),
+        }
+
+    def _consume_next_response(self, res: Any) -> list:
+        self.__maybe_cache(res)
+        return res[0 : min(self._query_options[BATCH_SIZE], len(res))]
+
+    def _finalize_batch(self, ret: list) -> list:
+        ret = self.__check_reached_limit(ret)
+        self.__update_cursor(ret)
+        io_operation(self._save_pk_cursor, "failed to save pk cursor")
+        self._returned_count += len(ret)
+        return ret
+
+    def _close_common(self) -> None:
+        # release cache in use
+        iterator_cache.release_cache(self._cache_id_in_use)
+        if self._cp_file_handler is not None:
+
+            def inner_close():
+                self._cp_file_handler.close()
+                self._cp_file_path.unlink()
+                log.info(f"removed cp file:{self._cp_file_path_str} for query iterator")
+
+            io_operation(
+                inner_close, f"failed to clear cp file:{self._cp_file_path_str} for query iterator"
             )
 
     def __init_cp_file_handler(self) -> bool:
@@ -203,7 +312,7 @@ class QueryIterator:
         )
         self._cp_file_handler.writelines(str(self._session_ts) + "\n")
 
-    def __save_pk_cursor(self):
+    def _save_pk_cursor(self):
         if self._need_save_cp and self._next_id is not None:
             if not self._cp_file_path.exists():
                 self._cp_file_handler.close()
@@ -281,69 +390,6 @@ class QueryIterator:
     def __is_element_filter_expr(expr: str) -> bool:
         return expr is not None and "element_filter" in expr.lower()
 
-    def __setup_ts_by_request(self):
-        init_ts_kwargs = self._query_options.copy()
-        init_ts_kwargs[OFFSET] = 0
-        init_ts_kwargs[MILVUS_LIMIT] = 1
-        # just to set up mvccTs for iterator, no need correct limit
-        res = self._handler.query(
-            collection_name=self._collection_name,
-            expr=self._expr,
-            output_fields=[],
-            partition_names=[],
-            timeout=self._timeout,
-            context=self._context,
-            **init_ts_kwargs,
-        )
-        if res is None:
-            raise MilvusException(
-                message="failed to connect to milvus for setting up "
-                "mvccTs, check milvus servers' status"
-            )
-        if res.extra is not None:
-            self._session_ts = res.extra.get(ITERATOR_SESSION_TS_FIELD, 0)
-        if self._session_ts <= 0:
-            log.warning("failed to get mvccTs from milvus server, use client-side ts instead")
-            self._session_ts = fall_back_to_latest_session_ts()
-        self._query_options[GUARANTEE_TIMESTAMP] = self._session_ts
-
-    def __set_up_ts_cp(self):
-        self._buffer_cursor_lines_number = 0
-        self._cp_file_path_str = self._query_options.get(ITERATOR_SESSION_CP_FILE, None)
-        self._cp_file_path = None
-        # no input cp_file, set up mvccTs by query request
-        if self._cp_file_path_str is None:
-            self._need_save_cp = False
-            self.__setup_ts_by_request()
-        else:
-            self._need_save_cp = True
-            self._cp_file_path = Path(self._cp_file_path_str)
-            if not self.__init_cp_file_handler():
-                # input cp file is empty, set up mvccTs by query request
-                self.__setup_ts_by_request()
-                io_operation(self.__save_mvcc_ts, "Failed to save mvcc ts")
-            else:
-                try:
-                    # input cp file is not emtpy, init mvccTs by reading cp file
-                    lines = self._cp_file_handler.readlines()
-                    line_count = len(lines)
-                    if line_count < 2:
-                        raise ParamError(
-                            message=f"input cp file:{self._cp_file_path_str} should contain "
-                            f"at least two lines, but only:{line_count} lines"
-                        )
-                    self._session_ts = int(lines[0])
-                    self._query_options[GUARANTEE_TIMESTAMP] = self._session_ts
-                    if line_count > 1:
-                        self._buffer_cursor_lines_number = line_count - 1
-                        self.__restore_cursor_line(lines[self._buffer_cursor_lines_number])
-                except OSError as ose:
-                    raise MilvusException(
-                        message=f"Failed to read cp info from file:{self._cp_file_path_str}"
-                    ) from ose
-                except ValueError as e:
-                    raise ParamError(message=f"cannot parse input cp session_ts:{lines[0]}") from e
-
     def __maybe_cache(self, result: list):
         if len(result) < 2 * self._query_options[BATCH_SIZE]:
             return
@@ -368,36 +414,6 @@ class QueryIterator:
             last_element_offset=self._next_element_offset,
         )
 
-    def next(self):
-        cached_res = iterator_cache.fetch_cache(self._cache_id_in_use)
-        ret = None
-        if self.__is_res_sufficient(cached_res):
-            ret = cached_res[0 : self._query_options[BATCH_SIZE]]
-            res_to_cache = cached_res[self._query_options[BATCH_SIZE] :]
-            iterator_cache.cache(res_to_cache, self._cache_id_in_use)
-        else:
-            iterator_cache.release_cache(self._cache_id_in_use)
-            current_expr = self.__setup_next_expr()
-            log.debug(f"query_iterator_next_expr:{current_expr}")
-            query_params = self.__setup_query_params()
-            res = self._handler.query(
-                collection_name=self._collection_name,
-                expr=current_expr,
-                output_fields=self._output_fields,
-                partition_names=self._partition_names,
-                timeout=self._timeout,
-                context=self._context,
-                **query_params,
-            )
-            self.__maybe_cache(res)
-            ret = res[0 : min(self._query_options[BATCH_SIZE], len(res))]
-
-        ret = self.__check_reached_limit(ret)
-        self.__update_cursor(ret)
-        io_operation(self.__save_pk_cursor, "failed to save pk cursor")
-        self._returned_count += len(ret)
-        return ret
-
     def __check_reached_limit(self, ret: list):
         if self._limit == UNLIMITED:
             return ret
@@ -420,7 +436,7 @@ class QueryIterator:
         if self._pk_field_name is None or self._pk_field_name == "":
             raise MilvusException(message="schema must contain pk field, broke")
 
-    def __setup_next_expr(self) -> str:
+    def _setup_next_expr(self) -> str:
         current_expr = self._expr
         if self._next_id is None:
             return current_expr
@@ -456,19 +472,73 @@ class QueryIterator:
         self._next_id = res[-1][self._pk_field_name]
         self._next_element_offset = res[-1].get(OFFSET)
 
-    def close(self) -> None:
-        # release cache in use
-        iterator_cache.release_cache(self._cache_id_in_use)
-        if self._cp_file_handler is not None:
 
-            def inner_close():
-                self._cp_file_handler.close()
-                self._cp_file_path.unlink()
-                log.info(f"removed cp file:{self._cp_file_path_str} for query iterator")
+class QueryIterator(_QueryIteratorBase):
+    def __init__(
+        self,
+        handler: QueryIteratorHandler,
+        context: CallContext | None,
+        collection_name: str,
+        batch_size: int | None = 1000,
+        limit: int | None = -1,
+        expr: str | None = None,
+        output_fields: list[str] | None = None,
+        partition_names: list[str] | None = None,
+        schema: Mapping[str, Any] | None = None,
+        timeout: float | None = None,
+        rpc_options: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(
+            handler=handler,
+            context=context,
+            collection_name=collection_name,
+            batch_size=batch_size,
+            limit=limit,
+            expr=expr,
+            output_fields=output_fields,
+            partition_names=partition_names,
+            schema=schema,
+            timeout=timeout,
+            rpc_options=rpc_options,
+        )
+        self._setup()
 
-            io_operation(
-                inner_close, f"failed to clear cp file:{self._cp_file_path_str} for query iterator"
+    def _setup(self) -> None:
+        self._apply_collection_id(
+            self._handler.describe_collection(self._collection_name, **self._describe_kwargs())
+        )
+        if self._prepare_ts_cp():
+            self._consume_ts_response(self._handler.query(**self._ts_query_kwargs()))
+            self._save_mvcc_ts_if_needed()
+        self._seek_to_offset()
+
+    def _seek_to_offset(self) -> None:
+        offset = self._seek_offset_start()
+        if offset <= 0:
+            return
+        start_time = time.time()
+        while offset > 0:
+            batch_size = min(MAX_BATCH_SIZE, offset)
+            query_kwargs = self._seek_query_kwargs(batch_size)
+            seeked_count = self._consume_seek_batch(self._handler.query(**query_kwargs))
+            log.debug(
+                f"seeked offset, seek_expr:{query_kwargs['expr']} "
+                f"batch_size:{batch_size} seeked_count:{seeked_count}"
             )
+            if seeked_count == 0:
+                log.info("seek offset has drained all matched results for query iterator, break")
+                break
+            offset -= seeked_count
+        self._finish_seek(offset, start_time)
+
+    def next(self):
+        ret = self._take_from_cache()
+        if ret is None:
+            ret = self._consume_next_response(self._handler.query(**self._next_query_kwargs()))
+        return self._finalize_batch(ret)
+
+    def close(self) -> None:
+        self._close_common()
 
 
 class IteratorCache:

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -7,7 +7,8 @@ from typing import Dict, List, Optional, Type, Union
 from pymilvus.client import type_info
 from pymilvus.client.abstract import AnnSearchRequest, BaseRanker
 from pymilvus.client.connection_manager import AsyncConnectionManager, ConnectionConfig
-from pymilvus.client.constants import CLUSTER_ID, DEFAULT_CONSISTENCY_LEVEL
+from pymilvus.client.constants import CLUSTER_ID, DEFAULT_CONSISTENCY_LEVEL, UNLIMITED
+from pymilvus.client.iterator import AsyncQueryIterator
 from pymilvus.client.search_aggregation import SearchAggregation
 from pymilvus.client.types import (
     ExceptionsMessage,
@@ -648,6 +649,92 @@ class AsyncMilvusClient(BaseMilvusClient):
             expr_params=kwargs.pop("filter_params", {}),
             context=self._generate_call_context(**kwargs),
             **kwargs,
+        )
+
+    async def query_iterator(
+        self,
+        collection_name: str,
+        batch_size: Optional[int] = 1000,
+        limit: Optional[int] = UNLIMITED,
+        filter: Optional[str] = "",
+        output_fields: Optional[List[str]] = None,
+        partition_names: Optional[List[str]] = None,
+        timeout: Optional[float] = None,
+        **kwargs,
+    ) -> AsyncQueryIterator:
+        """Creates an iterator that walks a filtered result set in batches.
+
+        Unlike ``query``, which caps the result set at ``limit`` rows with no ordering
+        guarantee, the iterator pages through every matching row using a primary-key
+        cursor pinned to one mvcc timestamp.
+
+        This coroutine performs the iterator's setup RPCs, so it must be awaited before
+        the iterator is used.
+
+        Args:
+            collection_name (str): Name of the collection to query.
+            batch_size (int, optional): Rows fetched per page. Defaults to 1000.
+            limit (int, optional): Total rows to return. Defaults to UNLIMITED.
+            filter (str, optional): Filtering expression. Defaults to "".
+            output_fields (List[str], optional): Fields to return.
+            partition_names (List[str], optional): Partitions to query.
+            timeout (float, optional): Timeout in seconds for each RPC call.
+
+        Returns:
+            AsyncQueryIterator: Call ``await it.next()`` until it returns an empty list,
+                then ``await it.close()``. ``async for`` is supported as well.
+
+        Raises:
+            DataTypeNotMatchException: If ``filter`` is not a string.
+            ParamError: If ``batch_size`` is negative or exceeds the server's max batch size.
+            MilvusException: If a setup RPC fails.
+
+        Note:
+            If you pass ``iterator_cp_file`` (a checkpoint file path) in ``kwargs``, the
+            iterator writes and flushes one cursor line to that file on every batch, and
+            this happens synchronously, on the event-loop thread; the same is true of the
+            checkpoint setup in this coroutine and the cleanup in ``it.close()``. A slow or
+            network-mounted checkpoint path will therefore block the loop and stall
+            unrelated coroutines. On latency-sensitive loops, leave checkpointing off or
+            point it at local disk.
+
+        Examples:
+            >>> it = await client.query_iterator(collection_name="c", filter="pk > 0")
+            >>> try:
+            ...     while True:
+            ...         batch = await it.next()
+            ...         if not batch:
+            ...             break
+            ...         handle(batch)
+            ... finally:
+            ...     await it.close()
+        """
+        if filter is not None and not isinstance(filter, str):
+            raise DataTypeNotMatchException(message=ExceptionsMessage.ExprType % type(filter))
+
+        conn = await self._get_connection()
+        context = self._generate_call_context(**kwargs)
+        # set up schema for iterator from cache
+        schema_dict, _ = await conn._get_schema(
+            collection_name,
+            timeout=timeout,
+            context=context,
+            **kwargs,
+        )
+
+        kwargs = self._with_cluster_id(kwargs)
+        return await AsyncQueryIterator.create(
+            handler=conn,
+            context=context,
+            collection_name=collection_name,
+            batch_size=batch_size,
+            limit=limit,
+            expr=filter,
+            output_fields=output_fields,
+            partition_names=partition_names,
+            schema=schema_dict,
+            timeout=timeout,
+            rpc_options=kwargs,
         )
 
     async def get(
@@ -2833,6 +2920,10 @@ class AsyncMilvusClientSession:
     async def query(self, *args, **kwargs):
         self._ensure_open()
         return await self._parent.query(*args, **self._with_cluster_id(kwargs))
+
+    async def query_iterator(self, *args, **kwargs):
+        self._ensure_open()
+        return await self._parent.query_iterator(*args, **self._with_cluster_id(kwargs))
 
     async def get(self, *args, **kwargs):
         self._ensure_open()

--- a/tests/unit/orm/test_iterator.py
+++ b/tests/unit/orm/test_iterator.py
@@ -424,6 +424,23 @@ class TestQueryIteratorInit:
                 schema=_SCHEMA_DICT,
             )
 
+    def test_invalid_batch_size_raises_before_describe_collection(self):
+        # batch_size validation now runs in _QueryIteratorBase.__init__, before the
+        # subclass issues the describe_collection RPC. Pin that ordering here so a
+        # future refactor can't silently move the RPC back in front of validation.
+        conn = _make_mock_conn()
+        with pytest.raises(ParamError):
+            QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=-1,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+            )
+        conn.describe_collection.assert_not_called()
+
     def test_session_ts_set(self):
         conn = _make_mock_conn(session_ts=5000)
         qi = QueryIterator(
@@ -609,7 +626,7 @@ class TestQueryIteratorNextExpr:
             schema=_SCHEMA_DICT,
         )
         # _next_id is None initially
-        expr = qi._QueryIterator__setup_next_expr()
+        expr = qi._setup_next_expr()
         assert expr == "pk > 0"
 
     def test_setup_next_expr_with_int_cursor(self):
@@ -624,7 +641,7 @@ class TestQueryIteratorNextExpr:
             schema=_SCHEMA_DICT,
         )
         qi._next_id = 42
-        expr = qi._QueryIterator__setup_next_expr()
+        expr = qi._setup_next_expr()
         assert "pk > 42" in expr
         assert "(pk > 0)" in expr
         # PK cursor must precede the user filter so that right-most-operand
@@ -644,7 +661,7 @@ class TestQueryIteratorNextExpr:
             schema=_SCHEMA_DICT,
         )
         qi._next_id = 211
-        expr = qi._QueryIterator__setup_next_expr()
+        expr = qi._setup_next_expr()
         # element_filter() must remain the right-most operand of AND.
         assert expr == f"pk > 211 and ({user_filter})"
 
@@ -662,7 +679,7 @@ class TestQueryIteratorNextExpr:
         )
         qi._next_id = 211
         qi._next_element_offset = 3
-        expr = qi._QueryIterator__setup_next_expr()
+        expr = qi._setup_next_expr()
         assert expr == f"pk >= 211 and ({user_filter})"
 
     def test_setup_next_expr_with_varchar_cursor(self):
@@ -677,7 +694,7 @@ class TestQueryIteratorNextExpr:
             schema=_VARCHAR_SCHEMA_DICT,
         )
         qi._next_id = "abc"
-        expr = qi._QueryIterator__setup_next_expr()
+        expr = qi._setup_next_expr()
         assert 'pk > "abc"' in expr
 
     def test_setup_next_expr_empty_expr_with_cursor(self):
@@ -693,7 +710,7 @@ class TestQueryIteratorNextExpr:
         )
         qi._next_id = 10
         qi._expr = ""
-        expr = qi._QueryIterator__setup_next_expr()
+        expr = qi._setup_next_expr()
         assert expr == "pk > 10"
 
 
@@ -1460,7 +1477,7 @@ class TestQueryIteratorCpFile:
             assert qi._next_id == 99
             assert qi._next_element_offset == 2
             assert (
-                qi._QueryIterator__setup_next_expr()
+                qi._setup_next_expr()
                 == "pk >= 99 and (element_filter(structA, $[int_val] >= 20000))"
             )
             qi.close()
@@ -1620,8 +1637,8 @@ class TestQueryIteratorSavePkCursor:
             qi._buffer_cursor_lines_number = 100
             qi._next_id = 42
 
-            # Manually call __save_pk_cursor
-            qi._QueryIterator__save_pk_cursor()
+            # Manually call _save_pk_cursor
+            qi._save_pk_cursor()
             # After truncation, lines reset to 0 + 1 new write
             assert qi._buffer_cursor_lines_number == 1
             qi.close()

--- a/tests/unit/test_async_milvus_client.py
+++ b/tests/unit/test_async_milvus_client.py
@@ -617,6 +617,7 @@ class TestAsyncMilvusClientSession:
             ("search", ("col",), {"data": [[0.1, 0.2]]}),
             ("hybrid_search", ("col", [], MagicMock()), {"limit": 10}),
             ("query", ("col",), {"filter": "id > 0"}),
+            ("query_iterator", ("col",), {"filter": "id > 0", "batch_size": 10}),
             ("get", ("col", [1, 2]), {"output_fields": ["id"]}),
         ],
     )

--- a/tests/unit/test_async_query_iterator.py
+++ b/tests/unit/test_async_query_iterator.py
@@ -1,12 +1,17 @@
 """Unit tests for AsyncQueryIterator (no server required)."""
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
+from pymilvus import AsyncMilvusClient
+from pymilvus.client.connection_manager import AsyncConnectionManager
 from pymilvus.client.constants import (
     COLLECTION_ID,
     ITERATOR_SESSION_TS_FIELD,
 )
 from pymilvus.client.iterator import AsyncQueryIterator
 from pymilvus.client.types import DataType
+from pymilvus.exceptions import DataTypeNotMatchException
 
 _SCHEMA_DICT = {
     "fields": [
@@ -119,3 +124,51 @@ async def test_cursor_expr_quotes_varchar_pk():
     await it.close()
 
     assert 'pk > "abc"' in handler.query_calls[2][1]["expr"]
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_connection_manager():
+    AsyncConnectionManager._reset_instance()
+    yield
+    AsyncConnectionManager._reset_instance()
+
+
+async def _client_with_handler(handler):
+    mock_handler = MagicMock()
+    mock_handler.ensure_channel_ready = AsyncMock()
+    mock_handler.describe_collection = handler.describe_collection
+    mock_handler.query = handler.query
+    mock_handler._get_schema = AsyncMock(return_value=(_SCHEMA_DICT, 1))
+    with patch("pymilvus.client.async_grpc_handler.AsyncGrpcHandler", return_value=mock_handler):
+        client = AsyncMilvusClient()
+        await client._connect()
+        return client
+
+
+@pytest.mark.asyncio
+async def test_client_query_iterator_returns_async_iterator():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": 1}, {"pk": 2}], []])
+    client = await _client_with_handler(handler)
+
+    it = await client.query_iterator(
+        collection_name="test", batch_size=2, filter="pk > 0", output_fields=["pk"]
+    )
+    assert isinstance(it, AsyncQueryIterator)
+    assert await it.next() == [{"pk": 1}, {"pk": 2}]
+    assert await it.next() == []
+    await it.close()
+
+
+@pytest.mark.asyncio
+async def test_client_query_iterator_rejects_non_string_filter():
+    handler = _FakeAsyncHandler()
+    client = await _client_with_handler(handler)
+
+    with pytest.raises(DataTypeNotMatchException):
+        await client.query_iterator(collection_name="test", filter=123)
+
+
+def test_async_client_session_exposes_query_iterator():
+    from pymilvus.milvus_client.async_milvus_client import AsyncMilvusClientSession  # noqa: PLC0415
+
+    assert hasattr(AsyncMilvusClientSession, "query_iterator")

--- a/tests/unit/test_async_query_iterator.py
+++ b/tests/unit/test_async_query_iterator.py
@@ -1,0 +1,121 @@
+"""Unit tests for AsyncQueryIterator (no server required)."""
+
+import pytest
+from pymilvus.client.constants import (
+    COLLECTION_ID,
+    ITERATOR_SESSION_TS_FIELD,
+)
+from pymilvus.client.iterator import AsyncQueryIterator
+from pymilvus.client.types import DataType
+
+_SCHEMA_DICT = {
+    "fields": [
+        {"name": "pk", "type": DataType.INT64, "is_primary": True},
+        {"name": "vec", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
+    ],
+}
+
+_VARCHAR_SCHEMA_DICT = {
+    "fields": [
+        {"name": "pk", "type": DataType.VARCHAR, "is_primary": True},
+        {"name": "vec", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
+    ],
+}
+
+
+class _QueryResult(list):
+    """Stand-in for HybridExtraList: a list that also carries `.extra`."""
+
+    def __init__(self, rows, session_ts=100):
+        super().__init__(rows)
+        self.extra = {ITERATOR_SESSION_TS_FIELD: session_ts}
+
+
+class _FakeAsyncHandler:
+    """Async handler double. `pages` is consumed one entry per query() call."""
+
+    def __init__(self, pages=None, session_ts=100):
+        self.pages = list(pages or [])
+        self.session_ts = session_ts
+        self.describe_calls = []
+        self.query_calls = []
+
+    async def describe_collection(self, collection_name, **kwargs):
+        self.describe_calls.append((collection_name, kwargs))
+        return {COLLECTION_ID: 999}
+
+    async def query(self, collection_name, **kwargs):
+        self.query_calls.append((collection_name, kwargs))
+        rows = self.pages.pop(0) if self.pages else []
+        return _QueryResult(rows, session_ts=self.session_ts)
+
+
+async def _make_iterator(handler, **overrides):
+    kwargs = {
+        "handler": handler,
+        "context": None,
+        "collection_name": "test",
+        "batch_size": 2,
+        "expr": "pk > 0",
+        "output_fields": ["pk"],
+        "schema": _SCHEMA_DICT,
+    }
+    kwargs.update(overrides)
+    return await AsyncQueryIterator.create(**kwargs)
+
+
+@pytest.mark.asyncio
+async def test_next_returns_batches_then_empty():
+    # first query() call is the mvccTs probe, the rest are data pages
+    handler = _FakeAsyncHandler(
+        pages=[
+            [],  # mvccTs probe
+            [{"pk": 1}, {"pk": 2}],
+            [{"pk": 3}],
+            [],
+        ]
+    )
+    it = await _make_iterator(handler)
+
+    assert await it.next() == [{"pk": 1}, {"pk": 2}]
+    assert await it.next() == [{"pk": 3}]
+    assert await it.next() == []
+    await it.close()
+
+
+@pytest.mark.asyncio
+async def test_describe_collection_called_once():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": 1}], []])
+    it = await _make_iterator(handler)
+    await it.next()
+    await it.next()
+    await it.close()
+
+    assert len(handler.describe_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_cursor_expr_advances_with_int_pk():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": 7}, {"pk": 9}], []])
+    it = await _make_iterator(handler)
+    await it.next()
+    await it.next()
+    await it.close()
+
+    # query_calls[0] is the mvccTs probe, [1] the first page, [2] the second page
+    assert handler.query_calls[1][1]["expr"] == "pk > 0"
+    second_expr = handler.query_calls[2][1]["expr"]
+    assert "pk > 9" in second_expr
+    assert "(pk > 0)" in second_expr
+    assert second_expr.index("pk > 9") < second_expr.index("(pk > 0)")
+
+
+@pytest.mark.asyncio
+async def test_cursor_expr_quotes_varchar_pk():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": "abc"}], []])
+    it = await _make_iterator(handler, expr='pk != ""', schema=_VARCHAR_SCHEMA_DICT)
+    await it.next()
+    await it.next()
+    await it.close()
+
+    assert 'pk > "abc"' in handler.query_calls[2][1]["expr"]

--- a/tests/unit/test_async_query_iterator.py
+++ b/tests/unit/test_async_query_iterator.py
@@ -1,17 +1,21 @@
 """Unit tests for AsyncQueryIterator (no server required)."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import tempfile
+from pathlib import Path
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from pymilvus import AsyncMilvusClient
 from pymilvus.client.connection_manager import AsyncConnectionManager
 from pymilvus.client.constants import (
     COLLECTION_ID,
+    ITERATOR_SESSION_CP_FILE,
     ITERATOR_SESSION_TS_FIELD,
+    MAX_BATCH_SIZE,
 )
 from pymilvus.client.iterator import AsyncQueryIterator
 from pymilvus.client.types import DataType
-from pymilvus.exceptions import DataTypeNotMatchException
+from pymilvus.exceptions import DataTypeNotMatchException, ParamError
 
 _SCHEMA_DICT = {
     "fields": [
@@ -26,6 +30,13 @@ _VARCHAR_SCHEMA_DICT = {
         {"name": "vec", "type": DataType.FLOAT_VECTOR, "params": {"dim": 4}},
     ],
 }
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_connection_manager():
+    AsyncConnectionManager._reset_instance()
+    yield
+    AsyncConnectionManager._reset_instance()
 
 
 class _QueryResult(list):
@@ -126,13 +137,6 @@ async def test_cursor_expr_quotes_varchar_pk():
     assert 'pk > "abc"' in handler.query_calls[2][1]["expr"]
 
 
-@pytest.fixture(autouse=True)
-def _reset_async_connection_manager():
-    AsyncConnectionManager._reset_instance()
-    yield
-    AsyncConnectionManager._reset_instance()
-
-
 async def _client_with_handler(handler):
     mock_handler = MagicMock()
     mock_handler.ensure_channel_ready = AsyncMock()
@@ -154,7 +158,11 @@ async def test_client_query_iterator_returns_async_iterator():
         collection_name="test", batch_size=2, filter="pk > 0", output_fields=["pk"]
     )
     assert isinstance(it, AsyncQueryIterator)
+    # the factory fetched the schema for the collection we asked for, not a stale one
+    client._handler._get_schema.assert_awaited_once_with("test", timeout=None, context=ANY)
     assert await it.next() == [{"pk": 1}, {"pk": 2}]
+    # query_calls[0] is the mvccTs probe; [1] is the first data page, keyed by our filter
+    assert handler.query_calls[1][1]["expr"] == "pk > 0"
     assert await it.next() == []
     await it.close()
 
@@ -168,7 +176,101 @@ async def test_client_query_iterator_rejects_non_string_filter():
         await client.query_iterator(collection_name="test", filter=123)
 
 
-def test_async_client_session_exposes_query_iterator():
-    from pymilvus.milvus_client.async_milvus_client import AsyncMilvusClientSession  # noqa: PLC0415
+@pytest.mark.asyncio
+async def test_negative_batch_size_raises_before_any_rpc():
+    handler = _FakeAsyncHandler()
+    with pytest.raises(ParamError):
+        await _make_iterator(handler, batch_size=-1)
+    assert handler.describe_calls == []
 
-    assert hasattr(AsyncMilvusClientSession, "query_iterator")
+
+@pytest.mark.asyncio
+async def test_batch_size_over_max_raises_before_any_rpc():
+    handler = _FakeAsyncHandler()
+    with pytest.raises(ParamError):
+        await _make_iterator(handler, batch_size=MAX_BATCH_SIZE + 1)
+    assert handler.describe_calls == []
+
+
+@pytest.mark.asyncio
+async def test_limit_cuts_off_the_last_batch():
+    handler = _FakeAsyncHandler(
+        pages=[
+            [],  # mvccTs probe
+            [{"pk": 1}, {"pk": 2}],
+            [{"pk": 3}, {"pk": 4}],
+        ]
+    )
+    it = await _make_iterator(handler, batch_size=2, limit=3)
+
+    assert await it.next() == [{"pk": 1}, {"pk": 2}]
+    assert await it.next() == [{"pk": 3}]
+    await it.close()
+
+
+@pytest.mark.asyncio
+async def test_async_for_yields_same_batches_as_next():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": 1}, {"pk": 2}], [{"pk": 3}], []])
+    it = await _make_iterator(handler)
+
+    batches = [batch async for batch in it]
+    await it.close()
+
+    assert batches == [[{"pk": 1}, {"pk": 2}], [{"pk": 3}]]
+
+
+@pytest.mark.asyncio
+async def test_get_cursor_reports_session_ts_and_pk():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": 5}]], session_ts=4242)
+    it = await _make_iterator(handler)
+    await it.next()
+    cursor = it.get_cursor()
+    await it.close()
+
+    assert cursor.session_ts == 4242
+    assert cursor.int_pk == 5
+    assert cursor.str_pk is None
+
+
+@pytest.mark.asyncio
+async def test_get_cursor_uses_str_pk_for_varchar():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": "zz"}]], session_ts=7)
+    it = await _make_iterator(handler, expr='pk != ""', schema=_VARCHAR_SCHEMA_DICT)
+    await it.next()
+    cursor = it.get_cursor()
+    await it.close()
+
+    assert cursor.str_pk == "zz"
+    assert cursor.int_pk is None
+
+
+@pytest.mark.asyncio
+async def test_cp_file_records_cursor_and_close_removes_it():
+    handler = _FakeAsyncHandler(pages=[[], [{"pk": 11}, {"pk": 12}]], session_ts=200)
+    with tempfile.TemporaryDirectory() as td:
+        cp_path = str(Path(td) / "cursor.cp")
+        it = await _make_iterator(handler, rpc_options={ITERATOR_SESSION_CP_FILE: cp_path})
+        await it.next()
+
+        assert Path(cp_path).read_text().splitlines() == ["200", "12"]
+
+        await it.close()
+        assert not Path(cp_path).exists()
+
+
+@pytest.mark.asyncio
+async def test_cp_file_resume_skips_the_mvcc_probe_and_restores_cursor():
+    with tempfile.TemporaryDirectory() as td:
+        cp_path = Path(td) / "cursor.cp"
+        cp_path.write_text("300\n42\n")
+
+        handler = _FakeAsyncHandler(pages=[[{"pk": 43}]])
+        it = await _make_iterator(handler, rpc_options={ITERATOR_SESSION_CP_FILE: str(cp_path)})
+
+        # session ts came from the file, so no mvccTs probe was issued
+        assert it._session_ts == 300
+        assert handler.query_calls == []
+
+        assert await it.next() == [{"pk": 43}]
+        assert "pk > 42" in handler.query_calls[0][1]["expr"]
+        await it.close()

--- a/tests/unit/test_iterator_ownership.py
+++ b/tests/unit/test_iterator_ownership.py
@@ -46,6 +46,19 @@ def test_query_iterator_compatibility_imports_share_client_owned_classes():
     assert collection_module.QueryIterator is ClientQueryIterator
 
 
+def test_async_query_iterator_is_owned_by_the_client_iterator_package():
+    from pymilvus.client.iterator import (  # noqa: PLC0415
+        AsyncQueryIterator as PackageAsyncQueryIterator,
+    )
+    from pymilvus.client.iterator.async_query_iterator import AsyncQueryIterator  # noqa: PLC0415
+    from pymilvus.milvus_client import (  # noqa: PLC0415
+        async_milvus_client as async_milvus_client_module,
+    )
+
+    assert PackageAsyncQueryIterator is AsyncQueryIterator
+    assert async_milvus_client_module.AsyncQueryIterator is AsyncQueryIterator
+
+
 def test_client_iterator_package_has_no_orm_imports():
     package = Path(__file__).parents[2] / "pymilvus" / "client" / "iterator"
 


### PR DESCRIPTION
related to: #3742

## Problem

`AsyncMilvusClient` has no `query_iterator()`. Async callers who need a full filtered result set fall back to `query(..., limit=N)` — which has no ordering guarantee, so which N rows come back is undefined — or hand-roll primary-key cursor pagination plus mvcc-timestamp pinning in application code.

## What this does

The sync `QueryIterator` touches the network in only four places, all through `self._handler`; everything else is pure logic. So instead of a parallel implementation, this splits the state machine out and drives it from both transports.

- **`refactor: extract transport-agnostic _QueryIteratorBase from QueryIterator`** — the base holds cursor bookkeeping, expression assembly, batch/limit accounting, the result cache and the checkpoint file, and exposes `_*_kwargs()` builders paired with `_consume_*()` methods. `QueryIterator` becomes a thin sync driver over it. Two private helpers move to a single underscore (`_setup_next_expr`, `_save_pk_cursor`) because the subclass driver calls them and existing tests reference the mangled names.
- **`enhance: add AsyncQueryIterator on top of the shared iterator base`** — the async driver. Setup RPCs run in a `create()` classmethod because `__init__` cannot await. `await next()`, `await close()`, `get_cursor()`, and `__aiter__`/`__anext__` for `async for`.
- **`enhance: add query_iterator to AsyncMilvusClient`** — the factory, mirroring the sync one (same parameter names/order/defaults, same `filter` type check, same schema-cache lookup). `AsyncMilvusClientSession` delegates it the way the sync session does.
- **`test: cover AsyncQueryIterator limits, cursors, checkpoint resume and async for`**

```python
it = await client.query_iterator(collection_name="c", filter="pk > 0", batch_size=1000)
try:
    while True:
        batch = await it.next()
        if not batch:
            break
        handle(batch)
finally:
    await it.close()

# or
async for batch in it:
    handle(batch)
```

## Behavior note

The refactor moves parameter validation ahead of the first RPC, so `QueryIterator(batch_size=-1)` now raises `ParamError` without the `describe_collection` call the old code made first (same for a schema dict with no `is_primary` field). This is the only intentional behavior difference, and it makes sync and async validate identically. It is stated in the refactor commit's message too.

## How the refactor was verified

Commit 1 renames the class at the top of the file and appends a subclass, so GitHub renders it as close to a rewrite — "existing tests pass" is weak evidence for a refactor whose tests were written against the old structure. So I also compared old vs new directly with a throwaway differential harness (not part of this PR), driving both versions against identical recording handlers and diffing the full ordered sequence of `describe_collection`/`query` calls with all kwargs, plus returned batches, final cursor and checkpoint-file contents:

- **19 scenarios, old vs new: identical except the validation-ordering difference above.** Covered int/varchar/None pk expressions, the cache hit-and-refill path, `limit` cut-off, offset seek (full / drained-early / partial-loop), `element_filter` with and without an element cursor, extra `rpc_options` passthrough, and all six checkpoint branches (fresh, resume, one-line `ParamError`, unparseable ts, element-cursor resume, resume-with-residual-offset).
- **24 scenarios, new sync vs new async: identical, zero divergence.** Also covered `limit=0`, `reduce_stop_for_best=False`, the mvccTs fallback when the server returns 0, and the 100-line checkpoint-file truncation path.

## Tests

`tests/unit/test_async_query_iterator.py` (new, no server needed) covers batch exhaustion, int and varchar PK cursor expressions, `batch_size` validation before any RPC, `limit` cut-off, checkpoint-file write / resume / removal, `describe_collection` called exactly once, `async for` parity with the `next()` loop, and `get_cursor()`. `tests/unit/test_iterator_ownership.py` gains an ownership assertion for the new class, and the session-delegation parametrize list in `tests/unit/test_async_milvus_client.py` gains a `query_iterator` row so `cluster_id` forwarding is pinned the way the sync suite pins it.

Full unit suite: `4553 passed, 3 skipped`. `black --check` and `ruff check` clean.

Also ran it against a live Milvus deployment: iterating one filtered set returned 4,621 rows over 47 pages, and `AsyncMilvusClient.query_iterator`, `async for`, and the sync `query_iterator` all produced the identical primary-key set with no duplicates.

## Scope

Deliberately limited to `query_iterator`, since #3483 was closed for bundling unrelated changes:

- `search_iterator` async support is left for a separate PR, which is why `AsyncMilvusClientSession` delegates only `query_iterator` where the sync session delegates both.
- `__aiter__`/`__anext__` has no sync counterpart on purpose — it is the idiomatic async consumption protocol and six lines. I did not add `__iter__` to the sync iterator.
- Checkpoint-file I/O stays synchronous inside the async coroutines. It lives in the shared base, it is one buffered line plus a flush per batch next to a network round-trip, and moving it off-thread would mean either a thread-pool hop per batch or lifting the checkpoint logic back out of the shared base.
- `AsyncQueryIterator` is not exported from the top-level `pymilvus` namespace, matching `QueryIterator`.

Happy to split, rename or adjust anything here — including the base-class extraction, if you would rather see the async driver built a different way.
