### PR TITLE
fix(async): honor reset_connection when AsyncMilvusClient rotates a password

### DIFF
--- a/pymilvus/client/async_grpc_handler.py
+++ b/pymilvus/client/async_grpc_handler.py
@@ -214,9 +214,25 @@ class AsyncGrpcHandler:
             return async_header_adder_interceptor(keys, values)
         return None
 
+    def _uninstall_authorization_interceptor(self):
+        """Detach the installed authorization interceptor from the live channel.
+
+        Interceptors are appended to the channel's list and never replaced, so the
+        header adder for a superseded credential would keep running -- and, being
+        first, keep winning -- alongside a newly appended one.
+        """
+        if self._async_authorization_interceptor is None:
+            return
+        for channel in (self._async_channel, self._final_channel):
+            interceptors = getattr(channel, "_unary_unary_interceptors", None)
+            while interceptors and self._async_authorization_interceptor in interceptors:
+                interceptors.remove(self._async_authorization_interceptor)
+        self._async_authorization_interceptor = None
+
     def _setup_authorization_interceptor(self, user: str, password: str, token: str):
         authorization_interceptor = self._create_authorization_interceptor(user, password, token)
         if authorization_interceptor:
+            self._uninstall_authorization_interceptor()
             self._async_authorization_interceptor = authorization_interceptor
             self._final_channel._unary_unary_interceptors.append(authorization_interceptor)
 
@@ -269,7 +285,10 @@ class AsyncGrpcHandler:
         final_channel = channel
 
         if self._async_authorization_interceptor:
-            final_channel._unary_unary_interceptors.append(self._async_authorization_interceptor)
+            if self._async_authorization_interceptor not in final_channel._unary_unary_interceptors:
+                final_channel._unary_unary_interceptors.append(
+                    self._async_authorization_interceptor
+                )
         else:
             authorization_interceptor = self._create_authorization_interceptor(
                 kwargs.get("user"),

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -1487,6 +1487,7 @@ class AsyncMilvusClient(BaseMilvusClient):
         new_password: str,
         timeout: Optional[float] = None,
         description: Optional[str] = None,
+        reset_connection: Optional[bool] = False,
         **kwargs,
     ):
         conn = await self._get_connection()
@@ -1499,6 +1500,9 @@ class AsyncMilvusClient(BaseMilvusClient):
             description=description,
             **kwargs,
         )
