### PR TITLE
fix: make QueryIterator checkpoint recovery resumable and crash-safe

### DIFF
--- a/pymilvus/client/iterator/query_iterator.py
+++ b/pymilvus/client/iterator/query_iterator.py
@@ -307,6 +307,39 @@ class QueryIterator:
             self._session_ts = fall_back_to_latest_session_ts()
         self._query_options[GUARANTEE_TIMESTAMP] = self._session_ts
 
+    def __init_fresh_cp(self):
+        # (re-)initialize as if the cp file had no content at all yet:
+        # set up mvccTs by a query request and persist it.
+        self.__setup_ts_by_request()
+        io_operation(self.__save_mvcc_ts, "Failed to save mvcc ts")
+
+    def __read_intact_cp_lines(self) -> list[str]:
+        # Every line this iterator writes to the cp file is newline-
+        # terminated: __save_mvcc_ts() writes str(self._session_ts) + "\n",
+        # and __save_pk_cursor() writes __dump_cursor_line() + "\n" -- and
+        # nothing else ever appends to this file. Both writers hand a
+        # single already-terminated "<content>\n" string to writelines()
+        # in one call, so a write interrupted partway through can only
+        # have landed a strict byte-prefix of that string; its trailing
+        # "\n" is its last byte, so a partial write can never include it.
+        # readlines() preserves line terminators, so a final line missing
+        # one is a definitive, content-independent signal that it was only
+        # partially written -- whatever shape the partial content takes
+        # (a bare "-1" left behind by an intended "-1234", a truncated
+        # JSON object, half a varchar pk, even half a ts). Discard it
+        # instead of parsing it: a fully written line is never missing its
+        # terminator, so this can never drop content that actually
+        # finished landing.
+        try:
+            lines = self._cp_file_handler.readlines()
+        except OSError as ose:
+            raise MilvusException(
+                message=f"Failed to read cp info from file:{self._cp_file_path_str}"
+            ) from ose
+        if lines and not lines[-1].endswith("\n"):
+            lines = lines[:-1]
+        return lines
+
     def __set_up_ts_cp(self):
         self._buffer_cursor_lines_number = 0
         self._cp_file_path_str = self._query_options.get(ITERATOR_SESSION_CP_FILE, None)
@@ -319,30 +352,38 @@ class QueryIterator:
             self._need_save_cp = True
             self._cp_file_path = Path(self._cp_file_path_str)
             if not self.__init_cp_file_handler():
-                # input cp file is empty, set up mvccTs by query request
-                self.__setup_ts_by_request()
-                io_operation(self.__save_mvcc_ts, "Failed to save mvcc ts")
+                # input cp file does not exist, set up mvccTs by query request
+                self.__init_fresh_cp()
             else:
-                try:
-                    # input cp file is not emtpy, init mvccTs by reading cp file
-                    lines = self._cp_file_handler.readlines()
-                    line_count = len(lines)
-                    if line_count < 2:
+                # input cp file exists, init mvccTs by reading cp file,
+                # ignoring any unterminated (partially written) final line
+                lines = self.__read_intact_cp_lines()
+                line_count = len(lines)
+                if line_count == 0:
+                    # Either the file was genuinely empty (run interrupted
+                    # right after creation, before the mvcc ts was
+                    # written), or its only line was an unterminated,
+                    # partially written ts -- both leave nothing intact to
+                    # resume from. Treat exactly like a brand new cp file.
+                    self.__init_fresh_cp()
+                else:
+                    try:
+                        self._session_ts = int(lines[0])
+                    except ValueError as e:
                         raise ParamError(
-                            message=f"input cp file:{self._cp_file_path_str} should contain "
-                            f"at least two lines, but only:{line_count} lines"
-                        )
-                    self._session_ts = int(lines[0])
+                            message=f"cannot parse input cp session_ts:{lines[0]}"
+                        ) from e
                     self._query_options[GUARANTEE_TIMESTAMP] = self._session_ts
                     if line_count > 1:
                         self._buffer_cursor_lines_number = line_count - 1
                         self.__restore_cursor_line(lines[self._buffer_cursor_lines_number])
-                except OSError as ose:
-                    raise MilvusException(
-                        message=f"Failed to read cp info from file:{self._cp_file_path_str}"
-                    ) from ose
-                except ValueError as e:
-                    raise ParamError(message=f"cannot parse input cp session_ts:{lines[0]}") from e
+                    # line_count == 1: either only the session_ts was ever
+                    # persisted (right after __save_mvcc_ts, before any
+                    # batch was consumed), or a later cursor line existed
+                    # but was discarded above as unterminated -- both
+                    # resume the ts with no pk cursor, and
+                    # _buffer_cursor_lines_number correctly stays at 0,
+                    # consistent with the intact lines that remain.
 
     def __maybe_cache(self, result: list):
         if len(result) < 2 * self._query_options[BATCH_SIZE]:

