### PR TITLE
fix(async): make AsyncMilvusClient.refresh_load actually refresh (#3772)

### DIFF
--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -865,6 +865,23 @@ class AsyncMilvusClient(BaseMilvusClient):
         timeout: Optional[float] = None,
         **kwargs,
     ):
+        """Refresh the loaded data of a collection, or of specific partitions.
+
+        Mirrors MilvusClient.refresh_load: the load request is re-issued with
+        ``_refresh=True`` so that data inserted after the initial load becomes
+        searchable.
+
+        Args:
+            collection_name (str): The name of the collection.
+            partition_names (str | List[str], optional): A partition name, or a list of
+                partition names, to refresh. If omitted, the whole collection is
+                refreshed. Defaults to None.
+            timeout (float, optional): An optional duration of time in seconds to allow
+                for the RPC. Defaults to None.
+
+        Returns:
+            None: nothing is returned; a MilvusException is raised on failure.
+        """
         if isinstance(partition_names, str):
             partition_names = [partition_names]
 

--- a/pymilvus/milvus_client/async_milvus_client.py
+++ b/pymilvus/milvus_client/async_milvus_client.py
@@ -861,15 +861,30 @@ class AsyncMilvusClient(BaseMilvusClient):
     async def refresh_load(
         self,
         collection_name: str,
-        partition_names: Optional[List[str]] = None,
+        partition_names: Optional[Union[str, List[str]]] = None,
         timeout: Optional[float] = None,
         **kwargs,
     ):
+        if isinstance(partition_names, str):
+            partition_names = [partition_names]
+
+        kwargs.pop("_refresh", None)
         conn = await self._get_connection()
