### PR TITLE
feat: add synchronous LoadCollection warmup option

### DIFF
--- a/pymilvus/client/prepare.py
+++ b/pymilvus/client/prepare.py
@@ -2228,6 +2228,13 @@ class Prepare:
             priority = kwargs.get("priority")
             req.load_params["load_priority"] = priority
 
+        if "warmup" in kwargs:
+            if kwargs["warmup"] != "sync":
+                raise ParamError(message="load parameter warmup only supports sync")
+            if req.refresh:
+                raise ParamError(message="load parameter warmup cannot be used with refresh")
+            req.load_params["warmup"] = "sync"
+
         return req
 
     @classmethod

--- a/tests/unit/test_load_warmup.py
+++ b/tests/unit/test_load_warmup.py
@@ -1,0 +1,30 @@
+import pytest
+from pymilvus.client.prepare import Prepare
+from pymilvus.exceptions import ParamError
+
+
+def test_load_sync_warmup_preserves_other_options():
+    request = Prepare.load_collection(
+        "warmup_test", replica_number=2, warmup="sync", load_fields=["id"], priority="HIGH"
+    )
+    assert request.load_params["warmup"] == "sync"
+    assert request.load_params["load_priority"] == "HIGH"
+    assert request.replica_number == 2
+    assert list(request.load_fields) == ["id"]
+
+
+def test_load_without_warmup_keeps_existing_semantics():
+    assert "warmup" not in Prepare.load_collection("warmup_test").load_params
+    assert Prepare.load_collection("warmup_test", refresh=True).refresh
+
+
+@pytest.mark.parametrize("warmup", ["disable", "async", "", None, True, 1])
+def test_load_rejects_unsupported_warmup(warmup):
+    with pytest.raises(ParamError, match="only supports sync"):
+        Prepare.load_collection("warmup_test", warmup=warmup)
+
+
+@pytest.mark.parametrize("refresh_key", ["refresh", "_refresh"])
+def test_load_sync_warmup_rejects_refresh(refresh_key):
+    with pytest.raises(ParamError, match="cannot be used with refresh"):
+        Prepare.load_collection("warmup_test", warmup="sync", **{refresh_key: True})


### PR DESCRIPTION
## Summary

Add explicit `warmup="sync"` handling to the shared `LoadCollection` request builder used by synchronous and asynchronous handlers.

- Encode the option as `LoadCollectionRequest.load_params["warmup"] = "sync"`.
- Preserve existing behavior when the option is omitted.
- Reject unsupported values and explicit sync together with `refresh` / `_refresh`.
- Preserve existing load priority, replica and field-selection options.

This is a clean, single-commit PR based on upstream `master` (`a4b3b38b`): only `pymilvus/client/prepare.py` and `tests/unit/test_load_warmup.py` change, with 37 added lines. The fork's namespace commits and local protobuf submodule changes are not included.

## References

- Related issue: https://github.com/milvus-io/milvus/issues/47371 (fine-grained warmup controls; this adds a separate load-time override).
- Server implementation, still under development in a fork: https://github.com/sunby/milvus/pull/17
- Design: https://github.com/sunby/milvus/blob/b2b2c343926f37e3067f547889b31f30a04216fb/docs/design-docs/design_docs/20260907-load-collection-force-sync-warmup.md
- Supersedes the SDK fork PR: https://github.com/sunby/pymilvus/pull/1

## Validation

Verified in an isolated checkout of this upstream-based commit:

- `pytest tests/unit/prepare/test_collection.py tests/unit/test_load_warmup.py -q`: **73 passed**, including all 10 new warmup cases.
- Ruff check and Ruff format check passed for both changed files.
- Black format check passed for both changed files.
- `git diff --check` passed.

## Release boundary

Keep this PR as **Draft** pending the corresponding server support and SDK/server E2E acceptance. Request serialization and validation are tested; actual synchronous cache warmup is not verified by these tests. The proposed server feature gate remains disabled by default. This SDK change does not negotiate capabilities and cannot guarantee warmup on older or otherwise unsupported servers.