--- a/pymilvus/client/iterator/query_iterator.py
+++ b/pymilvus/client/iterator/query_iterator.py
@@ -222,8 +222,42 @@ class QueryIterator:
                 )
                 self._buffer_cursor_lines_number = 0
                 self.__save_mvcc_ts()
-            self._cp_file_handler.writelines(self.__dump_cursor_line() + "\n")
-            self._cp_file_handler.flush()
+            # Everything above this point is already committed (whatever
+            # __init_cp_file_handler / the recreate branch / the compaction
+            # branch above left in place); only the cursor-line append below
+            # is rolled back on failure. Record the file's current offset
+            # first so a failure -- even one that only surfaces from
+            # flush(), after writelines() already handed the bytes to the
+            # file object -- can be undone: seek back, truncate the
+            # accepted-but-unconfirmed bytes off, and flush that truncation
+            # so the on-disk file matches the in-memory cursor that the
+            # caller (next()) is about to roll back too.
+            prev_offset = self._cp_file_handler.tell()
+            try:
+                self._cp_file_handler.writelines(self.__dump_cursor_line() + "\n")
+                self._cp_file_handler.flush()
+            except OSError as write_ose:
+                try:
+                    self._cp_file_handler.seek(prev_offset)
+                    self._cp_file_handler.truncate()
+                    self._cp_file_handler.flush()
+                except OSError as rollback_ose:
+                    # The rollback itself failed: we can no longer claim to
+                    # know what bytes are on disk (some unknown prefix of
+                    # the attempted write may have landed). Escalate loudly
+                    # instead of letting a caller believe the checkpoint
+                    # file still reflects the last successfully delivered
+                    # batch.
+                    raise MilvusException(
+                        message=(
+                            f"failed to save pk cursor to cp file:{self._cp_file_path_str}, "
+                            "and the attempt to roll the file back to its prior state also "
+                            f"failed (target offset {prev_offset}); its on-disk content is "
+                            "now unknown and must not be trusted for recovery. write error: "
+                            f"{write_ose!r}, rollback error: {rollback_ose!r}"
+                        )
+                    ) from rollback_ose
+                raise
             self._buffer_cursor_lines_number += 1
 
     def __dump_cursor_line(self) -> str:
@@ -241,7 +275,30 @@ class QueryIterator:
         cursor_line = line.strip()
         try:
             cursor = json.loads(cursor_line)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as e:
+            if self._is_element_filter_iterator:
+                # __read_intact_cp_lines() already discards any final line
+                # that lacks its trailing "\n" before we ever get here, so
+                # every line reaching this point -- including one left
+                # behind by a failed offset-rollback in __save_pk_cursor --
+                # was fully, durably written. __dump_cursor_line always
+                # writes an element-filter iterator's cursor as a complete
+                # JSON object once it has one to write (see
+                # _has_element_cursor), so a *terminated* line that still
+                # fails to parse as JSON cannot be explained by any
+                # write-failure path this iterator itself can hit; it can
+                # only be corruption from something else (e.g. bit-level
+                # disk corruption after a successful flush, or this cp
+                # file being resumed by a differently-configured iterator).
+                # Kept as defense in depth for that residual case -- it
+                # never rejects a line this iterator could have produced,
+                # so keeping it costs nothing. Fail loudly instead of
+                # silently adopting a garbage pk (like the generic
+                # fallback below does for genuinely plain, non-JSON pk
+                # cursors) that could narrow or drop the rest of the scan.
+                raise ParamError(
+                    message=f"cannot parse cp cursor line for element-filter iterator: {cursor_line}"
+                ) from e
             self._next_id = cursor_line
             self._next_element_offset = None
             return
@@ -410,13 +467,23 @@ class QueryIterator:
         )
 
     def next(self):
+        # Decide `ret` without mutating iterator_cache yet: the checkpoint
+        # write below is this batch's commit point, so any cache mutation
+        # that corresponds to it (splicing the cache-hit remainder back, or
+        # caching a fresh query's overflow) must wait until that write has
+        # actually succeeded.
         cached_res = iterator_cache.fetch_cache(self._cache_id_in_use)
