### PR TITLE
fix(client): enforce sync flush timeout as one end-to-end budget (#3745)

### DIFF
--- a/pymilvus/client/grpc_handler.py
+++ b/pymilvus/client/grpc_handler.py
@@ -2233,29 +2233,42 @@ class GrpcHandler:
         check_status(response.status)
         return response.infos
 
+    @staticmethod
+    def _remaining_budget(deadline: Optional[float], message: str) -> Optional[float]:
+        """Return the time left until ``deadline``, or ``None`` when unbounded.
+
+        Raises ``MilvusException`` with ``message`` if the deadline has already
+        passed, so a single ``timeout`` is enforced as one end-to-end budget
+        across the initial RPC and every subsequent state-poll RPC.
+        """
+        if deadline is None:
+            return None
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            raise MilvusException(message=message)
+        return remaining
+
     def _wait_for_flushed(
         self,
         segment_ids: List[int],
         collection_name: str,
         flush_ts: int,
-        timeout: Optional[float] = None,
+        deadline: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        flush_ret = False
-        start = time.time()
-        while not flush_ret:
-            flush_ret = self.get_flush_state(
-                segment_ids, collection_name, flush_ts, timeout, context=context, **kwargs
-            )
-            end = time.time()
-            if timeout is not None and end - start > timeout:
-                raise MilvusException(
-                    message=f"wait for flush timeout, collection: {collection_name}, flusht_ts: {flush_ts}"
-                )
+        message = f"wait for flush timeout, collection: {collection_name}, flusht_ts: {flush_ts}"
+        while True:
+            remaining = self._remaining_budget(deadline, message)
+            if self.get_flush_state(
+                segment_ids, collection_name, flush_ts, remaining, context=context, **kwargs
+            ):
+                return
 
-            if not flush_ret:
-                time.sleep(0.5)
+            sleep_for = 0.5
+            if deadline is not None:
+                sleep_for = min(sleep_for, max(0.0, deadline - time.time()))
+            time.sleep(sleep_for)
 
     @retry_on_rpc_failure(initial_back_off=1)
     def flush(
@@ -2272,6 +2285,8 @@ class GrpcHandler:
         for name in collection_names:
             check_pass_param(collection_name=name)
 
+        deadline = time.time() + timeout if timeout is not None else None
+
         request = Prepare.flush_param(collection_names)
         future = self._stub.Flush.future(request, timeout=timeout, metadata=_api_level_md(context))
         response = future.result()
@@ -2282,7 +2297,7 @@ class GrpcHandler:
                 segment_ids = future.result().coll_segIDs[collection_name].data
                 flush_ts = future.result().coll_flush_ts[collection_name]
                 self._wait_for_flushed(
-                    segment_ids, collection_name, flush_ts, timeout=timeout, context=context
+                    segment_ids, collection_name, flush_ts, deadline=deadline, context=context
                 )
 
         if kwargs.get("_async", False):
@@ -3208,22 +3223,20 @@ class GrpcHandler:
     def _wait_for_flush_all(
         self,
         flush_all_ts: int,
-        timeout: Optional[float] = None,
+        deadline: Optional[float] = None,
         context: Optional[CallContext] = None,
         **kwargs,
     ):
-        flush_ret = False
-        start = time.time()
-        while not flush_ret:
-            flush_ret = self.get_flush_all_state(flush_all_ts, timeout, context=context, **kwargs)
-            end = time.time()
-            if timeout is not None and end - start > timeout:
-                raise MilvusException(
-                    message=f"wait for flush all timeout, flush_all_ts: {flush_all_ts}"
-                )
+        message = f"wait for flush all timeout, flush_all_ts: {flush_all_ts}"
+        while True:
+            remaining = self._remaining_budget(deadline, message)
+            if self.get_flush_all_state(flush_all_ts, remaining, context=context, **kwargs):
+                return
 
-            if not flush_ret:
-                time.sleep(5)
+            sleep_for = 5
+            if deadline is not None:
+                sleep_for = min(sleep_for, max(0.0, deadline - time.time()))
+            time.sleep(sleep_for)
 
     @retry_on_rpc_failure()
     def flush_all(
@@ -3232,6 +3245,8 @@ class GrpcHandler:
         context: Optional[CallContext] = None,
         **kwargs,
     ):
+        deadline = time.time() + timeout if timeout is not None else None
+
         request = Prepare.flush_all_request(kwargs.get("db", ""))
         future = self._stub.FlushAll.future(
             request, timeout=timeout, metadata=_api_level_md(context)
@@ -3240,7 +3255,9 @@ class GrpcHandler:
         check_status(response.status)
 
         def _check():
-            self._wait_for_flush_all(response.flush_all_ts, timeout, context=context, **kwargs)
+            self._wait_for_flush_all(
+                response.flush_all_ts, deadline=deadline, context=context, **kwargs
+            )
 
         if kwargs.get("_async", False):
             flush_future = FlushFuture(future)

--- a/tests/unit/grpc_handler/test_flush_timeout.py
+++ b/tests/unit/grpc_handler/test_flush_timeout.py
@@ -1,0 +1,123 @@
+"""Tests that synchronous flush APIs enforce ``timeout`` as one end-to-end budget.
+
+Regression tests for the bug where ``GrpcHandler.flush``/``flush_all`` restarted a
+fresh timer for the state-poll phase, so a single ``timeout`` could be overshot by
+the time spent in the initial RPC (plus per-collection waits).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pymilvus.exceptions import MilvusException
+
+
+class FakeClock:
+    """Deterministic monotonic clock; ``sleep`` advances it instead of blocking."""
+
+    def __init__(self, start: float = 1000.0):
+        self.now = start
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _make_flush_response():
+    resp = MagicMock()
+    resp.status.code = 0
+    resp.status.error_code = 0
+    resp.status.reason = ""
+    resp.coll_segIDs = {"coll": MagicMock(data=[1, 2])}
+    resp.coll_flush_ts = {"coll": 123}
+    resp.flush_all_ts = 123
+    return resp
+
+
+class TestFlushTimeoutBudget:
+    def test_flush_enforces_end_to_end_timeout_budget(self, handler):
+        clock = FakeClock()
+        resp = _make_flush_response()
+
+        # The initial Flush RPC "spends" 8s of the 10s budget.
+        calls = {"n": 0}
+
+        def result_side_effect(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                clock.now += 8
+            return resp
+
+        handler._stub.Flush.future.return_value.result.side_effect = result_side_effect
+
+        # Segments never report flushed, so the wait loop must hit the deadline.
+        state = MagicMock()
+        state.status.code = 0
+        state.status.error_code = 0
+        state.status.reason = ""
+        state.flushed = False
+        handler._stub.GetFlushState.return_value = state
+
+        with patch("pymilvus.client.grpc_handler.time", clock):
+            start = clock.now
+            with pytest.raises(MilvusException, match="wait for flush timeout"):
+                handler.flush(["coll"], timeout=10)
+            elapsed = clock.now - start
+
+        # The whole operation (initial RPC + polling) must stay within the 10s
+        # budget, not restart a fresh 10s timer after the 8s RPC (which used to
+        # push the raise out to ~18s).
+        assert elapsed <= 10.5, f"flush overshot its timeout budget: {elapsed}s"
+
+    def test_flush_all_enforces_end_to_end_timeout_budget(self, handler):
+        clock = FakeClock()
+        resp = _make_flush_response()
+
+        calls = {"n": 0}
+
+        def result_side_effect(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                clock.now += 8
+            return resp
+
+        handler._stub.FlushAll.future.return_value.result.side_effect = result_side_effect
+
+        state = MagicMock()
+        state.status.code = 0
+        state.status.error_code = 0
+        state.status.reason = ""
+        state.flushed = False
+        handler._stub.GetFlushAllState.return_value = state
+
+        with patch("pymilvus.client.grpc_handler.time", clock):
+            start = clock.now
+            with pytest.raises(MilvusException, match="wait for flush all timeout"):
+                handler.flush_all(timeout=10)
+            elapsed = clock.now - start
+
+        assert elapsed <= 10.5, f"flush_all overshot its timeout budget: {elapsed}s"
+
+    def test_flush_without_timeout_still_waits_until_flushed(self, handler):
+        clock = FakeClock()
+        resp = _make_flush_response()
+        handler._stub.Flush.future.return_value.result.return_value = resp
+
+        # Not flushed on the first poll, flushed on the second.
+        seq = iter([False, True])
+
+        def get_flush_state(*args, **kwargs):
+            state = MagicMock()
+            state.status.code = 0
+            state.status.error_code = 0
+            state.status.reason = ""
+            state.flushed = next(seq)
+            return state
+
+        handler._stub.GetFlushState.side_effect = get_flush_state
+
+        with patch("pymilvus.client.grpc_handler.time", clock):
+            handler.flush(["coll"])  # timeout=None: must not raise
+
+        assert handler._stub.GetFlushState.call_count == 2


### PR DESCRIPTION
## Problem

Fixes #3745.

The synchronous flush APIs don't enforce `timeout` as a single end-to-end budget. `MilvusClient.flush(collection_name, timeout=N)` delegates to `GrpcHandler.flush`:

- the initial `Flush` RPC receives the full timeout;
- `_wait_for_flushed` then starts a **new** timer and receives the full timeout again;
- the multi-collection path restarts that timer for every collection;
- the poll loop sleeps a fixed `0.5s` (`5s` for `flush_all`) without capping to the remaining budget.

`GrpcHandler.flush_all` has the same split-budget behavior between the initial `FlushAll` RPC and `_wait_for_flush_all`. A deterministic mocked test with an 8s initial `Flush` RPC and `flush(..., timeout=10)` raised its timeout only after ~18.5s of simulated wall-clock.

The async handler is unaffected because its outer retry wrapper bounds the whole coroutine with `asyncio.wait_for`.

## Fix

- Compute one `deadline` when the public sync call starts.
- Pass the **remaining** budget to the initial RPC and to every `GetFlushState` / `GetFlushAllState` poll.
- Share the same deadline across all collection waits.
- Cap each poll sleep to what is left of the budget.
- Apply the same rule to `flush_all`.

## Tests

New `tests/unit/grpc_handler/test_flush_timeout.py`:

- `test_flush_enforces_end_to_end_timeout_budget` — 8s initial RPC + `timeout=10`; asserts the raise happens within the 10s budget (fails on `master`, which overshoots to ~18s).
- `test_flush_all_enforces_end_to_end_timeout_budget` — same for `flush_all`.
- `test_flush_without_timeout_still_waits_until_flushed` — `timeout=None` still polls until flushed and does not raise.

All three pass with the fix; the two budget tests fail on `master`. The existing `test_utility.py` flush tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