-        return await conn.refresh_load(
+        if partition_names:
+            await conn.load_partitions(
+                collection_name,
+                partition_names,
+                timeout=timeout,
+                _refresh=True,
+                context=self._generate_call_context(**kwargs),
+                **kwargs,
+            )
+            return
+
+        await conn.load_collection(
             collection_name,
-            partition_names,
             timeout=timeout,
+            _refresh=True,
             context=self._generate_call_context(**kwargs),
             **kwargs,
         )

--- a/tests/unit/test_async_milvus_client_ops.py
+++ b/tests/unit/test_async_milvus_client_ops.py
@@ -122,7 +122,10 @@ class TestAsyncClientRefreshLoad:
     @pytest.mark.asyncio
     async def test_refresh_load_requests_a_refresh(self):
         client, handler = _make_client()
-        await client.refresh_load("col")
+        result = await client.refresh_load("col")
+        # The public contract is "returns nothing"; the old code leaked the handler
+        # return value, so pin it here.
+        assert result is None
         args, kwargs = handler.load_collection.call_args
         assert args[0] == "col"
         assert kwargs.get("_refresh") is True
@@ -130,7 +133,8 @@ class TestAsyncClientRefreshLoad:
     @pytest.mark.asyncio
     async def test_refresh_load_scopes_to_partitions(self):
         client, handler = _make_client()
-        await client.refresh_load("col", ["part1", "part2"])
+        result = await client.refresh_load("col", ["part1", "part2"])
+        assert result is None
         handler.load_collection.assert_not_called()
         args, kwargs = handler.load_partitions.call_args
         assert args[0] == "col"

--- a/tests/unit/test_async_milvus_client_ops.py
+++ b/tests/unit/test_async_milvus_client_ops.py
@@ -116,6 +116,36 @@ class TestAsyncClientPartitionOps:
         handler.release_partitions.assert_called_once()
 
 
+class TestAsyncClientRefreshLoad:
+    """refresh_load must actually request a refresh, mirroring MilvusClient.refresh_load."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_load_requests_a_refresh(self):
+        client, handler = _make_client()
+        await client.refresh_load("col")
+        args, kwargs = handler.load_collection.call_args
+        assert args[0] == "col"
+        assert kwargs.get("_refresh") is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_load_scopes_to_partitions(self):
+        client, handler = _make_client()
+        await client.refresh_load("col", ["part1", "part2"])
+        handler.load_collection.assert_not_called()
+        args, kwargs = handler.load_partitions.call_args
+        assert args[0] == "col"
+        # partition_names is the 2nd positional argument
+        assert args[1] == ["part1", "part2"]
+        assert kwargs.get("_refresh") is True
+
+    @pytest.mark.asyncio
+    async def test_refresh_load_partition_str_converts(self):
+        client, handler = _make_client()
+        await client.refresh_load("col", "part1")
+        args, _ = handler.load_partitions.call_args
+        assert args[1] == ["part1"]
+
+
 # Each tuple: (client_method, args, kwargs, handler_method)
 _SIMPLE_ASYNC_DELEGATION_CASES = [
     # Collection management
@@ -132,7 +162,7 @@ _SIMPLE_ASYNC_DELEGATION_CASES = [
     ("add_collection_function", ("col", MagicMock()), {}, "add_collection_function"),
     ("alter_collection_function", ("col", "fn", MagicMock()), {}, "alter_collection_function"),
     # Server ops
-    ("refresh_load", ("col",), {}, "refresh_load"),
+    ("refresh_load", ("col",), {}, "load_collection"),
     ("run_analyzer", ("hello world",), {}, "run_analyzer"),
     ("update_replicate_configuration", (), {"clusters": []}, "update_replicate_configuration"),
     ("get_replicate_configuration", (), {}, "get_replicate_configuration"),


### PR DESCRIPTION
Fixes #3772

### What

`AsyncMilvusClient.refresh_load()` delegated to `AsyncGrpcHandler.refresh_load()`, which
issues a single `GetLoadingProgress` RPC and returns `response.refresh_progress`. That is a
read-only poll — it never asks the server to refresh anything.

The synchronous twin does the real work:

```python
# pymilvus/milvus_client/milvus_client.py:1072
def refresh_load(self, collection_name, timeout=None, **kwargs):
    kwargs.pop("_refresh", None)
    conn = self._get_connection()
    conn.load_collection(collection_name, timeout=timeout, _refresh=True, ...)
```

`LoadCollection(refresh=True)` followed by `wait_for_loading_collection(is_refresh=True)`.

### Why it matters

`optimize_collection()` exists in both clients and is structured line-for-line the same.
Both end with:

```python
if <collection is loaded>:
    task.set_progress(ProgressStage.REFRESHING_LOAD)
    await self.refresh_load(collection_name, timeout=remaining_timeout(), **kwargs)
```

(async `async_milvus_client.py:2415`, sync `milvus_client.py:3074`)

On the sync client the compacted segments are reloaded before the call returns. On the async
client nothing is reloaded — `optimize_collection()` still reports
`ProgressStage.REFRESHING_LOAD` and returns `status="success"` while queries keep being served
from the pre-compaction segments. Same for a direct `await client.refresh_load(name)` after a
bulk import. No error, no warning.

`partition_names` was affected too: the async signature accepted it and forwarded it to
`GetLoadingProgress`, so it selected *which progress was read* rather than *what got refreshed*.

### The fix

Route `refresh_load()` through the async load primitives, mirroring the sync client:

- `partition_names` given → `conn.load_partitions(..., _refresh=True)`
- otherwise → `conn.load_collection(..., _refresh=True)`

Both already exist on `AsyncGrpcHandler` (`async_grpc_handler.py:1321` and `:399`), already
forward `_refresh` through `Prepare`, and already wait via `wait_for_loading_partitions` /
`wait_for_loading_collection`. They were simply never called from `refresh_load`. A `str`
partition name is normalized to a list, matching `load_partitions` / `release_partitions` on
the same client.

**Deliberately not in scope:** `AsyncGrpcHandler.refresh_load()` is left exactly as it is.
Reading refresh progress is a reasonable low-level operation; only the name and the client
wiring were wrong. Renaming it (e.g. `get_refresh_progress`) would change a public handler
method and belongs in a separate call by maintainers.

**Behavior note for review:** the client method now returns `None`, like the sync twin,
instead of an integer. The previous return value was the progress of a refresh that was never
triggered, so it carried no usable information — but flagging it explicitly in case you would
rather preserve the old signature.

### Why CI did not catch it

The async test asserted delegation by handler method name only
(`tests/unit/test_async_milvus_client_ops.py`, `_SIMPLE_ASYNC_DELEGATION_CASES`):

```python
("refresh_load", ("col",), {}, "refresh_load"),
```

That stays green no matter what the handler does. The sync test asserts the actual contract
(`tests/unit/test_milvus_client.py::test_refresh_load`: `_refresh is True` on the
`load_collection` call), so the sync side was protected and the async side was not. This PR
brings the async test up to the same contract and adds partition scoping.

### Verification

Red/green on the new tests, same tree, only `async_milvus_client.py` reverted for the red run:

```
# unpatched source, new tests
4 failed  (TestAsyncClientRefreshLoad x3 + delegation[refresh_load])
    AssertionError: Expected 'load_collection' to have been called once. Called 0 times.

# patched
tests/unit/test_async_milvus_client_ops.py .......  83 passed
```

Full unit suite on this tree: **4486 passed, 1 skipped, 2 failed**. Both failures
(`orm/test_iterator.py::...test_deleted_cp_file_is_recreated_during_iteration` and
`test_check.py::TestGetCommit::test_get_commit`) reproduce identically with the whole change
stashed, i.e. they are pre-existing on this machine and unrelated. Six `test_bulk_*` /
`test_version.py` modules fail to collect locally for missing optional deps (`minio`, `azure`,
`setuptools_scm`) and were excluded.

`ruff check` and `ruff format --check` clean on both changed files (ruff 0.15.11, within the
`ruff>=0.12.9,<1` pin in `pyproject.toml`).

Not run locally: any test needing a live Milvus server (no server on this machine), so the
refresh RPC itself is covered by mock-level assertions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