-        ret = None
-        if self.__is_res_sufficient(cached_res):
+        served_from_cache = self.__is_res_sufficient(cached_res)
+        if served_from_cache:
             ret = cached_res[0 : self._query_options[BATCH_SIZE]]
-            res_to_cache = cached_res[self._query_options[BATCH_SIZE] :]
-            iterator_cache.cache(res_to_cache, self._cache_id_in_use)
+            cache_remainder = cached_res[self._query_options[BATCH_SIZE] :]
         else:
+            # This releases an *insufficient* cache remainder, if any,
+            # before the query below. That remainder is always a suffix of
+            # what the server returns for the current cursor, so releasing
+            # it here is safe even if the checkpoint write later fails:
+            # the cursor rollback makes the retry re-query, which re-fetches
+            # those same rows from the server rather than relying on cache.
             iterator_cache.release_cache(self._cache_id_in_use)
             current_expr = self.__setup_next_expr()
             log.debug(f"query_iterator_next_expr:{current_expr}")
@@ -430,12 +497,30 @@ class QueryIterator:
                 context=self._context,
                 **query_params,
             )
-            self.__maybe_cache(res)
             ret = res[0 : min(self._query_options[BATCH_SIZE], len(res))]
 
         ret = self.__check_reached_limit(ret)
+        prev_next_id = self._next_id
+        prev_next_element_offset = self._next_element_offset
         self.__update_cursor(ret)
-        io_operation(self.__save_pk_cursor, "failed to save pk cursor")
+        try:
+            io_operation(self.__save_pk_cursor, "failed to save pk cursor")
+        except MilvusException:
+            # The checkpoint write is this batch's commit point. Roll the
+            # cursor back so a retry re-derives the identical batch: since
+            # the cache mutation below hasn't run yet either, a query-branch
+            # retry re-issues the same expression and gets the same rows
+            # back, and a cache-hit retry finds the same untouched cache and
+            # re-serves the same batch from it.
+            self._next_id = prev_next_id
+            self._next_element_offset = prev_next_element_offset
+            raise
+        # Only now that the checkpoint write has durably recorded this batch
+        # as delivered is it safe to commit the cache mutation for it.
+        if served_from_cache:
+            iterator_cache.cache(cache_remainder, self._cache_id_in_use)
+        else:
+            self.__maybe_cache(res)
         self._returned_count += len(ret)
         return ret
 

--- a/tests/unit/orm/test_iterator.py
+++ b/tests/unit/orm/test_iterator.py
@@ -1802,6 +1802,98 @@ class TestQueryIteratorCpFile:
                 Path(cp_path).unlink()
             raise
 