+        if reset_connection:
+            conn._setup_authorization_interceptor(user_name, new_password, None)
+            conn._setup_grpc_channel()
 
     async def update_user(
         self,

--- a/tests/unit/async_grpc_handler/test_async_auth.py
+++ b/tests/unit/async_grpc_handler/test_async_auth.py
@@ -3,10 +3,13 @@
 Coverage: User, role, privilege, grant, resource group operations.
 """
 
+import base64
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from pymilvus import AsyncMilvusClient, MilvusClient
 from pymilvus.client.async_grpc_handler import AsyncGrpcHandler
 from pymilvus.client.call_context import CallContext
 
@@ -796,3 +799,108 @@ class TestAsyncGrpcHandlerResourceGroup:
             mock_prepare.transfer_replica.return_value = MagicMock()
             await handler.transfer_replica("src_rg", "tgt_rg", "test_coll", 1)
             mock_stub.TransferReplica.assert_called_once()
+
+
+class TestAsyncGrpcHandlerCredentialRotation:
+    """Tests for rotating the credential attached to a live async channel."""
+
+    @staticmethod
+    def _installed_authorizations(channel) -> list:
+        """Decode the authorization headers every installed interceptor would add."""
+        authorizations = []
+        for interceptor in channel._unary_unary_interceptors:
+            details = MagicMock()
+            details.metadata = None
+            new_details, _ = interceptor._fn(details, MagicMock())
+            authorizations.extend(
+                base64.b64decode(value).decode()
+                for header, value in new_details.metadata
+                if header == "authorization"
+            )
+        return authorizations
+
+    def _handler(self) -> AsyncGrpcHandler:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        return AsyncGrpcHandler(channel=mock_channel, user="root", password="old_pass")
+
+    def test_rotating_the_credential_replaces_the_stale_one(self) -> None:
+        """A rotated credential must not leave the superseded one on the channel.
+
+        Interceptors are appended to the channel's list, and each authorization
+        interceptor appends its own header, so a stale one left in place keeps
+        sending the old credential ahead of the new one.
+        """
+        handler = self._handler()
+        assert self._installed_authorizations(handler._async_channel) == ["root:old_pass"]
+
+        handler._setup_authorization_interceptor("root", "new_pass", None)
+        handler._setup_grpc_channel()
+        assert self._installed_authorizations(handler._async_channel) == ["root:new_pass"]
+
+        handler._setup_authorization_interceptor("root", "newer_pass", None)
+        handler._setup_grpc_channel()
+        assert self._installed_authorizations(handler._async_channel) == ["root:newer_pass"]
+
+    def test_rotating_the_credential_installs_exactly_one_interceptor(self) -> None:
+        handler = self._handler()
+        for password in ("new_pass", "newer_pass", "newest_pass"):
+            handler._setup_authorization_interceptor("root", password, None)
+            handler._setup_grpc_channel()
+            interceptors = handler._async_channel._unary_unary_interceptors
+            assert len(interceptors) == 1
+            assert handler._async_authorization_interceptor in interceptors
+
+    def test_uninstall_is_a_no_op_without_an_installed_interceptor(self) -> None:
+        mock_channel = MagicMock()
+        mock_channel._unary_unary_interceptors = []
+        handler = AsyncGrpcHandler(channel=mock_channel)
+        assert handler._async_authorization_interceptor is None
+
+        handler._uninstall_authorization_interceptor()
+
+        assert handler._async_authorization_interceptor is None
+        assert handler._async_channel._unary_unary_interceptors == []
+
+
+class TestAsyncMilvusClientUpdatePassword:
+    """Tests for AsyncMilvusClient.update_password's reset_connection flag."""
+
+    @staticmethod
+    def _client_with_connection() -> tuple:
+        client = AsyncMilvusClient.__new__(AsyncMilvusClient)
+        conn = MagicMock()
+        conn.update_password = AsyncMock()
+        client._get_connection = AsyncMock(return_value=conn)
+        client._generate_call_context = MagicMock(return_value=None)
+        return client, conn
+
+    @pytest.mark.asyncio
+    async def test_reset_connection_rebinds_the_channel(self) -> None:
+        """reset_connection must re-authorize the live connection, as the sync client does.
+
+        Without it, every later call on the same client keeps sending the password
+        that was just replaced.
+        """
+        client, conn = self._client_with_connection()
+
+        await client.update_password("root", "old_pass", "new_pass", reset_connection=True)
+
+        conn.update_password.assert_awaited_once()
+        conn._setup_authorization_interceptor.assert_called_once_with("root", "new_pass", None)
+        conn._setup_grpc_channel.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_connection_is_left_alone_by_default(self) -> None:
+        client, conn = self._client_with_connection()
+
+        await client.update_password("root", "old_pass", "new_pass")
+
+        conn.update_password.assert_awaited_once()
+        conn._setup_authorization_interceptor.assert_not_called()
+        conn._setup_grpc_channel.assert_not_called()
+
+    def test_signature_matches_the_sync_client(self) -> None:
+        sync_params = inspect.signature(MilvusClient.update_password).parameters
+        async_params = inspect.signature(AsyncMilvusClient.update_password).parameters
+        assert set(sync_params) == set(async_params)


### PR DESCRIPTION
### What

`AsyncMilvusClient.update_password()` has no `reset_connection` flag, so an async client that rotates its own password keeps sending the old one on every subsequent call.

The sync client has had this since the beginning:

```python
# pymilvus/milvus_client/milvus_client.py
def update_password(self, user_name, old_password, new_password,
                    reset_connection: Optional[bool] = False, ...):
    ...
    if reset_connection:
        conn._setup_authorization_interceptor(user_name, new_password, None)
        conn._setup_grpc_channel()
```

`AsyncGrpcHandler` even carries a mirrored `_setup_authorization_interceptor()` — but it has **zero call sites**; the async client never wires it up. So today the only way for an async caller to keep working after `update_password()` is to throw the client away and build a new one.

### Why adding the flag alone isn't enough

Porting the sync two-liner verbatim does not work, because the two handlers install interceptors differently:

- **sync** `_setup_authorization_interceptor()` only *records* `self._authorization_interceptor`; `_setup_grpc_channel()` then rebuilds `_final_channel` from the raw channel, so the old interceptor is dropped.
- **async** `_setup_authorization_interceptor()` **appends** to the live `_final_channel._unary_unary_interceptors`, and `_build_stub()` appends again. Nothing is ever removed.

Each authorization interceptor appends its own `authorization` metadata entry (`async_header_adder_interceptor`), so the superseded credential stays on the wire — and, being first in the list, is the one the server sees. Measured against the current `master` with a naive port of the sync code:

```
init      : ['root:old_pw']
1st reset : ['root:old_pw', 'root:new_pw', 'root:new_pw']
2nd reset : ['root:old_pw', 'root:new_pw', 'root:new_pw', 'root:newer_pw', 'root:newer_pw']
```

(`_setup_grpc_channel()` carries the comment `# avoid to add duplicate headers.` — `_build_stub` does not currently honor it.)

### What this PR changes

1. **`AsyncMilvusClient.update_password(..., reset_connection=False)`** — same semantics as the sync client.
2. **`AsyncGrpcHandler._uninstall_authorization_interceptor()`** (new) — detaches the interceptor being replaced from the live channel; `_setup_authorization_interceptor()` calls it before installing the new one.
3. **`AsyncGrpcHandler._build_stub()`** — no longer re-appends an authorization interceptor that is already installed on that channel, honoring its own comment. Building a stub on a *fresh* channel is unchanged.

After the change, the same measurement:

```
init      : ['root:old_pw']
1st reset : ['root:new_pw']
2nd reset : ['root:newer_pw']
```

**Signature note:** `reset_connection` is appended at the end of the async signature rather than placed after `new_password` as in the sync client, so existing positional calls like `update_password(u, old, new, 30)` keep binding `timeout`. Happy to mirror the sync ordering instead if you'd prefer exact positional parity.

### Tests

New in `tests/unit/async_grpc_handler/test_async_auth.py` (5 tests): credential rotation replaces the stale interceptor and installs exactly one; the uninstall helper is a no-op when nothing is installed; `reset_connection=True` re-authorizes the connection and the default leaves it alone; and the sync/async signatures carry the same parameter set.

The rotation tests assert on the **decoded `authorization` headers** the installed interceptors would emit, not just list length, so they fail loudly if a stale credential survives.

Verification (Windows, Python 3.12, no server required — `grpc.aio` channels are constructed but never connected):

- new code + new tests → `174 passed` in `tests/unit/async_grpc_handler/`
- unmodified source + new tests → `5 failed, 169 passed`, the key one being

  ```
  AssertionError: assert ['root:old_pa...oot:new_pass'] == ['root:new_pass']
  ```

**No existing test was modified or weakened.** An earlier draft moved interceptor installation out of `_setup_authorization_interceptor` and broke `test_setup_authorization_interceptor_appends_header`; the design in this PR keeps that method's contract intact (it still appends to the channel) and instead removes the interceptor it supersedes.

Full unit suite: `3377 passed`. The two unrelated failures on my machine (`test_check.py::test_get_commit`, plus collection errors in `test_version.py` / the bulk-writer modules) are missing optional dev dependencies (`setuptools_scm`) and reproduce identically on unmodified `master`.

`ruff check` and `ruff format --check` clean on all three files (tests checked with `tests/ruff.toml`).

---

This was found by diffing `MilvusClient` against `AsyncMilvusClient` method signatures. The scan also surfaced two naming drifts I have deliberately **not** touched, since they may be intentional and changing them would be breaking: `get_load_state(partition_name=)` vs `(partition_names=)`, and `transfer_replica(source_group, target_group, num_replicas)` vs `(source, target, num_replica)`. Happy to file those separately if they're unintended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