+    def test_cp_file_element_filter_corrupted_cursor_line_raises(self):
+        """__dump_cursor_line always writes an element-filter iterator's
+        cursor as a JSON object once it has one to write. A cursor line
+        that fails to parse as JSON for such an iterator can only be a
+        partially written line left behind by a mid-compaction failure
+        whose offset-rollback (see __save_pk_cursor) also failed --
+        silently treating it as a literal pk value could resume with a
+        garbage cursor that skips or drops the rest of the scan. Must raise
+        ParamError instead of silently accepting it."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write('{"pk":99,"last_el\n')  # truncated mid-JSON
+            cp_path = f.name
+
+        try:
+            with pytest.raises(ParamError, match="cannot parse"):
+                QueryIterator(
+                    handler=conn,
+                    context=None,
+                    collection_name="test",
+                    batch_size=10,
+                    expr="element_filter(structA, $[int_val] >= 20000)",
+                    output_fields=["pk"],
+                    schema=_SCHEMA_DICT,
+                    rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+                )
+        finally:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+
+    def test_cp_file_varchar_pk_non_json_cursor_line_still_resumes(self):
+        """Regression guard for the fix above: a plain (non-JSON) pk cursor
+        line for a *non* element-filter iterator is the normal, legitimate
+        format (see __dump_cursor_line's plain str(self._next_id) branch)
+        and must keep resuming successfully, not be mistaken for
+        corruption."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write("abc-99\n")
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr='pk != ""',
+                output_fields=["pk"],
+                schema=_VARCHAR_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == "abc-99"
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+
+class _RealFlushFailsOnceWrapper:
+    """Wraps a real, on-disk file handle. writelines() forwards to the real
+    handle and *really flushes it* (so the bytes are genuinely on disk
+    before this method returns); flush() raises OSError exactly once (when
+    armed via fail_next_flush) and delegates to the real flush() otherwise.
+
+    This reproduces a flush() call that reports failure even though the
+    data it was "flushing" had, via a different call, already landed --
+    the exact gap the reviewer flagged: __save_pk_cursor's own explicit
+    flush() can fail *after* writelines() already handed the bytes to the
+    file object."""
+
+    def __init__(self, real_handle):
+        self._real = real_handle
+        self.fail_next_flush = False
+
+    def writelines(self, lines):
+        self._real.writelines(lines)
+        self._real.flush()
+
+    def flush(self):
+        if self.fail_next_flush:
+            self.fail_next_flush = False
+            raise OSError("simulated flush failure after the bytes already landed on disk")
+        self._real.flush()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
 
 class TestQueryIteratorSavePkCursor:
     """Cover __save_pk_cursor (lines 195-214)."""
@@ -1911,6 +2003,320 @@ class TestQueryIteratorSavePkCursor:
             # After truncation, lines reset to 0 + 1 new write
             assert qi._buffer_cursor_lines_number == 1
             qi.close()
+
+    def test_checkpoint_write_failure_restores_cursor_for_retry(self):
+        """If persisting the pk cursor fails, next() must raise
+        MilvusException *and* roll _next_id/_next_element_offset back to
+        their pre-batch values, so a caller that retries next() re-issues
+        the same expression and gets the same batch again instead of
+        silently skipping it."""
+        conn = _make_mock_conn(session_ts=200)
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "cursor.cp")
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+
+            # Swap in a file-handle stub whose writelines fails once (the
+            # checkpoint write) then succeeds, without touching the method
+            # under test (__save_pk_cursor) itself.
+            failing_handler = Mock()
+            failing_handler.writelines = Mock(side_effect=[OSError("disk full"), None])
+            failing_handler.flush = Mock()
+            qi._cp_file_handler = failing_handler
+
+            conn.query.return_value = _make_query_res([{"pk": 5}])
+
+            assert qi._next_id is None
+            with pytest.raises(MilvusException, match="failed to save pk cursor"):
+                qi.next()
+            # the batch was never delivered -> cursor must not have advanced
+            assert qi._next_id is None
+
+            conn.query.reset_mock()
+            conn.query.return_value = _make_query_res([{"pk": 5}])
+            result = qi.next()
+
+            # retry re-issues the very same expression (no pk cursor leaked
+            # through), i.e. the same batch is re-delivered, not skipped
+            retry_expr = conn.query.call_args.kwargs["expr"]
+            assert retry_expr == "pk > 0"
+            assert len(result) == 1
+            qi.close()
+
+    def test_checkpoint_write_failure_restores_element_offset_for_retry(self):
+        """Same rollback guarantee as
+        test_checkpoint_write_failure_restores_cursor_for_retry, but for an
+        element-filter iterator: _next_element_offset (not just _next_id)
+        must also be rolled back on a failed checkpoint write."""
+        conn = _make_mock_conn(session_ts=200)
+        user_filter = "element_filter(structA, $[int_val] >= 20000)"
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "cursor.cp")
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr=user_filter,
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            try:
+                failing_handler = Mock()
+                failing_handler.writelines = Mock(side_effect=[OSError("disk full"), None])
+                failing_handler.flush = Mock()
+                qi._cp_file_handler = failing_handler
+
+                conn.query.return_value = _make_query_res([{"pk": 7, OFFSET: 1}])
+
+                assert qi._next_id is None
+                assert qi._next_element_offset is None
+                with pytest.raises(MilvusException, match="failed to save pk cursor"):
+                    qi.next()
+                # rollback must restore BOTH the pk cursor and the element offset
+                assert qi._next_id is None
+                assert qi._next_element_offset is None
+
+                conn.query.reset_mock()
+                conn.query.return_value = _make_query_res([{"pk": 7, OFFSET: 1}])
+                result = qi.next()
+
+                retry_call = conn.query.call_args
+                # no leaked cursor/offset -> retry re-issues the plain expr
+                assert retry_call.kwargs["expr"] == user_filter
+                assert QUERY_ITER_LAST_PK not in retry_call.kwargs
+                assert len(result) == 1
+                assert qi._next_id == 7
+                assert qi._next_element_offset == 1
+            finally:
+                qi.close()
+
+    def test_checkpoint_write_failure_after_cache_hit_replays_same_batch_from_cache(self):
+        """Cache-hit branch: a prior next() call cached the overflow of a
+        query result. If the checkpoint write fails for a batch served from
+        that cache, the retry must re-deliver the identical cached batch
+        (not the rows after it) -- the cache splice must not be committed
+        until the checkpoint write has succeeded."""
+        conn = _make_mock_conn(session_ts=200)
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "cursor.cp")
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=2,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            try:
+                # 7-row result overflows batch_size=2: rows [2..6] get cached.
+                conn.query.return_value = _make_query_res([{"pk": i} for i in range(7)])
+                first = qi.next()
+                assert [row["pk"] for row in first] == [0, 1]
+                assert qi._cache_id_in_use != NO_CACHE_ID
+                cached = iterator_cache.fetch_cache(qi._cache_id_in_use)
+                assert [row["pk"] for row in cached] == [2, 3, 4, 5, 6]
+
+                # Second call is served from cache. Make its checkpoint
+                # write fail once, then succeed.
+                failing_handler = Mock()
+                failing_handler.writelines = Mock(side_effect=[OSError("disk full"), None])
+                failing_handler.flush = Mock()
+                qi._cp_file_handler = failing_handler
+
+                conn.query.reset_mock()
+                with pytest.raises(MilvusException, match="failed to save pk cursor"):
+                    qi.next()
+                # the failed attempt must not touch the server or the cache
+                assert not conn.query.called
+                cached_after_failure = iterator_cache.fetch_cache(qi._cache_id_in_use)
+                assert [row["pk"] for row in cached_after_failure] == [2, 3, 4, 5, 6]
+
+                # Retry re-delivers the SAME batch [2, 3] from the untouched
+                # cache, not [4, 5] -- no rows are skipped.
+                retry = qi.next()
+                assert not conn.query.called
+                assert [row["pk"] for row in retry] == [2, 3]
+            finally:
+                qi.close()
+
+    def test_checkpoint_write_failure_after_fresh_query_overflow_replays_same_batch(self):
+        """Query branch: a fresh query's result overflows the batch size,
+        so __maybe_cache would cache the remainder. If the checkpoint
+        write for the delivered batch fails, that cache commit must not
+        have happened either -- the retry must re-issue the same query and
+        re-deliver the identical first batch, not serve the
+        never-committed cached overflow."""
+        conn = _make_mock_conn(session_ts=200)
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "cursor.cp")
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=2,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            try:
+                failing_handler = Mock()
+                failing_handler.writelines = Mock(side_effect=[OSError("disk full"), None])
+                failing_handler.flush = Mock()
+                qi._cp_file_handler = failing_handler
+
+                conn.query.return_value = _make_query_res([{"pk": i} for i in range(7)])
+
+                assert qi._cache_id_in_use == NO_CACHE_ID
+                with pytest.raises(MilvusException, match="failed to save pk cursor"):
+                    qi.next()
+                # the overflow must not have been committed to the cache
+                assert qi._cache_id_in_use == NO_CACHE_ID
+                assert qi._next_id is None
+
+                conn.query.reset_mock()
+                conn.query.return_value = _make_query_res([{"pk": i} for i in range(7)])
+                retry = qi.next()
+
+                # retry re-issued the same expression (cursor rolled back)...
+                assert conn.query.call_args.kwargs["expr"] == "pk > 0"
+                # ...and re-delivered the identical first batch
+                assert [row["pk"] for row in retry] == [0, 1]
+            finally:
+                qi.close()
+
+    def test_checkpoint_flush_failure_survives_process_restart(self):
+        """Reproduces the reviewer's finding on PR #3746 (query_iterator.py
+        __save_pk_cursor around the writelines()+flush() append): a
+        MilvusException from the checkpoint write does not guarantee the
+        file was left untouched -- writelines() can hand bytes to the file
+        before flush() reports failure. Wrap the *real* file handle so
+        writelines() forwards to it and really flushes (the bytes hit disk
+        for real), then make the wrapper's own flush() call raise --
+        reproducing "the cursor was accepted by the file, but the flush()
+        call reported failure" without touching __save_pk_cursor itself.
+
+        The decisive assertion is cross-restart: a brand new QueryIterator
+        constructed against the same cp file afterwards must resume at the
+        pre-failure cursor and re-deliver the batch that was never actually
+        handed to the caller, not skip it."""
+        conn = _make_mock_conn(session_ts=200)
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "cursor.cp")
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            qi2 = None
+            try:
+                # A first batch succeeds normally and lands a real cursor
+                # line, so the simulated failure below is a second append,
+                # not the very first write to the file.
+                conn.query.return_value = _make_query_res([{"pk": 5}])
+                first = qi.next()
+                assert [row["pk"] for row in first] == [5]
+                pre_failure_bytes = Path(cp_path).read_bytes()
+                assert pre_failure_bytes == b"200\n5\n"
+
+                wrapper = _RealFlushFailsOnceWrapper(qi._cp_file_handler)
+                qi._cp_file_handler = wrapper
+
+                conn.query.return_value = _make_query_res([{"pk": 9}])
+                wrapper.fail_next_flush = True
+                with pytest.raises(MilvusException, match="failed to save pk cursor"):
+                    qi.next()
+
+                # in-memory cursor rolled back
+                assert qi._next_id == 5
+                # on-disk bytes restored to exactly the pre-failure content,
+                # even though writelines() really flushed the new line to
+                # disk before the explicit flush() call reported failure
+                assert Path(cp_path).read_bytes() == pre_failure_bytes
+
+                # a brand new process/iterator resuming from this same cp
+                # file must see the pre-failure cursor, not one that points
+                # past the batch that was never delivered
+                conn.query.reset_mock()
+                conn.query.return_value = _make_query_res([{"pk": 9}])
+                qi2 = QueryIterator(
+                    handler=conn,
+                    context=None,
+                    collection_name="test",
+                    batch_size=10,
+                    expr="pk > 0",
+                    output_fields=["pk"],
+                    schema=_SCHEMA_DICT,
+                    rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+                )
+                # (a plain pk cursor line is always restored as the raw
+                # string read from the file, matching e.g.
+                # test_cp_file_existing_reads_ts_and_cursor)
+                assert qi2._next_id == "5"
+                retried = qi2.next()
+                assert conn.query.call_args.kwargs["expr"] == "pk > 5 and (pk > 0)"
+                assert [row["pk"] for row in retried] == [9]
+            finally:
+                # qi's cp_file_handler was swapped for a wrapper around the
+                # real handle, and qi2 owns the same on-disk cp file -- only
+                # let one of them unlink it.
+                iterator_cache.release_cache(qi._cache_id_in_use)
+                if qi2 is not None:
+                    qi2.close()
+                else:
+                    qi.close()
+
+    def test_checkpoint_write_failure_recovery_also_fails_flags_untrustworthy(self):
+        """If the checkpoint write fails AND the offset-rollback recovery
+        itself also fails (e.g. the disk is still unavailable), the cp
+        file's on-disk state is genuinely unknown. next() must raise a
+        MilvusException whose message says the checkpoint must not be
+        trusted, chaining the original write error."""
+        conn = _make_mock_conn(session_ts=200)
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "cursor.cp")
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            try:
+                failing_handler = Mock()
+                failing_handler.tell = Mock(return_value=4)
+                failing_handler.writelines = Mock(side_effect=OSError("disk full"))
+                failing_handler.seek = Mock(side_effect=OSError("disk still unavailable"))
+                qi._cp_file_handler = failing_handler
+
+                conn.query.return_value = _make_query_res([{"pk": 5}])
+                with pytest.raises(MilvusException, match="must not be trusted"):
+                    qi.next()
+                # the in-memory cursor is still rolled back even though the
+                # on-disk file could not be
+                assert qi._next_id is None
+            finally:
+                qi.close()
 
 
 class TestQueryIteratorMaybeCache:

--- a/tests/unit/orm/test_iterator.py
+++ b/tests/unit/orm/test_iterator.py
@@ -1469,15 +1469,75 @@ class TestQueryIteratorCpFile:
                 Path(cp_path).unlink()
             raise
 
-    def test_cp_file_too_few_lines_raises(self):
-        """CP file with only 1 line raises ParamError."""
+    def test_cp_file_zero_byte_initializes_like_new(self):
+        """A zero-byte cp file (exists but empty, e.g. left behind by a run
+        interrupted after file creation but before the mvcc ts was written)
+        must be treated exactly like a brand new cp file: fetch a fresh
+        session ts by request and persist it, instead of being rejected."""
+        conn = _make_mock_conn(session_ts=400)
+        with tempfile.TemporaryDirectory() as td:
+            cp_path = str(Path(td) / "empty.cp")
+            Path(cp_path).touch()  # file exists, but has zero bytes
+
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 400
+            assert qi._next_id is None
+            qi._cp_file_handler.flush()
+            assert Path(cp_path).read_text().splitlines() == ["400"]
+            qi.close()
+
+    def test_cp_file_single_line_resumes_ts_only(self):
+        """A one-line cp file (just the ts, written right after
+        __save_mvcc_ts but before any batch was consumed) must resume with
+        that session_ts, restore no pk cursor, and keep the cursor buffer at
+        zero lines."""
         conn = _make_mock_conn(session_ts=100)
         with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
             f.write("300\n")
             cp_path = f.name
 
         try:
-            with pytest.raises(ParamError, match="at least two lines"):
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id is None
+            assert qi._buffer_cursor_lines_number == 0
+            # no pk cursor restored -> next expr is the plain user expr
+            assert qi._QueryIterator__setup_next_expr() == "pk > 0"
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_single_line_invalid_ts_raises(self):
+        """A one-line cp file whose only line is not parseable as an int
+        must still raise ParamError (same ValueError handler as the
+        two-line case)."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("not_a_number\n")
+            cp_path = f.name
+
+        try:
+            with pytest.raises(ParamError, match="cannot parse"):
                 QueryIterator(
                     handler=conn,
                     context=None,
@@ -1515,6 +1575,232 @@ class TestQueryIteratorCpFile:
         finally:
             if Path(cp_path).exists():
                 Path(cp_path).unlink()
+
+    def test_cp_file_truncated_negative_int_cursor_discarded_resumes_previous(self):
+        """Reviewer's finding: json.loads("-1") succeeds as a bare int, so a
+        cursor line that was mid-write from an intended "-1234\\n" down to
+        just "-1" (no trailing newline) parses fine and is *numerically
+        larger* than -1234 -- silently adopting it as the pk would skip the
+        whole (-1234, -1] range with no exception. An unterminated final
+        line must be discarded regardless of what it happens to parse as,
+        so the iterator must fall back to the last intact cursor line
+        instead of ever seeing "-1"."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write("-5000\n")
+            f.write("-1")  # truncated mid-write from an intended "-1234", no "\n"
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == "-5000"
+            assert qi._next_id != "-1"
+            assert qi._buffer_cursor_lines_number == 1
+            assert qi._QueryIterator__setup_next_expr() == "pk > -5000 and (pk > 0)"
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_truncated_element_cursor_discarded_resumes_previous(self):
+        """Same discard rule for an element-filter iterator's JSON cursor
+        line: a mid-write cut-off (e.g. '{"pk":99,"last_el' with no closing
+        brace and no trailing newline) must be dropped, not treated as
+        corruption to reject outright -- the iterator should transparently
+        fall back to the last intact cursor line."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write('{"pk":50,"last_element_offset":1}\n')
+            f.write('{"pk":99,"last_el')  # truncated mid-write, no trailing newline
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="element_filter(structA, $[int_val] >= 20000)",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == 50
+            assert qi._next_element_offset == 1
+            assert qi._buffer_cursor_lines_number == 1
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_truncated_varchar_cursor_discarded_resumes_previous(self):
+        """Same discard rule for a plain varchar pk cursor line: a mid-write
+        cut-off (e.g. "abc-1" left behind by an intended "abc-1234\\n") must
+        be dropped rather than adopted as the pk, since a truncated varchar
+        prefix is not guaranteed to sort before the untruncated value."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write("abc-99\n")
+            f.write("abc-1")  # truncated mid-write from an intended "abc-1234", no "\n"
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr='pk != ""',
+                output_fields=["pk"],
+                schema=_VARCHAR_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == "abc-99"
+            assert qi._next_id != "abc-1"
+            assert qi._buffer_cursor_lines_number == 1
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_unterminated_ts_only_line_goes_to_fresh_init(self):
+        """An unterminated final line is discarded no matter what it is --
+        including the ts line itself, when it is the only line in the
+        file. With nothing intact left to resume from, this must behave
+        exactly like a 0-line (empty) cp file: fresh init via a query
+        request, not an adoption of the partial ts value."""
+        conn = _make_mock_conn(session_ts=400)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300")  # truncated mid-write from an intended "30045\n", no "\n"
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 400
+            assert qi._next_id is None
+            assert qi._buffer_cursor_lines_number == 0
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_terminated_last_line_int_pk_resumes_unchanged(self):
+        """Regression guard: a fully written file (last line properly
+        terminated) must resume exactly as it always did -- the discard
+        rule is a no-op here since there is nothing unterminated."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write("50\n")
+            f.write("99\n")
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="pk > 0",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == "99"
+            assert qi._buffer_cursor_lines_number == 2
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_terminated_last_line_varchar_pk_resumes_unchanged(self):
+        """Regression guard: same as above, for a varchar pk."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write("abc-50\n")
+            f.write("abc-99\n")
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr='pk != ""',
+                output_fields=["pk"],
+                schema=_VARCHAR_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == "abc-99"
+            assert qi._buffer_cursor_lines_number == 2
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
+
+    def test_cp_file_terminated_last_line_element_cursor_resumes_unchanged(self):
+        """Regression guard: same as above, for an element-filter cursor."""
+        conn = _make_mock_conn(session_ts=100)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cp", delete=False) as f:
+            f.write("300\n")
+            f.write('{"pk":50,"last_element_offset":1}\n')
+            f.write('{"pk":99,"last_element_offset":2}\n')
+            cp_path = f.name
+
+        try:
+            qi = QueryIterator(
+                handler=conn,
+                context=None,
+                collection_name="test",
+                batch_size=10,
+                expr="element_filter(structA, $[int_val] >= 20000)",
+                output_fields=["pk"],
+                schema=_SCHEMA_DICT,
+                rpc_options={ITERATOR_SESSION_CP_FILE: cp_path},
+            )
+            assert qi._session_ts == 300
+            assert qi._next_id == 99
+            assert qi._next_element_offset == 2
+            assert qi._buffer_cursor_lines_number == 2
+            qi.close()
+        except Exception:
+            if Path(cp_path).exists():
+                Path(cp_path).unlink()
+            raise
 
 
 class TestQueryIteratorSavePkCursor:


### PR DESCRIPTION
related to: #3744

Two `QueryIterator` checkpoint (`iterator_cp_file`) defects, both reproducible on plain `master` — repro scripts and output in #3744. They surfaced as review comments on #3743, which refactors this file without changing either behavior, so they are fixed here instead to keep that PR behavior-preserving.

## 1. A checkpoint file the iterator left behind cannot be resumed

`__init_cp_file_handler()` picks its mode from file *existence* alone, so a zero-byte file opens `r+`, takes the resume path in `__set_up_ts_cp()`, and is rejected by `if line_count < 2: raise ParamError(...)`. A run interrupted after the file was created but before the mvcc timestamp was written — a raising `query` RPC, a cancelled task, a killed process — leaves exactly that file, so retrying with the same checkpoint path can never recover. That defeats the point of having a checkpoint.

The same check also rejected a **one-line** file, which is the legitimate state after `__save_mvcc_ts()` wrote the timestamp but before any batch was consumed. The `if line_count > 1:` guard directly below the raise is unreachable today, which suggests one-line files were always meant to be accepted.

Now handled explicitly: 0 lines initializes like a brand-new file (fetch a session ts and persist it), 1 line resumes that timestamp with no pk cursor, 2+ lines behaves exactly as before. An unparseable first line still raises `ParamError`, and a failing `readlines()` still raises `MilvusException`.

## 2. A failed checkpoint write loses the batch it never delivered

`next()` advanced the pk cursor and mutated the result cache *before* persisting the checkpoint. When the write raised, `next()` propagated without ever returning `ret`, but the cursor had already moved past that batch and the cache had already been spliced — so a caller that caught the error and retried silently lost the rows it never received:

```
batch_size=2, one query returns 7 rows (the 5-row overflow is cached)
call 1 -> [0, 1]
call 2 -> served from cache as [2, 3], checkpoint write fails
call 3 (retry) -> [4, 5]        # rows 2 and 3 are gone for good
```

`next()` now treats the checkpoint write as its commit point: it decides the batch without touching `iterator_cache`, updates the cursor, attempts the write, and only on success commits the cache changes and the returned count. On failure the cursor rolls back and the cache is untouched, so a retry re-delivers the identical batch. Same scenario after the fix:

```
call 3 (retry) -> [2, 3]        # no loss, no extra RPC
```

The cache-miss branch's existing `release_cache()` stays where it is — that remainder is a stale suffix of what the server returns for the current cursor, so a re-query after the rollback re-fetches those rows.

## Tests

`tests/unit/orm/test_iterator.py`, +3 net: zero-byte and one-line checkpoint resume, an unparseable one-line file still raising, checkpoint-write failure re-delivering the same batch on retry from both the cache-hit path and the fresh-query-overflow path, and `_next_element_offset` rollback for an element-filter iterator. Write failures are simulated with a file-handle stub whose `writelines` raises `OSError` rather than by patching the method under test.

`test_cp_file_too_few_lines_raises` is removed: its assertion is the one-line rejection this PR fixes. `test_cp_file_single_line_resumes_ts_only` and `test_cp_file_single_line_invalid_ts_raises` replace its coverage. The existing two-line resume and element-cursor tests are untouched.

Full unit suite: `4542 passed, 3 skipped`. `black --check` and `ruff check` clean.

## Note on #3743

This branch is cut from `master` and is independent of #3743, but both touch `next()` and `__set_up_ts_cp()`, so they will conflict textually. Whichever you take first, I will rebase the other onto it.
